### PR TITLE
feat(home): add Framer Motion scroll animations to homepage sections

### DIFF
--- a/src/components/home/CTABanner.tsx
+++ b/src/components/home/CTABanner.tsx
@@ -1,6 +1,7 @@
-"use client";
+﻿"use client";
 
 import { ArrowRight } from "lucide-react";
+import { motion } from "framer-motion";
 
 interface CTABannerProps {
   onGetStarted: () => void;
@@ -14,7 +15,11 @@ export function CTABanner({ onGetStarted }: CTABannerProps) {
         borderTop: "1px solid #ededed",
       }}
     >
-      <div
+      <motion.div
+        initial={{ opacity: 0, y: 24 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5, ease: "easeOut" }}
+        viewport={{ once: true }}
         style={{
           maxWidth: "72rem",
           margin: "0 auto",
@@ -99,7 +104,7 @@ export function CTABanner({ onGetStarted }: CTABannerProps) {
             Star on GitHub
           </a>
         </div>
-      </div>
+      </motion.div>
     </section>
   );
 }

--- a/src/components/home/Features.tsx
+++ b/src/components/home/Features.tsx
@@ -1,3 +1,5 @@
+﻿"use client";
+
 import {
   GitPullRequest,
   Activity,
@@ -8,6 +10,7 @@ import {
   Share2,
   Flame,
 } from "lucide-react";
+import { motion, type Variants } from "framer-motion";
 
 const features = [
   {
@@ -60,6 +63,20 @@ const features = [
   },
 ];
 
+const containerVariants: Variants = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.08 } },
+};
+
+const cardVariants: Variants = {
+  hidden: { opacity: 0, y: 24 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.5, ease: "easeOut" },
+  },
+};
+
 export function Features() {
   return (
     <section
@@ -78,7 +95,13 @@ export function Features() {
         }}
       >
         {/* Header */}
-        <div style={{ textAlign: "center", marginBottom: "48px" }}>
+        <motion.div
+          initial={{ opacity: 0, y: 24 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, ease: "easeOut" }}
+          viewport={{ once: true }}
+          style={{ textAlign: "center", marginBottom: "48px" }}
+        >
           <p
             style={{ fontSize: "13px", fontWeight: 500, color: "#3ecf8e", marginBottom: "10px" }}
           >
@@ -108,10 +131,14 @@ export function Features() {
             OSSfolio pulls from the GitHub GraphQL API to build a complete
             picture of your contributions — automatically.
           </p>
-        </div>
+        </motion.div>
 
         {/* Grid */}
-        <div
+        <motion.div
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true }}
+          variants={containerVariants}
           style={{
             display: "grid",
             gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))",
@@ -119,8 +146,9 @@ export function Features() {
           }}
         >
           {features.map(({ icon: Icon, title, description }) => (
-            <div
+            <motion.div
               key={title}
+              variants={cardVariants}
               style={{
                 backgroundColor: "#ffffff",
                 border: "1px solid #dfdfdf",
@@ -150,9 +178,9 @@ export function Features() {
               <p style={{ fontSize: "13px", lineHeight: 1.6, color: "#707070" }}>
                 {description}
               </p>
-            </div>
+            </motion.div>
           ))}
-        </div>
+        </motion.div>
       </div>
     </section>
   );

--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -1,15 +1,33 @@
-"use client";
+﻿"use client";
 
 import { ArrowRight } from "lucide-react";
+import { motion, type Variants } from "framer-motion";
 
 interface HeroProps {
   onGetStarted: () => void;
 }
 
+const container: Variants = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.12 } },
+};
+
+const fadeUp: Variants = {
+  hidden: { opacity: 0, y: 24 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.5, ease: "easeOut" },
+  },
+};
+
 export function Hero({ onGetStarted }: HeroProps) {
   return (
     <section style={{ width: "100%", backgroundColor: "#ffffff" }}>
-      <div
+      <motion.div
+        initial="hidden"
+        animate="visible"
+        variants={container}
         style={{
           maxWidth: "72rem",
           margin: "0 auto",
@@ -21,7 +39,8 @@ export function Hero({ onGetStarted }: HeroProps) {
         }}
       >
         {/* Pill */}
-        <div
+        <motion.div
+          variants={fadeUp}
           style={{
             display: "inline-flex",
             alignItems: "center",
@@ -45,10 +64,11 @@ export function Hero({ onGetStarted }: HeroProps) {
             }}
           />
           Open Source · Free Forever
-        </div>
+        </motion.div>
 
         {/* Headline */}
-        <h1
+        <motion.h1
+          variants={fadeUp}
           style={{
             fontSize: "clamp(36px, 5vw, 56px)",
             fontWeight: 600,
@@ -60,10 +80,11 @@ export function Hero({ onGetStarted }: HeroProps) {
         >
           Your open-source identity,{" "}
           <span style={{ color: "#3ecf8e" }}>beyond GitHub.</span>
-        </h1>
+        </motion.h1>
 
         {/* Sub */}
-        <p
+        <motion.p
+          variants={fadeUp}
           style={{
             marginTop: "20px",
             maxWidth: "520px",
@@ -78,10 +99,11 @@ export function Hero({ onGetStarted }: HeroProps) {
           </span>{" "}
           showing your real open-source impact — merged PRs, streaks, orgs,
           badges, and more.
-        </p>
+        </motion.p>
 
         {/* CTAs */}
-        <div
+        <motion.div
+          variants={fadeUp}
           style={{
             marginTop: "32px",
             display: "flex",
@@ -128,10 +150,11 @@ export function Hero({ onGetStarted }: HeroProps) {
           >
             See how it works
           </a>
-        </div>
+        </motion.div>
 
         {/* Stats */}
-        <div
+        <motion.div
+          variants={fadeUp}
           style={{
             marginTop: "56px",
             paddingTop: "32px",
@@ -165,8 +188,8 @@ export function Hero({ onGetStarted }: HeroProps) {
               </p>
             </div>
           ))}
-        </div>
-      </div>
+        </motion.div>
+      </motion.div>
     </section>
   );
 }

--- a/src/components/home/HowItWorks.tsx
+++ b/src/components/home/HowItWorks.tsx
@@ -1,3 +1,7 @@
+﻿"use client";
+
+import { motion, type Variants } from "framer-motion";
+
 const steps = [
   {
     number: "01",
@@ -19,6 +23,20 @@ const steps = [
   },
 ];
 
+const containerVariants: Variants = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.12 } },
+};
+
+const stepVariants: Variants = {
+  hidden: { opacity: 0, y: 24 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.5, ease: "easeOut" },
+  },
+};
+
 export function HowItWorks() {
   return (
     <section id="how-it-works" style={{ backgroundColor: "#ffffff" }}>
@@ -30,7 +48,13 @@ export function HowItWorks() {
         }}
       >
         {/* Header */}
-        <div style={{ textAlign: "center", marginBottom: "48px" }}>
+        <motion.div
+          initial={{ opacity: 0, y: 24 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, ease: "easeOut" }}
+          viewport={{ once: true }}
+          style={{ textAlign: "center", marginBottom: "48px" }}
+        >
           <p
             style={{ fontSize: "13px", fontWeight: 500, color: "#3ecf8e", marginBottom: "10px" }}
           >
@@ -47,10 +71,14 @@ export function HowItWorks() {
           >
             Up and running in 30 seconds
           </h2>
-        </div>
+        </motion.div>
 
         {/* Steps */}
-        <div
+        <motion.div
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true }}
+          variants={containerVariants}
           style={{
             display: "grid",
             gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))",
@@ -58,7 +86,11 @@ export function HowItWorks() {
           }}
         >
           {steps.map(({ number, title, description }) => (
-            <div key={number} style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+            <motion.div
+              key={number}
+              variants={stepVariants}
+              style={{ display: "flex", flexDirection: "column", gap: "16px" }}
+            >
               <div
                 style={{
                   display: "flex",
@@ -91,9 +123,9 @@ export function HowItWorks() {
                   {description}
                 </p>
               </div>
-            </div>
+            </motion.div>
           ))}
-        </div>
+        </motion.div>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary

The homepage sections were completely static — nothing moved as you scrolled, which made the page feel flat. This PR adds scroll-triggered motion using Framer Motion so the sections come alive: the Hero reveals itself on page load with a staggered fade-up, and the Features, How it Works, and CTA Banner sections fade and slide up as you scroll into each one. Everything is set to animate only once so it doesn't replay when you scroll back up.

## Related Issue

Closes #37

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Chore / dependency update

## Changes Made

- **Hero.tsx** — Added an on-load staggered reveal. The outer content is now a `motion.div` parent with a `staggerChildren` transition, and each child (pill, headline, subtext, CTA group, stats row) animates in one after another using a shared `fadeUp` variant. Used `initial`/`animate` here rather than `whileInView` since the Hero is above the fold.
- **Features.tsx** — Added `"use client"` (required for Framer Motion). The section header fades up via `whileInView`, and the card grid is a stagger container so each of the 8 feature cards fades and slides up in sequence as the grid enters the viewport.
- **HowItWorks.tsx** — Added `"use client"`. Same approach as Features: the header fades up and the 3 numbered steps stagger in on scroll.
- **CTABanner.tsx** — Wrapped the inner content in a `motion.div` that fades up via `whileInView` when it enters the viewport.
- All scroll animations use `viewport={{ once: true }}`, easing `easeOut`, and a 0.5s duration for a consistent feel.

## AI Usage

- [ ] I did not use AI for any part of the code in this PR
- [x] I used AI for coding (specify which tool below) and I fully understand every change I made, including which functions I changed, why I changed them, and what side effects they could create

Used Claude for coding. I understand every change: which components were touched, why each one needed the animation wrappers, and the one notable side effect — `Features.tsx` and `HowItWorks.tsx` had to be converted to client components with `"use client"` because Framer Motion's `motion` components only run on the client. No other behavior was changed.

## Screenshots (if UI change)

<!-- Add a short screen recording of the scroll animations here -->

## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with `main`
- [x] Code works locally and I have tested it
- [x] No `console.log` left in `src/`
- [ ] If schema changed — both `schema.sql` and a new migration file are included
- [x] If this is a UI change — I read `DESIGN.md` and followed the design system (colors, spacing, typography, components)
- [ ] Docs updated if needed
- [x] PR title follows Conventional Commits format (`feat:`, `fix:`, `docs:`, etc.)
- [x] This PR description is written in my own words

https://github.com/user-attachments/assets/f2eed055-875a-41a5-b60e-52d1bef687ad

