### PR TITLE
add custom 404 page for unknown usernames

### DIFF
--- a/src/app/[username]/not-found.tsx
+++ b/src/app/[username]/not-found.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <main className="min-h-screen bg-canvas-night flex items-center justify-center">
+      <div className="text-center space-y-4 px-4">
+        <p className="text-6xl font-bold text-primary">404</p>
+        <h1 className="text-2xl font-semibold text-on-dark">User not found</h1>
+        <p className="text-ink-mute max-w-sm mx-auto">
+          This username doesn&apos;t exist on OSSfolio yet, or hasn&apos;t
+          signed up.
+        </p>
+        <div className="flex justify-center gap-4 pt-2">
+          <Link
+            href="/"
+            className="text-sm underline underline-offset-4 text-ink-mute hover:text-on-dark transition-colors"
+          >
+            Home
+          </Link>
+          <Link
+            href="/explore"
+            className="text-sm underline underline-offset-4 text-ink-mute hover:text-on-dark transition-colors"
+          >
+            Explore
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/[username]/page.tsx
+++ b/src/app/[username]/page.tsx
@@ -1,11 +1,14 @@
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
+import { supabase } from "@/lib/supabase";
 
 interface ProfilePageProps {
   params: Promise<{ username: string }>;
 }
 
-export async function generateMetadata({ params }: ProfilePageProps): Promise<Metadata> {
+export async function generateMetadata({
+  params,
+}: ProfilePageProps): Promise<Metadata> {
   const { username } = await params;
   return {
     title: `${username} — OSSfolio`,
@@ -17,7 +20,13 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
   const { username } = await params;
 
   // TODO: fetch contributor data from Supabase / GitHub API
-  if (!username) notFound();
+  const { data: user } = await supabase
+    .from("profiles")
+    .select("username")
+    .eq("username", username)
+    .single();
+
+  if (!user) notFound();
 
   return (
     <main className="min-h-screen bg-background">


### PR DESCRIPTION
Closes #23

Created the missing `not-found.tsx` file inside `src/app/[username]/`.

When someone visits a username that doesn't exist, they now see a 404 page 
with a short message and links back to Home and Explore. Styled to match 
the dark design of the rest of the site.