### PR TITLE
feat: add sitemap.xml and robots.txt for SEO (#40)

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,10 @@
+import type { MetadataRoute } from "next";
+
+const SITE_URL = "https://ossfolio.qzz.io";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: { userAgent: "*", allow: "/" },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from "next";
+
+const SITE_URL = "https://ossfolio.qzz.io";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: `${SITE_URL}/`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 1,
+    },
+  ];
+}


### PR DESCRIPTION
## Summary

OSSfolio had no robots.txt or sitemap.xml, which means search engines were
crawling blind with no guidance on what to index. I added both using Next.js's
built-in metadata route convention — src/app/robots.ts and src/app/sitemap.ts
— so no extra packages are needed and everything stays consistent with how the
rest of the app is structured. The robots file allows all crawlers and points
them to the sitemap. The sitemap includes the homepage for now, with dynamic
/<username> profile pages left as a follow-up once public profiles are
queryable from Supabase (as you mentioned in the issue). I used ossfolio.qzz.io
as the base URL since that's the live domain, and wired it through a single
SITE_URL constant at the top of each file so it's a one-line change if the
domain ever moves.

## Related Issue
Closes #40

## Type of Change
- [x] New feature

## Changes Made
- Created `src/app/robots.ts` — allows all crawlers (`userAgent: "*"`, `allow: "/"`) and points to the sitemap URL
- Created `src/app/sitemap.ts` — homepage entry with weekly change frequency and priority 1
- Both files share a single `SITE_URL = "https://ossfolio.qzz.io"` constant — one-line change if the domain ever moves
- No extra dependencies — uses Next.js built-in metadata route convention (`src/app/robots.ts` → `/robots.txt`, `src/app/sitemap.ts` → `/sitemap.xml`)

## AI Usage
- [x] I used AI for coding and I fully understand every change I made
Used Claude as a coding assistant

## Checklist
- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with main
- [x] Code works locally and I have tested it
- [x] No console.log left in src/
- [x] If this is a UI change — I read DESIGN.md and followed the design system
- [x] PR title follows Conventional Commits format
- [x] This PR description is written in my own words
<img width="493" height="203" alt="Screenshot 2026-06-05 204247" src="https://github.com/user-attachments/assets/c07f448c-93a6-4705-97ad-b82214c35189" />
<img width="783" height="308" alt="Screenshot 2026-06-05 204321" src="https://github.com/user-attachments/assets/caa1fe8b-59f9-40a1-b995-534a526b0e84" />
