### PR TITLE
fix(footer): add Privacy and Terms placeholder pages (#67, #63)

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,125 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { Navbar } from "@/components/layout/Navbar";
+import { Footer } from "@/components/layout/Footer";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy - OSSfolio",
+  description:
+    "How OSSfolio handles your data. This page is a placeholder while the full privacy policy is being finalised.",
+};
+
+// Placeholder Privacy Policy page. The footer links here, so the route needs to
+// resolve rather than 404. The detailed policy copy is still being written; the
+// section outline below shows what the finished page will cover. Styled with the
+// same inline-style language as the rest of the app (see score-explained/page.tsx)
+// so it stays consistent with the existing pages.
+const SECTIONS: { heading: string; body: string }[] = [
+  {
+    heading: "Information we collect",
+    body: "OSSfolio builds your profile from public GitHub data. The full list of what is read and stored will be detailed here.",
+  },
+  {
+    heading: "How we use your information",
+    body: "An explanation of how your public activity is used to generate profiles, scores, and leaderboards will go here.",
+  },
+  {
+    heading: "Data sharing",
+    body: "Details on whether and how any data is shared with third parties will be documented in this section.",
+  },
+  {
+    heading: "Your rights and choices",
+    body: "Information about accessing, correcting, or removing your data will be provided here.",
+  },
+  {
+    heading: "Contact",
+    body: "Details on how to get in touch with questions about privacy will be added here.",
+  },
+];
+
+export default function PrivacyPolicyPage() {
+  const sectionTitleStyle = {
+    fontSize: "18px",
+    fontWeight: 500,
+    color: "#171717",
+    margin: "0 0 8px 0",
+  };
+  const paragraphStyle = {
+    fontSize: "15px",
+    lineHeight: 1.55,
+    color: "#707070",
+    margin: 0,
+  };
+
+  return (
+    <>
+      <Navbar />
+      <main style={{ backgroundColor: "#ffffff", minHeight: "100vh" }}>
+        <div style={{ maxWidth: "44rem", margin: "0 auto", padding: "56px 20px" }}>
+          {/* Header */}
+          <header style={{ marginBottom: "24px" }}>
+            <h1
+              style={{
+                fontSize: "28px",
+                fontWeight: 500,
+                color: "#171717",
+                letterSpacing: "-0.42px",
+                margin: 0,
+              }}
+            >
+              Privacy Policy
+            </h1>
+            <p
+              style={{
+                fontSize: "15px",
+                color: "#707070",
+                margin: "8px 0 0 0",
+                lineHeight: 1.55,
+              }}
+            >
+              How OSSfolio handles your data, in plain language.
+            </p>
+          </header>
+
+          {/* Placeholder notice */}
+          <div
+            style={{
+              border: "1px solid #ededed",
+              borderRadius: "12px",
+              backgroundColor: "#fafafa",
+              padding: "16px 18px",
+              marginBottom: "40px",
+            }}
+          >
+            <p style={{ fontSize: "14px", lineHeight: 1.55, color: "#707070", margin: 0 }}>
+              This is a placeholder page - the full privacy policy is being finalised.
+              The sections below outline what it will cover.
+            </p>
+          </div>
+
+          {/* Section outline */}
+          {SECTIONS.map((section, i) => (
+            <section
+              key={section.heading}
+              style={{ marginBottom: i === SECTIONS.length - 1 ? "40px" : "28px" }}
+            >
+              <h2 style={sectionTitleStyle}>{section.heading}</h2>
+              <p style={paragraphStyle}>{section.body}</p>
+            </section>
+          ))}
+
+          {/* Back link */}
+          <p style={{ margin: 0 }}>
+            <Link
+              href="/"
+              style={{ fontSize: "14px", fontWeight: 500, color: "#171717" }}
+            >
+              Back to home
+            </Link>
+          </p>
+        </div>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,129 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { Navbar } from "@/components/layout/Navbar";
+import { Footer } from "@/components/layout/Footer";
+
+export const metadata: Metadata = {
+  title: "Terms of Service - OSSfolio",
+  description:
+    "The terms that govern your use of OSSfolio. This page is a placeholder while the full terms are being finalised.",
+};
+
+// Placeholder Terms of Service page. The footer links here, so the route needs
+// to resolve rather than 404. The detailed terms are still being written; the
+// section outline below shows what the finished page will cover. Styled with the
+// same inline-style language as the rest of the app (see score-explained/page.tsx)
+// so it stays consistent with the existing pages.
+const SECTIONS: { heading: string; body: string }[] = [
+  {
+    heading: "Acceptance of terms",
+    body: "By using OSSfolio you agree to these terms. The full acceptance language will be provided here.",
+  },
+  {
+    heading: "Use of the service",
+    body: "What you can and cannot do when using OSSfolio will be detailed in this section.",
+  },
+  {
+    heading: "Profiles and public data",
+    body: "An explanation of how profiles are generated from public GitHub data and what that means for you will go here.",
+  },
+  {
+    heading: "Limitation of liability",
+    body: "The standard limitation-of-liability terms for the service will be documented here.",
+  },
+  {
+    heading: "Changes to these terms",
+    body: "How updates to these terms are made and communicated will be described in this section.",
+  },
+  {
+    heading: "Contact",
+    body: "Details on how to get in touch with questions about these terms will be added here.",
+  },
+];
+
+export default function TermsOfServicePage() {
+  const sectionTitleStyle = {
+    fontSize: "18px",
+    fontWeight: 500,
+    color: "#171717",
+    margin: "0 0 8px 0",
+  };
+  const paragraphStyle = {
+    fontSize: "15px",
+    lineHeight: 1.55,
+    color: "#707070",
+    margin: 0,
+  };
+
+  return (
+    <>
+      <Navbar />
+      <main style={{ backgroundColor: "#ffffff", minHeight: "100vh" }}>
+        <div style={{ maxWidth: "44rem", margin: "0 auto", padding: "56px 20px" }}>
+          {/* Header */}
+          <header style={{ marginBottom: "24px" }}>
+            <h1
+              style={{
+                fontSize: "28px",
+                fontWeight: 500,
+                color: "#171717",
+                letterSpacing: "-0.42px",
+                margin: 0,
+              }}
+            >
+              Terms of Service
+            </h1>
+            <p
+              style={{
+                fontSize: "15px",
+                color: "#707070",
+                margin: "8px 0 0 0",
+                lineHeight: 1.55,
+              }}
+            >
+              The terms that govern your use of OSSfolio.
+            </p>
+          </header>
+
+          {/* Placeholder notice */}
+          <div
+            style={{
+              border: "1px solid #ededed",
+              borderRadius: "12px",
+              backgroundColor: "#fafafa",
+              padding: "16px 18px",
+              marginBottom: "40px",
+            }}
+          >
+            <p style={{ fontSize: "14px", lineHeight: 1.55, color: "#707070", margin: 0 }}>
+              This is a placeholder page - the full terms of service are being finalised.
+              The sections below outline what they will cover.
+            </p>
+          </div>
+
+          {/* Section outline */}
+          {SECTIONS.map((section, i) => (
+            <section
+              key={section.heading}
+              style={{ marginBottom: i === SECTIONS.length - 1 ? "40px" : "28px" }}
+            >
+              <h2 style={sectionTitleStyle}>{section.heading}</h2>
+              <p style={paragraphStyle}>{section.body}</p>
+            </section>
+          ))}
+
+          {/* Back link */}
+          <p style={{ margin: 0 }}>
+            <Link
+              href="/"
+              style={{ fontSize: "14px", fontWeight: 500, color: "#171717" }}
+            >
+              Back to home
+            </Link>
+          </p>
+        </div>
+      </main>
+      <Footer />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

The footer has two links — Privacy pointing to /privacy and Terms pointing
to /terms — but neither of those routes existed in src/app/, so clicking
either one landed on a 404. I created both pages as styled placeholder pages
that fit right into the rest of the site. Each one has proper Next.js
metadata, the shared Navbar and Footer, a clear notice saying the full
policy content is still being written, and a section outline showing what
the finished page will cover. No existing files were changed — this is
purely additive.

## Related Issue

Closes #67
Closes #63

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Chore / dependency update

## Changes Made

- Added `src/app/privacy/page.tsx` — Privacy Policy placeholder page with
  metadata, Navbar/Footer wrapper, a "coming soon" notice box, and
  section headings outlining what the full policy will cover
- Added `src/app/terms/page.tsx` — Terms of Service placeholder with the
  same structure and approach
- Both pages styled with inline styles matching the existing codebase
  (same approach as score-explained/page.tsx — no Tailwind/shadcn tokens,
  consistent color palette: #171717, #707070, #ededed, #fafafa)
- Zero changes to existing files — fully additive

## AI Usage

- [ ] I did not use AI for any part of the code in this PR
- [x] I used AI for coding (specify which tool below) and I fully
      understand every change I made, including which functions I changed,
      why I changed them, and what side effects they could create

Used Claude to help scaffold the two new page files. I understand the
changes fully — two new Next.js route files are added under src/app/privacy/
and src/app/terms/, each exporting a metadata object and a default React
component that renders Navbar, a styled main container with the placeholder
content, and Footer. The only side effect is that /privacy and /terms now
resolve to real pages instead of 404s, which is exactly what the bug fix
asked for.

## Screenshots (if UI change)

<img width="1916" height="984" alt="Screenshot 2026-06-08 235419" src="https://github.com/user-attachments/assets/81276bc0-108a-4e45-b13a-313e19204c44" />
<img width="1906" height="983" alt="Screenshot 2026-06-08 235433" src="https://github.com/user-attachments/assets/324f8b43-7980-4198-9e14-e03487f1bfc4" />


## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with `main`
- [x] Code works locally and I have tested it
- [x] No `console.log` left in `src/`
- [ ] If schema changed — both `schema.sql` and a new migration file
      are included  ← N/A, no schema changes
- [x] If this is a UI change — I read `DESIGN.md` and followed the
      design system (colors, spacing, typography, components)
- [ ] Docs updated if needed  ← N/A, no docs changes needed
- [x] PR title follows Conventional Commits format (`fix:`)
- [x] This PR description is written in my own words