### PR TITLE
feat(profile): add loading skeleton for profile pages

### DIFF
--- a/src/app/[username]/loading.tsx
+++ b/src/app/[username]/loading.tsx
@@ -1,0 +1,297 @@
+/**
+ * src/app/[username]/loading.tsx
+ *
+ * Next.js App Router loading UI — displayed automatically while page.tsx
+ * awaits its GitHub API fetches. Mirrors the ProfileView layout section by
+ * section using grey shimmer blocks per the DESIGN.md palette:
+ *   canvas  #ffffff · hairline-cool #ededed · hairline #dfdfdf
+ *
+ * Rules: inline styles only, no Tailwind, no TypeScript errors. (Issue #42)
+ */
+
+import type { CSSProperties } from "react";
+
+// Shimmer base style — reused by every skeleton block.
+// The 800px backgroundSize combined with the keyframe position sweep
+// produces the left-to-right highlight that reads as a loading state.
+const shimmer: CSSProperties = {
+  background:
+    "linear-gradient(90deg, #ededed 25%, #dfdfdf 50%, #ededed 75%)",
+  backgroundSize: "800px 100%",
+  animation: "shimmer 1.4s infinite linear",
+  borderRadius: "6px",
+};
+
+// Reusable shimmer block. Accepts explicit dimensions and optional style
+// overrides (e.g. borderRadius for circles/pills).
+function Block({
+  width,
+  height,
+  style,
+}: {
+  width: number | string;
+  height: number;
+  style?: CSSProperties;
+}) {
+  return (
+    <div
+      style={{
+        ...shimmer,
+        width,
+        height,
+        flexShrink: 0,
+        ...style,
+      }}
+    />
+  );
+}
+
+export default function ProfileLoading() {
+  return (
+    <>
+      {/* Keyframe injected as a style tag — the only way to use @keyframes
+          with inline-style-only components. */}
+      <style>{`
+        @keyframes shimmer {
+          0%   { background-position: -400px 0; }
+          100% { background-position:  400px 0; }
+        }
+      `}</style>
+
+      <main style={{ backgroundColor: "#ffffff", minHeight: "100vh" }}>
+        {/* Outer container mirrors ProfileView's maxWidth + padding exactly */}
+        <div
+          style={{
+            maxWidth: "56rem",
+            margin: "0 auto",
+            padding: "48px 20px 80px",
+          }}
+        >
+
+          {/* ── Profile header ──────────────────────────────────────── */}
+          {/* Mirrors: flex row (avatar + info column), borderBottom */}
+          <div
+            style={{
+              display: "flex",
+              alignItems: "flex-start",
+              gap: "24px",
+              flexWrap: "wrap",
+              paddingBottom: "40px",
+              borderBottom: "1px solid #ededed",
+            }}
+          >
+            {/* Avatar — 88×88 circle matching Image dimensions in ProfileView */}
+            <Block
+              width={88}
+              height={88}
+              style={{ borderRadius: "9999px" }}
+            />
+
+            {/* Name / username / bio / links / follower counts */}
+            <div
+              style={{
+                flex: 1,
+                minWidth: "200px",
+                display: "flex",
+                flexDirection: "column",
+                gap: "0px",
+              }}
+            >
+              {/* Display name — h1 24px */}
+              <Block width={180} height={20} />
+              {/* @username — 14px muted */}
+              <Block width={110} height={14} style={{ marginTop: "8px" }} />
+              {/* Bio — two lines */}
+              <Block width="90%" height={14} style={{ marginTop: "14px" }} />
+              <Block width="65%" height={14} style={{ marginTop: "6px" }} />
+
+              {/* Location / website / twitter / github link row */}
+              <div
+                style={{
+                  display: "flex",
+                  flexWrap: "wrap",
+                  gap: "12px",
+                  marginTop: "14px",
+                }}
+              >
+                {([88, 110, 78, 68] as number[]).map((w, i) => (
+                  <Block key={i} width={w} height={13} />
+                ))}
+              </div>
+
+              {/* Followers · following · repos row */}
+              <div
+                style={{
+                  display: "flex",
+                  gap: "20px",
+                  marginTop: "14px",
+                }}
+              >
+                {([72, 72, 56] as number[]).map((w, i) => (
+                  <Block key={i} width={w} height={13} />
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* ── Popular repositories ────────────────────────────────── */}
+          {/* Mirrors: heading + repeat(auto-fill, minmax(280px, 1fr)) grid */}
+          <div style={{ marginTop: "40px" }}>
+            <Block
+              width={158}
+              height={16}
+              style={{ marginBottom: "20px" }}
+            />
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))",
+                gap: "16px",
+              }}
+            >
+              {Array.from({ length: 6 }).map((_, i) => (
+                <div
+                  key={i}
+                  style={{
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: "10px",
+                    padding: "20px",
+                    border: "1px solid #ededed",
+                    borderRadius: "12px",
+                    backgroundColor: "#ffffff",
+                  }}
+                >
+                  {/* Repo name */}
+                  <Block width="55%" height={14} />
+                  {/* Description — two lines */}
+                  <Block width="92%" height={12} />
+                  <Block width="75%" height={12} />
+                  {/* Language dot + stars + forks */}
+                  <div
+                    style={{
+                      display: "flex",
+                      gap: "12px",
+                      marginTop: "4px",
+                    }}
+                  >
+                    <Block width={52} height={12} />
+                    <Block width={38} height={12} />
+                    <Block width={38} height={12} />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* ── Contribution stats ──────────────────────────────────── */}
+          {/* Mirrors: heading + repeat(auto-fit, minmax(140px, 1fr)) grid */}
+          <div style={{ marginTop: "44px" }}>
+            <Block
+              width={148}
+              height={16}
+              style={{ marginBottom: "20px" }}
+            />
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))",
+                gap: "12px",
+              }}
+            >
+              {Array.from({ length: 4 }).map((_, i) => (
+                <div
+                  key={i}
+                  style={{
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: "10px",
+                    padding: "16px",
+                    border: "1px solid #ededed",
+                    borderRadius: "8px",
+                  }}
+                >
+                  {/* Stat number */}
+                  <Block width="55%" height={24} />
+                  {/* Stat label */}
+                  <Block width="80%" height={12} />
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* ── Tech stack ──────────────────────────────────────────── */}
+          {/* Mirrors: heading + flex-wrap pill row */}
+          <div style={{ marginTop: "44px" }}>
+            <Block
+              width={96}
+              height={16}
+              style={{ marginBottom: "16px" }}
+            />
+            <div style={{ display: "flex", flexWrap: "wrap", gap: "8px" }}>
+              {([72, 90, 68, 80, 64, 88, 74, 66] as number[]).map((w, i) => (
+                <Block
+                  key={i}
+                  width={w}
+                  height={28}
+                  style={{ borderRadius: "9999px" }}
+                />
+              ))}
+            </div>
+          </div>
+
+          {/* ── Organizations ───────────────────────────────────────── */}
+          {/* Mirrors: heading + flex-wrap row of avatar + name chips */}
+          <div style={{ marginTop: "44px" }}>
+            <Block
+              width={118}
+              height={16}
+              style={{ marginBottom: "16px" }}
+            />
+            <div style={{ display: "flex", flexWrap: "wrap", gap: "12px" }}>
+              {([80, 96, 72, 88, 76] as number[]).map((w, i) => (
+                <div
+                  key={i}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "8px",
+                    padding: "6px 12px 6px 6px",
+                    border: "1px solid #ededed",
+                    borderRadius: "8px",
+                  }}
+                >
+                  {/* Org avatar circle — 36×36 matching Image size in ProfileView */}
+                  <Block
+                    width={36}
+                    height={36}
+                    style={{ borderRadius: "9999px" }}
+                  />
+                  {/* Org handle */}
+                  <Block width={w} height={13} />
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* ── Contribution activity (heatmap) ─────────────────────── */}
+          {/* Mirrors the heatmap section heading + the grid of week columns */}
+          <div style={{ marginTop: "44px" }}>
+            <Block
+              width={178}
+              height={16}
+              style={{ marginBottom: "16px" }}
+            />
+            {/* Single shimmer rectangle represents the 52-week heatmap */}
+            <Block
+              width="100%"
+              height={88}
+              style={{ borderRadius: "8px" }}
+            />
+          </div>
+
+        </div>
+      </main>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

The profile page (e.g. `/torvalds`) fetches data from the GitHub API before it can render, and until that resolves the user just sees a blank white page, which reads as broken. This PR adds the App Router `loading.tsx` for the `[username]` route so Next.js shows a shimmer skeleton during that fetch instead. The skeleton mirrors the real profile layout, so when the data arrives the page fills in place rather than jumping.

## Related Issue

Closes #42

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Chore / dependency update

## Changes Made

- Added `src/app/[username]/loading.tsx` (the only file in this PR). Next.js App Router renders it automatically while `page.tsx` awaits its GitHub fetches — no extra wiring needed.
- Built the skeleton to mirror `ProfileView` section by section — header (avatar + name/bio/links/follower bars), Popular repositories grid, Contribution stats, Tech stack, Organizations, and the contribution heatmap — so the layout doesn't shift when real content swaps in.
- Reused the same grid definitions as the live page (`repeat(auto-fill, minmax(280px, 1fr))` for repos, `repeat(auto-fit, minmax(140px, 1fr))` for stats) so the skeleton's column counts match the real layout at every width.
- Added a small `Block` helper component to keep every placeholder consistent and avoid repeating the shimmer style.
- The shimmer is a `@keyframes` gradient sweep injected via a `<style>` tag — keyframes can't be expressed as a pure inline style, so this is the minimal way to honor the inline-styles-only convention.

## AI Usage

- [ ] I did not use AI for any part of the code in this PR
- [x] I used AI for coding (specify which tool below) and I fully understand every change I made, including which functions I changed, why I changed them, and what side effects they could create

Used Claude for coding.

## Screenshots (if UI change)

**Before:** blank white page while profile data loads.

**After:** shimmer skeleton mirroring the profile layout.

<!-- paste your screenshot here -->

## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with `main`
- [x] Code works locally and I have tested it
- [x] No `console.log` left in `src/`
- [x] If schema changed — both `schema.sql` and a new migration file are included *(N/A — no schema change)*
- [x] If this is a UI change — I read `DESIGN.md` and followed the design system (colors, spacing, typography, components)
- [x] Docs updated if needed *(none needed)*
- [x] PR title follows Conventional Commits format (`feat:`, `fix:`, `docs:`, etc.)
- [x] This PR description is written in my own words
<img width="1911" height="909" alt="Screenshot 2026-06-04 234646" src="https://github.com/user-attachments/assets/38da4ee7-8e3a-46b8-87ae-2ab8a023f639" />
<img width="690" height="906" alt="Screenshot 2026-06-04 235056" src="https://github.com/user-attachments/assets/2b28b783-7426-4c1c-9d22-19e243d78bdc" />
