### PR TITLE
feat-navbar: add divider between profile link and sign-out in dropdown

### DIFF
--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -218,6 +218,14 @@ export function Navbar({ onSignIn, onGetStarted }: NavbarProps) {
                 >
                   My Portfolio
                 </Link>
+                <div
+                  role="separator"
+                  style={{
+                    height: "1px",
+                    backgroundColor: "#ededed",
+                    margin: "4px 10px",
+                  }}
+                />
                 <button
                   role="menuitem"
                   onClick={handleLogout}
@@ -366,6 +374,14 @@ export function Navbar({ onSignIn, onGetStarted }: NavbarProps) {
                   >
                     My Portfolio
                   </Link>
+                  <div
+                    role="separator"
+                    style={{
+                      height: "1px",
+                      backgroundColor: "#ededed",
+                      margin: "8px 0",
+                    }}
+                  />
                   <button
                     onClick={handleLogout}
                     style={{


### PR DESCRIPTION
### Summary
This PR adds a subtle visual divider between the "My Portfolio" link and the "Log out" button in the navigation bar's profile dropdown. This improves the visual hierarchy and clearly separates the navigation link from the destructive sign-out action, making the UI feel more polished.
### Related Issue
Closes #79 
### Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Chore / dependency update
### Changes Made
- Added a 1px `<hr>` style divider (`role="separator"`) in the desktop dropdown menu using the `hairline-cool` (`#ededed`) color from the design system.
- Added the same divider to the mobile menu panel between the portfolio and sign-out buttons.
- Ensured spacing (`margin`) aligns with the existing padding in both views.
### AI Usage
- [ ] I did not use AI for any part of the code in this PR
- [x] I used AI for coding and I fully understand every change I made, including which functions I changed, why I changed them, and what side effects they could create
Used Gemini/Claude for coding assistance.
### Screenshots (if UI change)
<img width="3160" height="1456" alt="Screenshot 2026-06-07 184021" src="https://github.com/user-attachments/assets/1ec39b73-cc8e-4c8f-ab2e-c6260ac43a08" />

<!-- Drag and drop the screenshot you just took right here! -->
### Checklist
- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with `main`
- [x] Code works locally and I have tested it
- [x] No `console.log` left in `src/`
- [ ] If schema changed — both `schema.sql` and a new migration file are included
- [x] If this is a UI change — I read `DESIGN.md` and followed the design system (colors, spacing, typography, components)
- [ ] Docs updated if needed
- [x] PR title follows Conventional Commits format (`feat:`, `fix:`, `docs:`, etc.)
- [x] This PR description is written in my own words
