### PR TITLE
fix(profile): show error message when GitHub API is unavailable

### DIFF
--- a/src/app/[username]/page.tsx
+++ b/src/app/[username]/page.tsx
@@ -24,7 +24,13 @@ async function fetchGitHubUser(username: string) {
     headers: { Accept: "application/vnd.github.v3+json" },
     next: { revalidate: 3600 },
   });
+
+  if (res.status === 403 || res.status === 429) {
+    throw new Error("GITHUB_RATE_LIMIT");
+  }
+
   if (!res.ok) return null;
+
   return res.json();
 }
 
@@ -34,14 +40,21 @@ async function fetchGitHubRepos(username: string) {
     {
       headers: { Accept: "application/vnd.github.v3+json" },
       next: { revalidate: 3600 },
-    }
+    },
   );
+
+  if (res.status === 403 || res.status === 429) {
+    throw new Error("GITHUB_RATE_LIMIT");
+  }
+
   if (!res.ok) return [];
+
   const repos = await res.json();
   return repos.filter((r: { fork: boolean }) => !r.fork).slice(0, 6);
 }
-
-export async function generateMetadata({ params }: ProfilePageProps): Promise<Metadata> {
+export async function generateMetadata({
+  params,
+}: ProfilePageProps): Promise<Metadata> {
   const { username } = await params;
   return {
     title: `${username} — OSSfolio`,
@@ -52,17 +65,62 @@ export async function generateMetadata({ params }: ProfilePageProps): Promise<Me
 export default async function ProfilePage({ params }: ProfilePageProps) {
   const { username } = await params;
 
-  // Base profile + repos (already-working live data) plus the new live extras.
-  // Each extra fetch fails soft (empty / zero) so a rate-limited Search call
-  // never takes down the whole page.
-  const [user, repos, liveStats, orgs] = await Promise.all([
+  let githubUnavailable = false;
+
+  const [userResult, reposResult, liveStats, orgs] = await Promise.allSettled([
     fetchGitHubUser(username),
     fetchGitHubRepos(username),
     fetchLiveStats(username),
     fetchOrganizations(username),
   ]);
+  const user = userResult.status === "fulfilled" ? userResult.value : null;
 
-  if (!user) notFound();
+  const repos = reposResult.status === "fulfilled" ? reposResult.value : [];
+
+  if (userResult.status === "rejected" || reposResult.status === "rejected") {
+   const error =
+  userResult.status === "rejected"
+    ? userResult.reason
+    : reposResult.status === "rejected"
+      ? reposResult.reason
+      : null;
+
+    if (error instanceof Error && error.message === "GITHUB_RATE_LIMIT") {
+      githubUnavailable = true;
+    }
+  }
+if (!user && !githubUnavailable) {
+  notFound();
+}
+if (!user && githubUnavailable) {
+  return (
+    <>
+      <Navbar />
+      <main
+        style={{
+          minHeight: "100vh",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          backgroundColor: "#ffffff",
+        }}
+      >
+        <div
+          style={{
+            padding: "16px",
+            border: "1px solid #fbbf24",
+            borderRadius: "8px",
+            backgroundColor: "#fffbeb",
+            color: "#92400e",
+          }}
+        >
+          GitHub data is temporarily unavailable. Please try again in a few minutes.
+        </div>
+      </main>
+      <Footer />
+    </>
+  );
+}
 
   const mappedRepos = mapRepos(repos);
   const techStack = deriveTechStack(repos);
@@ -71,7 +129,20 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
   // placeholder and surface its total as the headline contribution count.
   const { weeks: heatmap, totalContributions } = generateMockHeatmap(username);
 
-  const stats = { ...liveStats, totalContributions };
+const statsData =
+  liveStats.status === "fulfilled"
+    ? liveStats.value
+    : {
+        totalCommits: 0,
+        totalPRs: 0,
+        totalIssues: 0,
+        totalReviews: 0,
+        totalContributions: 0,
+      };
+
+const organizations =
+  orgs.status === "fulfilled" ? orgs.value : [];
+const stats = { ...statsData, totalContributions };
   const liveScore = calculateScore(stats, mappedRepos);
 
   // DB-first: prefer the stored (synced) score so every visitor — including
@@ -100,9 +171,10 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
           repos={repos}
           stats={stats}
           techStack={techStack}
-          orgs={orgs}
+          orgs={organizations}
           heatmap={heatmap}
           score={score}
+           githubUnavailable={githubUnavailable}
         />
       </main>
       <Footer />

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -54,6 +54,7 @@ interface ProfileExtras {
   orgs: Org[];
   heatmap: HeatmapWeek[];
   score: number;
+  githubUnavailable?: boolean;
 }
 
 export function ProfileView({
@@ -64,6 +65,7 @@ export function ProfileView({
   orgs,
   heatmap,
   score,
+  githubUnavailable,
 }: { user: GitHubUser; repos: GitHubRepo[] } & ProfileExtras) {
   const displayName = user.name || user.login;
   const website = user.blog
@@ -74,7 +76,21 @@ export function ProfileView({
 
   return (
     <div style={{ maxWidth: "56rem", margin: "0 auto", padding: "48px 20px 80px" }}>
-
+{githubUnavailable && (
+  <div
+    style={{
+      marginBottom: "24px",
+      padding: "12px 16px",
+      border: "1px solid #fbbf24",
+      borderRadius: "8px",
+      backgroundColor: "#fffbeb",
+      color: "#92400e",
+      fontSize: "14px",
+    }}
+  >
+    GitHub data is temporarily unavailable. Please try again in a few minutes.
+  </div>
+)}
       {/* Profile header */}
       <div style={{ display: "flex", alignItems: "flex-start", gap: "24px", flexWrap: "wrap", paddingBottom: "40px", borderBottom: "1px solid #ededed" }}>
         <Image


### PR DESCRIPTION
## Summary

This PR improves the profile page experience when GitHub API requests fail due to rate limits or temporary unavailability.

## Changes

* Detect GitHub API rate limit responses (403/429)
* Prevent the page from silently rendering empty sections
* Show a user-friendly message when GitHub data is temporarily unavailable
* Use `Promise.allSettled()` so partial failures do not crash the page
* Preserve the existing profile experience when GitHub data is available

Closes #71 