### PR TITLE
feat(hero): add username search bar to hero section

### DIFF
--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -1,6 +1,8 @@
-﻿"use client";
+"use client";
 
-import { ArrowRight } from "lucide-react";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { ArrowRight, Search } from "lucide-react";
 import { motion, type Variants } from "framer-motion";
 
 interface HeroProps {
@@ -22,6 +24,15 @@ const fadeUp: Variants = {
 };
 
 export function Hero({ onGetStarted }: HeroProps) {
+  const [query, setQuery] = useState("");
+  const router = useRouter();
+
+  function handleSearch(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = query.trim();
+    if (trimmed) router.push(`/${trimmed}`);
+  }
+
   return (
     <section style={{ width: "100%", backgroundColor: "#ffffff" }}>
       <motion.div
@@ -100,6 +111,81 @@ export function Hero({ onGetStarted }: HeroProps) {
           showing your real open-source impact — merged PRs, streaks, orgs,
           badges, and more.
         </motion.p>
+
+        {/* Search bar */}
+        <motion.form
+          variants={fadeUp}
+          onSubmit={handleSearch}
+          style={{
+            marginTop: "28px",
+            display: "flex",
+            width: "100%",
+            maxWidth: "420px",
+            gap: "0",
+          }}
+        >
+          <div style={{ position: "relative", flex: 1 }}>
+            <Search
+              size={16}
+              style={{
+                position: "absolute",
+                left: "12px",
+                top: "50%",
+                transform: "translateY(-50%)",
+                color: "#9a9a9a",
+                pointerEvents: "none",
+              }}
+            />
+            <input
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Enter a GitHub username..."
+              style={{
+                width: "100%",
+                padding: "10px 12px 10px 36px",
+                fontSize: "16px",
+                fontWeight: 400,
+                lineHeight: 1.5,
+                color: "#171717",
+                backgroundColor: "#ffffff",
+                border: "1px solid #dfdfdf",
+                borderRadius: "6px 0 0 6px",
+                outline: "none",
+              }}
+              onFocus={(e) => (e.currentTarget.style.borderColor = "#c7c7c7")}
+              onBlur={(e) => (e.currentTarget.style.borderColor = "#dfdfdf")}
+            />
+          </div>
+          <button
+            type="submit"
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: "6px",
+              padding: "10px 16px",
+              fontSize: "14px",
+              fontWeight: 500,
+              color: "#171717",
+              backgroundColor: "#ffffff",
+              border: "1px solid #dfdfdf",
+              borderLeft: "none",
+              borderRadius: "0 6px 6px 0",
+              cursor: "pointer",
+              whiteSpace: "nowrap",
+            }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.backgroundColor = "#fafafa";
+              e.currentTarget.style.borderColor = "#c7c7c7";
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.backgroundColor = "#ffffff";
+              e.currentTarget.style.borderColor = "#dfdfdf";
+            }}
+          >
+            View profile
+          </button>
+        </motion.form>
 
         {/* CTAs */}
         <motion.div


### PR DESCRIPTION
## Summary

Adds a search bar to the hero section on the homepage so visitors can look up any GitHub username and jump straight to their profile page. Previously the only way to reach a profile was to manually type the URL in the browser address bar, which made profile discovery difficult.

## Related Issue

Closes #77 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Chore / dependency update

## Changes Made

- Added a search form between the subtitle and existing CTA buttons in the hero section (`src/components/home/Hero.tsx`).
- The input accepts any GitHub username string and navigates to `/<username>` on submit using `useRouter` from `next/navigation`.
- Works with both keyboard (Enter key) and mouse click on the "View profile" button.
- Empty or whitespace-only input is silently ignored to prevent navigating to `/`.
- Added a `Search` icon inside the input using `lucide-react` for visual clarity.
- Used outline button styling (`button-secondary-outline`) for the submit button to respect the one-green-CTA-per-viewport rule from `DESIGN.md`.
- Input styling matches the `text-input` design token: `#ffffff` background, `#171717` text, `16px` font, `6px` border-radius, `1px #dfdfdf` border.

## AI Usage

- [ ] I did not use AI for any part of the code in this PR
- [x] I used AI for coding and I fully understand every change I made, including which functions I changed, why I changed them, and what side effects they could create
  Used Gemini/Claude for coding assistance.

## Screenshots (if UI change)

<img width="3156" height="1556" alt="Screenshot 2026-06-07 235929" src="https://github.com/user-attachments/assets/16dbffc4-4178-4f5d-983c-b0105cfa2130" />

<img width="3160" height="1668" alt="Screenshot 2026-06-08 000758" src="https://github.com/user-attachments/assets/fb7c14ed-c24a-4656-be6c-6f5d24a2388a" />


## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with `main`
- [x] Code works locally and I have tested it
- [x] No `console.log` left in `src/`
- [ ] If schema changed — both `schema.sql` and a new migration file are included
- [x] If this is a UI change — I read `DESIGN.md` and followed the design system (colors, spacing, typography, components)
- [ ] Docs updated if needed
- [x] PR title follows Conventional Commits format (`feat:`, `fix:`, `docs:`, etc.)
- [x] This PR description is written in my own words