### PR TITLE
[FEAT] Add sitemap.xml and robots.txt for SEO (#40)

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,10 @@
+import type { MetadataRoute } from "next";
+
+const BASE_URL = "https://ossfolio.vercel.app";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: { userAgent: "*", allow: "/", disallow: "/api/" },
+    sitemap: `${BASE_URL}/sitemap.xml`,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,12 @@
+import type { MetadataRoute } from "next";
+
+const BASE_URL = "https://ossfolio.vercel.app";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    { url: BASE_URL, lastModified: new Date(), changeFrequency: "monthly", priority: 1 },
+    { url: `${BASE_URL}/explore`, lastModified: new Date(), changeFrequency: "weekly", priority: 0.8 },
+    { url: `${BASE_URL}/privacy`, lastModified: new Date(), changeFrequency: "yearly", priority: 0.3 },
+    { url: `${BASE_URL}/terms`, lastModified: new Date(), changeFrequency: "yearly", priority: 0.3 },
+  ];
+}


### PR DESCRIPTION
Closes #40

## What
Added two Next.js App Router metadata files:
- \src/app/sitemap.ts\ — generates \/sitemap.xml\ with home, explore, privacy, and terms pages
- \src/app/robots.ts\ — generates \/robots.txt\ allowing all crawlers except \/api/\

## Why
Search engines had no guidance on which pages to crawl, hurting SEO for contributor profile pages.