### PR TITLE
feat(score): compute and store the contributor score on login (#15)

### DIFF
--- a/src/app/[username]/page.tsx
+++ b/src/app/[username]/page.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/lib/profile-data";
 import { generateMockHeatmap } from "@/lib/mock";
 import { calculateScore } from "@/lib/score";
+import { supabase } from "@/lib/supabase";
 
 export const runtime = "edge";
 
@@ -71,7 +72,24 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
   const { weeks: heatmap, totalContributions } = generateMockHeatmap(username);
 
   const stats = { ...liveStats, totalContributions };
-  const score = calculateScore(stats, mappedRepos);
+  const liveScore = calculateScore(stats, mappedRepos);
+
+  // DB-first: prefer the stored (synced) score so every visitor — including
+  // signed-out ones — sees the same official number that feeds the leaderboard.
+  // Falls back to the live-computed score if this user hasn't synced a row yet.
+  let score = liveScore;
+  try {
+    const { data: profileRow } = await supabase
+      .from("profiles")
+      .select("score")
+      .eq("username", username)
+      .maybeSingle();
+    if (profileRow && typeof profileRow.score === "number") {
+      score = profileRow.score;
+    }
+  } catch {
+    // Ignore and use the live score — a Supabase hiccup must not break the page.
+  }
 
   return (
     <>

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -10,13 +10,85 @@ import { mapRepos, fetchLiveStats } from "@/lib/profile-data";
 import { calculateScore } from "@/lib/score";
 import type { ContributorStats, Repo } from "@/types";
 
+// Cap how long the post-login score sync may delay the redirect. The sync is
+// best-effort (the profile page recomputes the score live as a fallback), so a
+// slow GitHub/Supabase response must never hold the user on this screen.
+const SYNC_TIMEOUT_MS = 4000;
+
+// Unauthenticated REST pipeline — the same one the public profile page uses.
+// Reviews aren't visible here (totalReviews stays 0), but it lets the score be
+// stored even when the GraphQL/token path is unavailable or fails.
+async function statsFromRest(
+  username: string
+): Promise<{ stats: ContributorStats; repos: Repo[] }> {
+  const reposRes = await fetch(
+    `https://api.github.com/users/${username}/repos?sort=stars&per_page=12&type=owner`,
+    { headers: { Accept: "application/vnd.github.v3+json" } }
+  );
+  const rawRepos = reposRes.ok ? await reposRes.json() : [];
+  const filtered = Array.isArray(rawRepos)
+    ? rawRepos.filter((r: { fork: boolean }) => !r.fork).slice(0, 6)
+    : [];
+  return { repos: mapRepos(filtered), stats: await fetchLiveStats(username) };
+}
+
+// Compute the user's score and persist it to their own profiles row. Prefers
+// the authenticated GraphQL path (which includes review counts) and falls back
+// to REST when the token is absent OR the GraphQL call fails, so a login always
+// stores a score.
+async function syncScore(
+  userId: string,
+  username: string,
+  providerToken: string | undefined
+): Promise<void> {
+  let stats: ContributorStats;
+  let repos: Repo[];
+
+  if (providerToken) {
+    try {
+      const contributor = await fetchContributorProfile(username, providerToken);
+      ({ stats, repos } = contributorToScoreInputs(contributor));
+    } catch {
+      // GraphQL failed (token expired, rate limit, network) — fall back to REST
+      // rather than abandoning persistence for this login.
+      ({ stats, repos } = await statsFromRest(username));
+    }
+  } else {
+    ({ stats, repos } = await statsFromRest(username));
+  }
+
+  const score = calculateScore(stats, repos);
+
+  // RLS ("Users can update/insert own profile", auth.uid() = id) permits this
+  // with the anon client — no service-role key needed. upsert() resolves with
+  // { error } rather than throwing, so check it explicitly instead of relying
+  // on a surrounding try/catch.
+  const { error } = await supabase.from("profiles").upsert(
+    {
+      id: userId,
+      username,
+      score,
+      total_commits: stats.totalCommits,
+      total_prs: stats.totalPRs,
+      total_issues: stats.totalIssues,
+      total_reviews: stats.totalReviews,
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: "id" }
+  );
+  if (error) {
+    // Non-fatal: surface for debugging but let sign-in proceed.
+    console.error("Score sync upsert failed:", error.message);
+  }
+}
+
 export default function AuthCallbackPage() {
   const router = useRouter();
 
   useEffect(() => {
     let cancelled = false;
 
-    async function syncAndRedirect() {
+    async function run() {
       const {
         data: { session },
       } = await supabase.auth.getSession();
@@ -26,63 +98,18 @@ export default function AuthCallbackPage() {
         | undefined;
       const userId = session?.user?.id;
       // GitHub OAuth access token. Supabase only exposes this right after the
-      // OAuth redirect (it isn't persisted or refreshed), which is why the score
-      // sync runs here, at the callback, while the token is still in hand.
+      // OAuth redirect (it isn't persisted or refreshed), which is why the
+      // score sync runs here, at the callback, while the token is still in hand.
       const providerToken = session?.provider_token ?? undefined;
 
       if (username && userId) {
-        try {
-          let stats: ContributorStats;
-          let repos: Repo[];
-
-          if (providerToken) {
-            // Authenticated GraphQL path — includes review counts, so the stored
-            // score reflects every signal in the formula.
-            const contributor = await fetchContributorProfile(
-              username,
-              providerToken
-            );
-            ({ stats, repos } = contributorToScoreInputs(contributor));
-          } else {
-            // Fallback: the same unauthenticated REST pipeline the public profile
-            // page uses. Reviews aren't available here (totalReviews stays 0), but
-            // the score is still stored so sign-in never depends on the GraphQL
-            // call succeeding.
-            const reposRes = await fetch(
-              `https://api.github.com/users/${username}/repos?sort=stars&per_page=12&type=owner`,
-              { headers: { Accept: "application/vnd.github.v3+json" } }
-            );
-            const rawRepos = reposRes.ok ? await reposRes.json() : [];
-            const filtered = Array.isArray(rawRepos)
-              ? rawRepos
-                  .filter((r: { fork: boolean }) => !r.fork)
-                  .slice(0, 6)
-              : [];
-            repos = mapRepos(filtered);
-            stats = await fetchLiveStats(username);
-          }
-
-          const score = calculateScore(stats, repos);
-
-          // Upsert the user's own row. RLS ("Users can update own profile" /
-          // "Users can insert own profile", both auth.uid() = id) permits this
-          // with the regular anon client — no service-role key needed.
-          await supabase.from("profiles").upsert(
-            {
-              id: userId,
-              username,
-              score,
-              total_commits: stats.totalCommits,
-              total_prs: stats.totalPRs,
-              total_issues: stats.totalIssues,
-              total_reviews: stats.totalReviews,
-              updated_at: new Date().toISOString(),
-            },
-            { onConflict: "id" }
-          );
-        } catch {
-          // Non-fatal: a failed score sync must never block sign-in.
-        }
+        // Best-effort and time-boxed: race the sync against a timeout so a slow
+        // GitHub/Supabase response can't hold the redirect, and catch any error
+        // so sign-in stays strictly non-blocking.
+        await Promise.race([
+          syncScore(userId, username, providerToken).catch(() => {}),
+          new Promise<void>((resolve) => setTimeout(resolve, SYNC_TIMEOUT_MS)),
+        ]);
       }
 
       if (!cancelled) {
@@ -90,7 +117,7 @@ export default function AuthCallbackPage() {
       }
     }
 
-    syncAndRedirect();
+    run();
 
     return () => {
       cancelled = true;

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -5,19 +5,96 @@ export const dynamic = "force-dynamic";
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { supabase } from "@/lib/supabase";
+import { fetchContributorProfile, contributorToScoreInputs } from "@/lib/github";
+import { mapRepos, fetchLiveStats } from "@/lib/profile-data";
+import { calculateScore } from "@/lib/score";
+import type { ContributorStats, Repo } from "@/types";
 
 export default function AuthCallbackPage() {
   const router = useRouter();
 
   useEffect(() => {
-    supabase.auth.getSession().then(({ data: { session } }) => {
-      const username = session?.user?.user_metadata?.user_name;
-      if (username) {
-        router.replace(`/${username}`);
-      } else {
-        router.replace("/");
+    let cancelled = false;
+
+    async function syncAndRedirect() {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+
+      const username = session?.user?.user_metadata?.user_name as
+        | string
+        | undefined;
+      const userId = session?.user?.id;
+      // GitHub OAuth access token. Supabase only exposes this right after the
+      // OAuth redirect (it isn't persisted or refreshed), which is why the score
+      // sync runs here, at the callback, while the token is still in hand.
+      const providerToken = session?.provider_token ?? undefined;
+
+      if (username && userId) {
+        try {
+          let stats: ContributorStats;
+          let repos: Repo[];
+
+          if (providerToken) {
+            // Authenticated GraphQL path — includes review counts, so the stored
+            // score reflects every signal in the formula.
+            const contributor = await fetchContributorProfile(
+              username,
+              providerToken
+            );
+            ({ stats, repos } = contributorToScoreInputs(contributor));
+          } else {
+            // Fallback: the same unauthenticated REST pipeline the public profile
+            // page uses. Reviews aren't available here (totalReviews stays 0), but
+            // the score is still stored so sign-in never depends on the GraphQL
+            // call succeeding.
+            const reposRes = await fetch(
+              `https://api.github.com/users/${username}/repos?sort=stars&per_page=12&type=owner`,
+              { headers: { Accept: "application/vnd.github.v3+json" } }
+            );
+            const rawRepos = reposRes.ok ? await reposRes.json() : [];
+            const filtered = Array.isArray(rawRepos)
+              ? rawRepos
+                  .filter((r: { fork: boolean }) => !r.fork)
+                  .slice(0, 6)
+              : [];
+            repos = mapRepos(filtered);
+            stats = await fetchLiveStats(username);
+          }
+
+          const score = calculateScore(stats, repos);
+
+          // Upsert the user's own row. RLS ("Users can update own profile" /
+          // "Users can insert own profile", both auth.uid() = id) permits this
+          // with the regular anon client — no service-role key needed.
+          await supabase.from("profiles").upsert(
+            {
+              id: userId,
+              username,
+              score,
+              total_commits: stats.totalCommits,
+              total_prs: stats.totalPRs,
+              total_issues: stats.totalIssues,
+              total_reviews: stats.totalReviews,
+              updated_at: new Date().toISOString(),
+            },
+            { onConflict: "id" }
+          );
+        } catch {
+          // Non-fatal: a failed score sync must never block sign-in.
+        }
       }
-    });
+
+      if (!cancelled) {
+        router.replace(username ? `/${username}` : "/");
+      }
+    }
+
+    syncAndRedirect();
+
+    return () => {
+      cancelled = true;
+    };
   }, [router]);
 
   return (

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,3 +1,5 @@
+import type { ContributorStats, Repo } from "@/types";
+
 const GITHUB_GRAPHQL_URL = "https://api.github.com/graphql";
 
 async function githubGraphQL<T>(
@@ -131,4 +133,34 @@ export async function fetchContributorProfile(
     token
   );
   return data.user;
+}
+
+/**
+ * Convert a GraphQL `GitHubContributor` into the `{ stats, repos }` inputs that
+ * `calculateScore` expects. Unlike the unauthenticated REST pipeline, the
+ * authenticated GraphQL `contributionsCollection` exposes review counts, so the
+ * resulting score reflects every signal in the formula (commits, PRs, issues,
+ * reviews, stars). Pure and side-effect free so it can be unit-tested directly.
+ */
+export function contributorToScoreInputs(
+  c: GitHubContributor
+): { stats: ContributorStats; repos: Repo[] } {
+  const cc = c.contributionsCollection;
+  const stats: ContributorStats = {
+    totalCommits: cc.totalCommitContributions,
+    totalPRs: cc.totalPullRequestContributions,
+    totalIssues: cc.totalIssueContributions,
+    totalReviews: cc.totalPullRequestReviewContributions,
+    totalContributions: cc.contributionCalendar.totalContributions,
+  };
+  const repos: Repo[] = c.repositories.nodes.map((n) => ({
+    name: n.name,
+    description: n.description,
+    stars: n.stargazerCount,
+    forks: n.forkCount,
+    language: n.primaryLanguage?.name ?? null,
+    languageColor: n.primaryLanguage?.color ?? null,
+    url: n.url,
+  }));
+  return { stats, repos };
 }

--- a/supabase/migrations/20260605000001_add_profile_score.sql
+++ b/supabase/migrations/20260605000001_add_profile_score.sql
@@ -1,0 +1,11 @@
+-- Add contributor score + component stats to profiles (issue #15)
+-- Additive and idempotent: safe to run on an existing profiles table.
+-- The score is computed from the documented weights in src/lib/score.ts and
+-- synced into profiles on login (see src/app/auth/callback/page.tsx).
+
+alter table public.profiles
+  add column if not exists score          integer not null default 0,
+  add column if not exists total_commits  integer not null default 0,
+  add column if not exists total_prs      integer not null default 0,
+  add column if not exists total_issues   integer not null default 0,
+  add column if not exists total_reviews  integer not null default 0;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -14,6 +14,11 @@ create table public.profiles (
   name       text,
   avatar_url text,
   github_url text,
+  score          integer not null default 0,
+  total_commits  integer not null default 0,
+  total_prs      integer not null default 0,
+  total_issues   integer not null default 0,
+  total_reviews  integer not null default 0,
   created_at timestamptz default now(),
   updated_at timestamptz default now()
 );


### PR DESCRIPTION
## Summary

This wires up score persistence for #15. Reading through the code first, the scoring formula in `src/lib/score.ts` and the on-page display were already done — `calculateScore()` already had the documented weights and `[username]/page.tsx` was already calling it and passing the result into `ProfileView`. The missing piece was storing the score: it was computed on every page view but never written to `profiles`, so there was nothing persistent for a leaderboard to read.

So this PR adds the persistence path. The score (plus its component stats) is computed and upserted into `profiles` when a user signs in, and the profile page now prefers that stored value.

Per our discussion on the issue I went with the client-side option (A): the sync runs in the OAuth callback, right after sign-in, updating the user's own row with the regular anon client. The repo only uses `@supabase/supabase-js` (no `ssr` package), so a server route can't read the user's session from cookies, and the GitHub `provider_token` is only exposed right after the OAuth redirect — the callback is the one spot where both are in hand. The existing RLS policies (`auth.uid() = id` for insert/update) already allow a user to write their own row, so no service-role key is needed.

To make the stored score reflect every signal in the formula — including reviews, which the unauthenticated REST path can't see — I use the authenticated GraphQL `fetchContributorProfile()` with the user's `provider_token`. If that token isn't present or the GraphQL call fails for any reason, it falls back to the same REST pipeline the profile page already uses, so the score still gets stored and sign-in is never blocked. The whole sync is wrapped so any failure just proceeds to the redirect.

One honest note on testing: I couldn't run the full login → database round-trip locally because that needs the project's Supabase credentials, which I don't have — so that final step is for you to confirm on your end. I made it fail-safe (login never breaks; the REST fallback stores the score even if the GraphQL/token path doesn't fire), and I verified everything else (see the checklist).

One open question: the weights say "Merged PR ×3", but both the GraphQL `totalPullRequestContributions` and the REST `type:pr` search count PRs *authored*, not merged-only — which is what the rest of the app already uses, so I kept it consistent. If you'd prefer merged-only it's a one-line change (`+is:merged` on the search) and I'm happy to add it.

## Related Issue

Closes #15 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Chore / dependency update

## Changes Made

- **`supabase/migrations/20260605000001_add_profile_score.sql` (new):** adds `score`, `total_commits`, `total_prs`, `total_issues`, `total_reviews` to `profiles` (all `integer not null default 0`). Uses `add column if not exists` so it's additive and safe to re-run.
- **`supabase/schema.sql`:** added the same five columns to the master `profiles` table so a fresh setup matches the migration.
- **`src/lib/github.ts`:** added `contributorToScoreInputs()` — a pure helper that maps a GraphQL `GitHubContributor` into the `{ stats, repos }` shape `calculateScore()` expects (this is where review counts come from). Kept separate so it's easy to unit-test. Existing query and fetch are unchanged.
- **`src/app/auth/callback/page.tsx`:** after `getSession()`, compute the signed-in user's score and upsert it (plus the stat columns) into their own `profiles` row — GraphQL path when `provider_token` is present, REST fallback otherwise, all in a try/catch so a sync failure never blocks the redirect.
- **`src/app/[username]/page.tsx`:** read `profiles.score` first (DB-first) and fall back to the live-computed score if the user hasn't synced yet, so signed-out visitors see the same stored number. Wrapped in try/catch so a Supabase hiccup can't break the page.

## AI Usage

- [ ] I did not use AI for any part of the code in this PR
- [x] I used AI for coding (specify which tool below) and I fully understand every change I made, including which functions I changed, why I changed them, and what side effects they could create

Used Claude as a coding assistant. I read through `score.ts`, `github.ts`, `profile-data.ts`, the auth callback, `supabase.ts`, and the schema before any code was written, and I can walk through the sync flow, the GraphQL→REST fallback, the DB-first read, or the score math on request.

## Screenshots (if UI change)

N/A — backend change (DB persistence + sync). No visual change; the score was already displayed on the profile page before this PR.

## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with `main`
- [x] Code works locally and I have tested it — `npm run lint` and `npm run type-check` both pass, and I unit-tested the score formula and the GraphQL→score mapping (stars cap, rounding, and the review signal all check out). The live login→DB round-trip needs the project's Supabase credentials I don't have, so that step is for maintainer verification; it's wrapped to fail safe.
- [x] No `console.log` left in `src/`
- [x] If schema changed — both `schema.sql` and a new migration file are included
- [ ] If this is a UI change — I read `DESIGN.md` and followed the design system → N/A, backend only, no visual change
- [x] Docs updated if needed — no doc changes needed for this
- [x] PR title follows Conventional Commits format (`feat:`)
- [x] This PR description is written in my own words