### PR TITLE
[FEAT] Add hover effects to footer links (#43)

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -54,14 +54,7 @@ export function Footer() {
               href="https://github.com/PRODHOSH/ossfolio"
               target="_blank"
               rel="noopener noreferrer"
-              style={{
-                display: "inline-flex",
-                alignItems: "center",
-                gap: "6px",
-                fontSize: "12px",
-                color: "#9a9a9a",
-                textDecoration: "none",
-              }}
+              className="inline-flex items-center gap-1.5 text-xs text-[#9a9a9a] no-underline hover:text-[#171717] transition-colors"
             >
               <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
@@ -81,7 +74,7 @@ export function Footer() {
                   <li key={label}>
                     <Link
                       href={href}
-                      style={{ fontSize: "13px", color: "#707070", textDecoration: "none" }}
+                      className="text-[13px] text-[#707070] no-underline hover:text-[#171717] transition-colors"
                     >
                       {label}
                     </Link>


### PR DESCRIPTION
Closes #43

## What
Added hover effects to all footer links by converting from inline styles to Tailwind classes:
- Navigation links (Features, How it works, etc.) → darken on hover
- GitHub star link → darken on hover
- Uses \	ransition-colors\ for smooth animation

## Why
Footer links were static with no hover feedback, making the UI feel less interactive.