### PR TITLE
fix(profile): use production URL in Share on X tweet (ossfolio.qzz.io)

### DIFF
--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -166,7 +166,7 @@ export function ProfileView({
             <button
               type="button"
               onClick={() => {
-                const profileUrl = `https://ossfolio.vercel.app/${user.login}`;
+                const profileUrl = `https://ossfolio.qzz.io/${user.login}`;
                 const text = `My open source contributor score is ${score} on OSSfolio: ${profileUrl} #opensource`;
                 window.open(
                   `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}`,


### PR DESCRIPTION
## Summary

The Share on X button added in #102 was building the tweet URL with
`https://ossfolio.vercel.app` instead of the production domain. Anyone
clicking Share on X would get a tweet pointing to the Vercel preview URL
rather than the real site. This fixes it to use `https://ossfolio.qzz.io`
which is the canonical production domain already used by `robots.ts` and
`sitemap.ts` across the codebase.

One line changed. Nothing else touched.

## Related Issue

Follow-up fix to #102

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Chore / dependency update

## Changes Made

- `src/components/profile/ProfileView.tsx` line 169:
  `ossfolio.vercel.app` → `ossfolio.qzz.io`
- Consistent with `SITE_URL` already defined in `robots.ts` and `sitemap.ts`

## AI Usage

- [ ] I did not use AI for any part of the code in this PR
- [x] I used AI for coding (Claude) and I fully understand every change I
  made, including which functions I changed, why I changed them, and what
  side effects they could create

## Screenshots (if UI change)

No visual change — button appearance is identical. The fix only affects
where the tweet URL points.

## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with main
- [x] Code works locally and I have tested it
- [x] No console.log left in src/
- [ ] If schema changed — both schema.sql and a new migration file are included
- [ ] If this is a UI change — I read DESIGN.md and followed the design system
- [x] Docs updated if needed
- [x] PR title follows Conventional Commits format
- [x] This PR description is written in my own words