### PR TITLE
fix: rewrite 404 pages with inline styles and add global not-found (#41)

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,10 +1,9 @@
 /**
- * src/app/[username]/not-found.tsx
+ * src/app/not-found.tsx
  *
- * Shown when a requested /[username] profile does not exist (page.tsx calls
- * notFound() after a failed GitHub lookup). Inline styles only - no Tailwind
- * layout/color classes - per the project convention, using the DESIGN.md
- * palette:
+ * Global 404 fallback for any unmatched route across the app (the per-profile
+ * 404 lives at src/app/[username]/not-found.tsx). Inline styles only - no
+ * Tailwind layout/color classes - using the DESIGN.md palette:
  *   canvas #ffffff | ink #171717 | ink-mute #707070 | primary #3ecf8e
  *
  * Rules: inline styles only, no Tailwind, no TypeScript errors. (Issue #41)
@@ -22,21 +21,6 @@ const primaryButton: CSSProperties = {
   borderRadius: "8px",
   backgroundColor: "#3ecf8e",
   color: "#171717",
-  fontSize: "16px",
-  fontWeight: 600,
-  textDecoration: "none",
-};
-
-const secondaryButton: CSSProperties = {
-  display: "inline-flex",
-  alignItems: "center",
-  justifyContent: "center",
-  minWidth: "130px",
-  padding: "10px 28px",
-  borderRadius: "8px",
-  backgroundColor: "#ffffff",
-  color: "#171717",
-  border: "1px solid #dfdfdf",
   fontSize: "16px",
   fontWeight: 600,
   textDecoration: "none",
@@ -73,25 +57,14 @@ export default function NotFound() {
             color: "#171717",
           }}
         >
-          User not found
+          Page not found
         </h1>
         <p style={{ marginTop: "12px", fontSize: "16px", color: "#707070" }}>
-          This username does not exist or has not signed up yet.
+          The page you are looking for does not exist or may have moved.
         </p>
-        <div
-          style={{
-            display: "flex",
-            justifyContent: "center",
-            gap: "16px",
-            marginTop: "28px",
-            flexWrap: "wrap",
-          }}
-        >
+        <div style={{ display: "flex", justifyContent: "center", marginTop: "28px" }}>
           <Link href="/" style={primaryButton}>
-            Home
-          </Link>
-          <Link href="/explore" style={secondaryButton}>
-            Explore
+            Back to home
           </Link>
         </div>
       </div>


### PR DESCRIPTION
## Summary

The [username]/not-found.tsx page used Tailwind classes like bg-canvas-night 
and text-primary that don't follow the project's inline-style convention and 
render broken on the live site. There was also no global src/app/not-found.tsx, 
so any unmatched route hit Next.js's plain default 404. I rewrote the profile 
404 with inline styles using DESIGN.md tokens and created the missing global 
fallback following the same pattern as loading.tsx.

## Related Issue

Closes #41

## Type of Change

- [x] Bug fix

## Changes Made

- Rewrote `src/app/[username]/not-found.tsx`: removed all Tailwind color and layout classes (`bg-canvas-night`, `text-primary`, `text-on-dark`, `text-ink-mute`, `min-w-32.5`) that were not rendering correctly on the live site; replaced every style with inline `style` props using the exact hex tokens from DESIGN.md — `#ffffff` canvas background, `#3ecf8e` primary green for the 404 number, `#171717` ink for the heading, `#707070` ink-mute for the body text, `#dfdfdf` hairline for the secondary button border
- Created `src/app/not-found.tsx` as the missing global 404 fallback; without this file any unmatched route (e.g. `/anything-invalid`) fell through to Next.js's unstyled default error page with no project branding or navigation
- Both pages follow the same inline-style convention already established in `src/app/[username]/loading.tsx` (Issue #42): `import type { CSSProperties }` for typed style constants, `<main style={{ backgroundColor: "#ffffff", minHeight: "100vh" }}>` outer container, centered content div with `maxWidth: "28rem"`, and all spacing/color/radius values taken directly from DESIGN.md
- `tsc --noEmit` passes clean, `eslint src/` passes clean, no `console.log`, no `className` anywhere in either file

## AI Usage

- [x] I used AI for coding (specify which tool below) and I fully understand every change I made, including which functions I changed, why I changed them, and what side effects they could create

Used Claude as a coding assistant

## Screenshots (if UI change)

[ossfolio_404_before_after.html](https://github.com/user-attachments/files/28642131/ossfolio_404_before_after.html)


## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with `main`
- [x] Code works locally and I have tested it
- [x] No `console.log` left in `src/`
- [ ] If schema changed — both `schema.sql` and a new migration file are included
- [x] If this is a UI change — I read `DESIGN.md` and followed the design system (colors, spacing, typography, components)
- [ ] Docs updated if needed
- [x] PR title follows Conventional Commits format (`feat:`, `fix:`, `docs:`, etc.)
- [x] This PR description is written in my own words