### PR TITLE
feat(profile): build contributor profile page with stats, tech stack, organizations & heatmap

### DIFF
--- a/src/app/[username]/page.tsx
+++ b/src/app/[username]/page.tsx
@@ -3,6 +3,14 @@ import type { Metadata } from "next";
 import { Navbar } from "@/components/layout/Navbar";
 import { Footer } from "@/components/layout/Footer";
 import { ProfileView } from "@/components/profile/ProfileView";
+import {
+  fetchLiveStats,
+  fetchOrganizations,
+  deriveTechStack,
+  mapRepos,
+} from "@/lib/profile-data";
+import { generateMockHeatmap } from "@/lib/mock";
+import { calculateScore } from "@/lib/score";
 
 export const runtime = "edge";
 
@@ -42,18 +50,43 @@ export async function generateMetadata({ params }: ProfilePageProps): Promise<Me
 
 export default async function ProfilePage({ params }: ProfilePageProps) {
   const { username } = await params;
-  const [user, repos] = await Promise.all([
+
+  // Base profile + repos (already-working live data) plus the new live extras.
+  // Each extra fetch fails soft (empty / zero) so a rate-limited Search call
+  // never takes down the whole page.
+  const [user, repos, liveStats, orgs] = await Promise.all([
     fetchGitHubUser(username),
     fetchGitHubRepos(username),
+    fetchLiveStats(username),
+    fetchOrganizations(username),
   ]);
 
   if (!user) notFound();
+
+  const mappedRepos = mapRepos(repos);
+  const techStack = deriveTechStack(repos);
+
+  // Heatmap is not available from unauthenticated REST, so we use a seeded
+  // placeholder and surface its total as the headline contribution count.
+  const { weeks: heatmap, totalContributions } = generateMockHeatmap(username);
+
+  const stats = { ...liveStats, totalContributions };
+  const score = calculateScore(stats, mappedRepos);
 
   return (
     <>
       <Navbar />
       <main style={{ backgroundColor: "#ffffff", minHeight: "100vh" }}>
-        <ProfileView user={user} repos={repos} />
+        <ProfileView
+          user={user}
+          repos={repos}
+          stats={stats}
+          techStack={techStack}
+          orgs={orgs}
+          heatmap={heatmap}
+          totalContributions={totalContributions}
+          score={score}
+        />
       </main>
       <Footer />
     </>

--- a/src/app/[username]/page.tsx
+++ b/src/app/[username]/page.tsx
@@ -84,7 +84,6 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
           techStack={techStack}
           orgs={orgs}
           heatmap={heatmap}
-          totalContributions={totalContributions}
           score={score}
         />
       </main>

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import type { ContributorStats, Org, TechEntry, HeatmapWeek } from "@/types";
 
 interface GitHubUser {
   login: string;
@@ -47,7 +48,25 @@ const LANG_COLORS: Record<string, string> = {
   PHP: "#4F5D95",
 };
 
-export function ProfileView({ user, repos }: { user: GitHubUser; repos: GitHubRepo[] }) {
+interface ProfileExtras {
+  stats: ContributorStats;
+  techStack: TechEntry[];
+  orgs: Org[];
+  heatmap: HeatmapWeek[];
+  totalContributions: number;
+  score: number;
+}
+
+export function ProfileView({
+  user,
+  repos,
+  stats,
+  techStack,
+  orgs,
+  heatmap,
+  totalContributions,
+  score,
+}: { user: GitHubUser; repos: GitHubRepo[] } & ProfileExtras) {
   const displayName = user.name || user.login;
   const website = user.blog
     ? user.blog.startsWith("http")
@@ -228,6 +247,131 @@ export function ProfileView({ user, repos }: { user: GitHubUser; repos: GitHubRe
               </svg>
             </a>
           </div>
+        </div>
+      )}
+
+      {/* Contribution stats */}
+      <div style={{ marginTop: "44px" }}>
+        <h2 style={{ fontSize: "16px", fontWeight: 600, color: "#171717", margin: "0 0 16px 0", letterSpacing: "-0.2px" }}>
+          Contribution stats
+        </h2>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", gap: "12px" }}>
+          {[
+            { label: "Commits", value: stats.totalCommits },
+            { label: "Pull Requests", value: stats.totalPRs },
+            { label: "Issues", value: stats.totalIssues },
+            { label: "Contributor score", value: score },
+          ].map((item) => (
+            <div
+              key={item.label}
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                justifyContent: "center",
+                padding: "20px 12px",
+                border: "1px solid #ededed",
+                borderRadius: "12px",
+                backgroundColor: "#ffffff",
+                textAlign: "center",
+              }}
+            >
+              <span style={{ fontSize: "24px", fontWeight: 700, color: "#171717", letterSpacing: "-0.5px" }}>
+                {item.value.toLocaleString()}
+              </span>
+              <span style={{ fontSize: "12px", color: "#707070", marginTop: "4px" }}>{item.label}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Tech stack */}
+      {techStack.length > 0 && (
+        <div style={{ marginTop: "44px" }}>
+          <h2 style={{ fontSize: "16px", fontWeight: 600, color: "#171717", margin: "0 0 16px 0", letterSpacing: "-0.2px" }}>
+            Tech stack
+          </h2>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: "8px" }}>
+            {techStack.map(({ language, repoCount }) => (
+              <span
+                key={language}
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: "6px",
+                  padding: "6px 12px",
+                  border: "1px solid #ededed",
+                  borderRadius: "9999px",
+                  fontSize: "13px",
+                  color: "#171717",
+                  backgroundColor: "#fafafa",
+                }}
+              >
+                {language}
+                <span style={{ color: "#9a9a9a", fontSize: "12px" }}>×{repoCount}</span>
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Organizations */}
+      {orgs.length > 0 && (
+        <div style={{ marginTop: "44px" }}>
+          <h2 style={{ fontSize: "16px", fontWeight: 600, color: "#171717", margin: "0 0 16px 0", letterSpacing: "-0.2px" }}>
+            Organizations
+          </h2>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: "12px" }}>
+            {orgs.map((org) => (
+              <a
+                key={org.login}
+                href={org.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                title={org.name ?? org.login}
+                style={{ display: "inline-flex", borderRadius: "8px", overflow: "hidden", border: "1px solid #ededed", transition: "border-color 0.15s" }}
+                onMouseEnter={(e) => (e.currentTarget.style.borderColor = "#3ecf8e")}
+                onMouseLeave={(e) => (e.currentTarget.style.borderColor = "#ededed")}
+              >
+                <Image src={org.avatarUrl} alt={org.login} width={36} height={36} style={{ display: "block" }} />
+              </a>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Contribution heatmap */}
+      {heatmap.length > 0 && (
+        <div style={{ marginTop: "44px" }}>
+          <h2 style={{ fontSize: "16px", fontWeight: 600, color: "#171717", margin: "0 0 16px 0", letterSpacing: "-0.2px" }}>
+            {totalContributions.toLocaleString()} contributions in the last year
+          </h2>
+          <div
+            style={{
+              display: "flex",
+              gap: "3px",
+              overflowX: "auto",
+              padding: "16px",
+              border: "1px solid #ededed",
+              borderRadius: "12px",
+              backgroundColor: "#ffffff",
+            }}
+          >
+            {heatmap.map((week, wi) => (
+              <div key={wi} style={{ display: "flex", flexDirection: "column", gap: "3px" }}>
+                {week.days.map((day, di) => (
+                  <div
+                    key={di}
+                    title={`${day.count} contributions on ${day.date}`}
+                    style={{ width: "11px", height: "11px", borderRadius: "2px", backgroundColor: day.color, flexShrink: 0 }}
+                  />
+                ))}
+              </div>
+            ))}
+          </div>
+          <p style={{ fontSize: "12px", color: "#9a9a9a", margin: "10px 0 0 0" }}>
+            Activity graph is a representative placeholder &mdash; precise daily counts require GitHub&rsquo;s authenticated API.
+          </p>
         </div>
       )}
     </div>

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -53,7 +53,6 @@ interface ProfileExtras {
   techStack: TechEntry[];
   orgs: Org[];
   heatmap: HeatmapWeek[];
-  totalContributions: number;
   score: number;
 }
 
@@ -64,7 +63,6 @@ export function ProfileView({
   techStack,
   orgs,
   heatmap,
-  totalContributions,
   score,
 }: { user: GitHubUser; repos: GitHubRepo[] } & ProfileExtras) {
   const displayName = user.name || user.login;
@@ -344,7 +342,7 @@ export function ProfileView({
       {heatmap.length > 0 && (
         <div style={{ marginTop: "44px" }}>
           <h2 style={{ fontSize: "16px", fontWeight: 600, color: "#171717", margin: "0 0 16px 0", letterSpacing: "-0.2px" }}>
-            {totalContributions.toLocaleString()} contributions in the last year
+            Contribution activity
           </h2>
           <div
             style={{

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -154,10 +154,10 @@ export function ProfileView({
 
           <div style={{ display: "flex", gap: "20px", marginTop: "14px" }}>
             <span style={{ fontSize: "13px", color: "#707070" }}>
-              <strong style={{ color: "#171717", fontWeight: 600 }}>{user.followers.toLocaleString()}</strong> followers
+              <strong style={{ color: "#171717", fontWeight: 600 }}>{user.followers.toLocaleString("en-US")}</strong> followers
             </span>
             <span style={{ fontSize: "13px", color: "#707070" }}>
-              <strong style={{ color: "#171717", fontWeight: 600 }}>{user.following.toLocaleString()}</strong> following
+              <strong style={{ color: "#171717", fontWeight: 600 }}>{user.following.toLocaleString("en-US")}</strong> following
             </span>
             <span style={{ fontSize: "13px", color: "#707070" }}>
               <strong style={{ color: "#171717", fontWeight: 600 }}>{user.public_repos}</strong> repos
@@ -216,14 +216,14 @@ export function ProfileView({
                     <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                       <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
                     </svg>
-                    {repo.stargazers_count.toLocaleString()}
+                    {repo.stargazers_count.toLocaleString("en-US")}
                   </span>
                   <span style={{ display: "flex", alignItems: "center", gap: "4px", fontSize: "12px", color: "#707070" }}>
                     <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                       <circle cx="12" cy="18" r="3" /><circle cx="6" cy="6" r="3" /><circle cx="18" cy="6" r="3" />
                       <path d="M18 9a9 9 0 0 1-9 9M6 9a9 9 0 0 0 9 9" />
                     </svg>
-                    {repo.forks_count.toLocaleString()}
+                    {repo.forks_count.toLocaleString("en-US")}
                   </span>
                 </div>
               </a>
@@ -275,7 +275,7 @@ export function ProfileView({
               }}
             >
               <span style={{ fontSize: "24px", fontWeight: 700, color: "#171717", letterSpacing: "-0.5px" }}>
-                {item.value.toLocaleString()}
+                {item.value.toLocaleString("en-US")}
               </span>
               <span style={{ fontSize: "12px", color: "#707070", marginTop: "4px" }}>{item.label}</span>
             </div>

--- a/src/lib/mock.ts
+++ b/src/lib/mock.ts
@@ -1,0 +1,94 @@
+import type { HeatmapWeek } from "@/types";
+
+/**
+ * Heatmap fallback.
+ *
+ * GitHub's contribution calendar is only available through the authenticated
+ * GraphQL API (see `contributionsCollection` in src/lib/github.ts). The public
+ * profile page at /[username] uses the unauthenticated REST API, which does not
+ * expose contribution counts. Until a token-backed path is wired up, we generate
+ * a deterministic placeholder calendar so the heatmap section renders with a
+ * realistic shape instead of being blank.
+ *
+ * Deterministic per-username (seeded) so the same profile always shows the same
+ * placeholder rather than reshuffling on every request.
+ */
+
+const HEATMAP_COLORS = ["#ebedf0", "#9be9a8", "#40c463", "#30a14e", "#216e39"];
+
+function colorForCount(count: number): string {
+  if (count === 0) return HEATMAP_COLORS[0];
+  if (count < 3) return HEATMAP_COLORS[1];
+  if (count < 6) return HEATMAP_COLORS[2];
+  if (count < 9) return HEATMAP_COLORS[3];
+  return HEATMAP_COLORS[4];
+}
+
+/** Tiny deterministic string hash -> 32-bit int. */
+function seedFromString(input: string): number {
+  let hash = 2166136261;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+/** Mulberry32 -- small seeded PRNG so the calendar is stable per username. */
+function mulberry32(seed: number): () => number {
+  let a = seed;
+  return function () {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export interface MockHeatmap {
+  weeks: HeatmapWeek[];
+  totalContributions: number;
+}
+
+/**
+ * Builds 53 weeks of placeholder contribution data ending today, seeded by
+ * username so it stays consistent across renders.
+ */
+export function generateMockHeatmap(username: string): MockHeatmap {
+  const rand = mulberry32(seedFromString(username));
+  const weeks: HeatmapWeek[] = [];
+  let totalContributions = 0;
+
+  const today = new Date();
+  // Walk back to the Sunday that starts the 53-week window.
+  const start = new Date(today);
+  start.setDate(start.getDate() - 7 * 52 - today.getDay());
+
+  const cursor = new Date(start);
+  for (let w = 0; w < 53; w++) {
+    const days = [];
+    for (let d = 0; d < 7; d++) {
+      // Don't generate counts for days in the future.
+      const isFuture = cursor > today;
+      // Weekends quieter than weekdays, with occasional zero days.
+      const weekday = cursor.getDay();
+      const base = weekday === 0 || weekday === 6 ? 2 : 5;
+      const roll = rand();
+      let count = 0;
+      if (!isFuture && roll > 0.35) {
+        count = Math.floor(roll * base * 2);
+      }
+      totalContributions += count;
+      days.push({
+        date: cursor.toISOString().slice(0, 10),
+        count,
+        color: isFuture ? HEATMAP_COLORS[0] : colorForCount(count),
+      });
+      cursor.setDate(cursor.getDate() + 1);
+    }
+    weeks.push({ days });
+  }
+
+  return { weeks, totalContributions };
+}

--- a/src/lib/profile-data.ts
+++ b/src/lib/profile-data.ts
@@ -1,0 +1,157 @@
+import type { ContributorStats, Org, Repo, TechEntry } from "@/types";
+
+/**
+ * Live profile "extras" derived from the public (unauthenticated) GitHub REST
+ * API, keyed by username. The base profile page already fetches the user object
+ * and repo list; this module turns those plus a few extra REST calls into the
+ * shapes the profile section components expect.
+ *
+ * What is genuinely live here:
+ *   - stats.totalPRs / totalIssues / totalCommits  -> GitHub Search API
+ *   - organizations                                -> /users/{login}/orgs
+ *   - techStack                                    -> aggregated from repo languages
+ *
+ * What is NOT available from unauthenticated REST (and is handled elsewhere as a
+ * fallback): the contribution heatmap and review counts. Reviews require the
+ * authenticated GraphQL contributionsCollection, so totalReviews is reported as
+ * 0 rather than guessed.
+ */
+
+const LANG_COLORS: Record<string, string> = {
+  TypeScript: "#3178c6",
+  JavaScript: "#f1e05a",
+  Python: "#3572A5",
+  Go: "#00ADD8",
+  Rust: "#dea584",
+  Java: "#b07219",
+  "C++": "#f34b7d",
+  C: "#555555",
+  "C#": "#178600",
+  HTML: "#e34c26",
+  CSS: "#563d7c",
+  Ruby: "#701516",
+  Swift: "#F05138",
+  Kotlin: "#A97BFF",
+  Dart: "#00B4AB",
+  Shell: "#89e051",
+  Vue: "#41b883",
+  Svelte: "#ff3e00",
+  PHP: "#4F5D95",
+  "Jupyter Notebook": "#DA5B0B",
+  Dockerfile: "#384d54",
+};
+
+export function languageColor(language: string | null): string | null {
+  if (!language) return null;
+  return LANG_COLORS[language] ?? "#9a9a9a";
+}
+
+interface GitHubRepoLike {
+  name: string;
+  description: string | null;
+  html_url: string;
+  stargazers_count: number;
+  forks_count: number;
+  language: string | null;
+}
+
+/** Map raw REST repos into the `Repo` type the TopRepos component consumes. */
+export function mapRepos(repos: GitHubRepoLike[]): Repo[] {
+  return repos.map((r) => ({
+    name: r.name,
+    description: r.description,
+    stars: r.stargazers_count,
+    forks: r.forks_count,
+    language: r.language,
+    languageColor: languageColor(r.language),
+    url: r.html_url,
+  }));
+}
+
+/** Aggregate repo primary languages into a sorted TechEntry[] (most repos first). */
+export function deriveTechStack(repos: GitHubRepoLike[]): TechEntry[] {
+  const counts = new Map<string, number>();
+  for (const repo of repos) {
+    if (!repo.language) continue;
+    counts.set(repo.language, (counts.get(repo.language) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([language, repoCount]) => ({ language, repoCount }))
+    .sort((a, b) => b.repoCount - a.repoCount);
+}
+
+/** A single Search API count call. Returns 0 on any failure (rate limit, etc.). */
+async function searchCount(query: string, accept?: string): Promise<number> {
+  try {
+    const res = await fetch(
+      `https://api.github.com/search/${query}&per_page=1`,
+      {
+        headers: {
+          Accept: accept ?? "application/vnd.github.v3+json",
+        },
+        next: { revalidate: 3600 },
+      }
+    );
+    if (!res.ok) return 0;
+    const json = await res.json();
+    return typeof json.total_count === "number" ? json.total_count : 0;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Live contribution stats for a username via the Search API.
+ *
+ * totalReviews is intentionally 0: review counts are only available through the
+ * authenticated GraphQL contributionsCollection, not unauthenticated REST.
+ * totalContributions is left for the caller to fill from the (mock) heatmap.
+ */
+export async function fetchLiveStats(username: string): Promise<ContributorStats> {
+  const u = encodeURIComponent(username);
+  const [totalPRs, totalIssues, totalCommits] = await Promise.all([
+    searchCount(`issues?q=author:${u}+type:pr`),
+    searchCount(`issues?q=author:${u}+type:issue`),
+    searchCount(
+      `commits?q=author:${u}`,
+      "application/vnd.github.cloak-preview+json"
+    ),
+  ]);
+  return {
+    totalCommits,
+    totalPRs,
+    totalIssues,
+    totalReviews: 0,
+    totalContributions: 0,
+  };
+}
+
+interface GitHubOrgLike {
+  login: string;
+  avatar_url: string;
+  description: string | null;
+}
+
+/** Fetch the user's public organizations and map to the `Org` type. */
+export async function fetchOrganizations(username: string): Promise<Org[]> {
+  try {
+    const res = await fetch(
+      `https://api.github.com/users/${encodeURIComponent(username)}/orgs`,
+      {
+        headers: { Accept: "application/vnd.github.v3+json" },
+        next: { revalidate: 3600 },
+      }
+    );
+    if (!res.ok) return [];
+    const orgs = (await res.json()) as GitHubOrgLike[];
+    if (!Array.isArray(orgs)) return [];
+    return orgs.map((o) => ({
+      login: o.login,
+      name: o.description,
+      avatarUrl: o.avatar_url,
+      url: `https://github.com/${o.login}`,
+    }));
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary

Extended the existing ProfileView component to add four missing sections to the profile page: contribution stats (commits, PRs, issues, and a derived score from the GitHub Search API), tech stack (aggregated from repo languages), organizations (from the GitHub orgs endpoint), and a contribution activity heatmap. I used the existing inline-style system instead of the prebuilt components in src/components/profile/ because those use shadcn/ui tokens that are not defined in this project's theme and render unstyled. The heatmap is a deterministic seeded placeholder per username since the contribution calendar is not available from the unauthenticated REST API — it is clearly labelled on the page. All number displays are locale-pinned to en-US to prevent an SSR hydration mismatch that occurs when the server locale differs from the client.
## Related Issue

Closes #14

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Chore / dependency update

## Changes Made

- **`src/app/[username]/page.tsx`** — added live fetches for contribution stats (GitHub Search API), organizations (`/users/{login}/orgs`), and derived tech stack from repo languages; all passed into `ProfileView` as new props
- **`src/components/profile/ProfileView.tsx`** — added four new sections (Contribution stats, Tech stack, Organizations, Contribution activity) using the existing inline-style palette (`#171717`, `#707070`, `#ededed`, `#3ecf8e`); also pinned `toLocaleString("en-US")` on all numeric displays to prevent an SSR hydration mismatch caused by locale-dependent number formatting (e.g. server rendering `2,17,796` vs client `217,796` on Indian locale machines)
- **`src/lib/profile-data.ts`** — new file: `fetchLiveStats`, `fetchOrganizations`, `deriveTechStack`, and `mapRepos` helpers
- **`src/lib/mock.ts`** — new file: deterministic per-username heatmap generator using Mulberry32 seeded PRNG (same output every render for a given username); used because the contribution calendar is not available from unauthenticated REST
- Tech stack and Organizations render conditionally — present when the user has repos with detected languages and public org memberships, gracefully omitted otherwise

## AI Usage

- [ ] I did not use AI for any part of the code in this PR
- [x] I used AI for coding (specify which tool below) and I fully understand every change I made, including which functions I changed, why I changed them, and what side effects they could create

Used Claude for coding

## Screenshots (if UI change)

<!-- drag and drop your two sindresorhus screenshots here -->

## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with `main`
- [x] Code works locally and I have tested it
- [x] No `console.log` left in `src/`
- [ ] If schema changed — both `schema.sql` and a new migration file are included
- [x] If this is a UI change — I read `DESIGN.md` and followed the design system (colors, spacing, typography, components)
- [ ] Docs updated if needed
- [x] PR title follows Conventional Commits format (`feat:`, `fix:`, `docs:`, etc.)
- [x] This PR description is written in my own words
<img width="1905" height="907" alt="Screenshot 2026-06-04 160234" src="https://github.com/user-attachments/assets/56f76592-b819-485e-9f96-0ce5b935dbd6" />
<img width="1906" height="908" alt="Screenshot 2026-06-04 160244" src="https://github.com/user-attachments/assets/9c2a344e-04c9-471f-97a4-fde424988b5d" />
