### PR TITLE
feat: add hover effects to footer links (#43)

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Image from "next/image";
 import Link from "next/link";
 
@@ -82,6 +84,8 @@ export function Footer() {
                     <Link
                       href={href}
                       style={{ fontSize: "13px", color: "#707070", textDecoration: "none" }}
+                      onMouseEnter={(e) => (e.currentTarget.style.color = "#171717")}
+                      onMouseLeave={(e) => (e.currentTarget.style.color = "#707070")}
                     >
                       {label}
                     </Link>


### PR DESCRIPTION
## Summary

The footer links had no hover effect at all — they just stayed the same grey
color when you moused over them, which felt inconsistent with the navbar links
that already darken on hover. I added the exact same onMouseEnter/onMouseLeave
pattern the navbar uses to the footer's column links (Product, Developers,
Legal), so they now darken from #707070 to #171717 on hover and go back on
mouse-out. One thing I had to handle: Footer.tsx was a server component, so I
added "use client" at the top since DOM event handlers can't run server-side.
Only Footer.tsx changed — nothing else touched.

## Related Issue
Closes #43

## Type of Change
- [x] New feature

## Changes Made
- Added `"use client"` directive to `Footer.tsx` — required because `onMouseEnter`
  and `onMouseLeave` are DOM event handlers and cannot run in a server component
- Added `onMouseEnter={(e) => (e.currentTarget.style.color = "#171717")}` and
  `onMouseLeave={(e) => (e.currentTarget.style.color = "#707070")}` to the footer
  column links in the `.map()` loop — exactly the same pattern the navbar uses
- Only `src/components/layout/Footer.tsx` changed, no other files touched

## AI Usage
- [x] I used AI for coding and I fully understand every change I made
Used Claude as a coding assistant

## Screenshots
[paste screenshot 3 here — the one showing "Contributing" darkened on hover]

## Checklist
- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with main
- [x] Code works locally and I have tested it
- [x] No console.log left in src/
- [x] If this is a UI change — I read DESIGN.md and followed the design system
- [x] PR title follows Conventional Commits format
- [x] This PR description is written in my own words
<img width="1903" height="317" alt="Screenshot 2026-06-05 214004" src="https://github.com/user-attachments/assets/3c04cef9-2e7f-4e8b-9248-4d865c6adc75" />
<img width="1261" height="320" alt="Screenshot 2026-06-05 214015" src="https://github.com/user-attachments/assets/8cce226c-1082-4f40-a31b-23122e18ec29" />
<img width="1237" height="307" alt="Screenshot 2026-06-05 214133" src="https://github.com/user-attachments/assets/465b6900-c9d2-495e-b560-3e420d04bd9d" />
