### PR TITLE
fix(footer): add New badge to Leaderboard link to signal the page is live (Closes #69)

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -101,7 +101,7 @@ export function Footer() {
                             fontSize: "10px",
                             fontWeight: 600,
                             lineHeight: 1,
-                            color: "#ffffff",
+                            color: "#171717",
                             backgroundColor: "#3ecf8e",
                             borderRadius: "4px",
                             padding: "2px 5px",

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -3,11 +3,11 @@
 import Image from "next/image";
 import Link from "next/link";
 
-const links = {
+const links: Record<string, { label: string; href: string; badge?: string }[]> = {
   Product: [
     { label: "Features", href: "#features" },
     { label: "How it works", href: "#how-it-works" },
-    { label: "Leaderboard", href: "/explore" },
+    { label: "Leaderboard", href: "/explore", badge: "New" },
   ],
   Developers: [
     { label: "GitHub", href: "https://github.com/PRODHOSH/ossfolio" },
@@ -79,15 +79,38 @@ export function Footer() {
                 {section}
               </p>
               <ul style={{ listStyle: "none", display: "flex", flexDirection: "column", gap: "8px" }}>
-                {items.map(({ label, href }) => (
+                {items.map(({ label, href, badge }) => (
                   <li key={label}>
                     <Link
                       href={href}
-                      style={{ fontSize: "13px", color: "#707070", textDecoration: "none" }}
+                      style={{
+                        fontSize: "13px",
+                        color: "#707070",
+                        textDecoration: "none",
+                        display: "inline-flex",
+                        alignItems: "center",
+                        gap: "6px",
+                      }}
                       onMouseEnter={(e) => (e.currentTarget.style.color = "#171717")}
                       onMouseLeave={(e) => (e.currentTarget.style.color = "#707070")}
                     >
                       {label}
+                      {badge && (
+                        <span
+                          style={{
+                            fontSize: "10px",
+                            fontWeight: 600,
+                            lineHeight: 1,
+                            color: "#ffffff",
+                            backgroundColor: "#3ecf8e",
+                            borderRadius: "4px",
+                            padding: "2px 5px",
+                            letterSpacing: "0.02em",
+                          }}
+                        >
+                          {badge}
+                        </span>
+                      )}
                     </Link>
                   </li>
                 ))}


### PR DESCRIPTION
## Summary

The footer linked "Leaderboard" to `/explore` with no visual indicator
of the page's status. When the issue was filed the page was a stub, but
the full leaderboard has since been implemented. The footer link now
needs to signal to visitors that this is a live, working feature.

This PR extends the `links` data structure in `Footer.tsx` to support
an optional `badge` field, adds `badge: "New"` to the Leaderboard entry,
and renders a small pill badge in the brand green (`#3ecf8e`) inline
with the link text. All other footer links are unaffected.

Closes #69

## What changed

**`src/components/layout/Footer.tsx`** — three surgical edits:

1. Added TypeScript type annotation to `links`:
   `Record<string, { label: string; href: string; badge?: string }[]>`
   so the optional `badge` field is type-safe across all entries

2. Added `badge: "New"` to the Leaderboard entry — the only item
   with a badge; all other entries are unchanged

3. Updated the `items.map` render to destructure `badge` and render
   a conditional `<span>` pill when present — no badge renders for
   Features, How it works, GitHub, Contributing, Issues, Privacy,
   Terms, or License

The badge uses `#3ecf8e` (the brand green already used for the
OSSfolio wordmark) and `#ffffff` text, `border-radius: 4px`,
`font-size: 10px`, `font-weight: 600` — consistent with the existing
inline style approach throughout the component.

## AI Usage

- [ ] I did not use AI for any part of the code in this PR
- [x] I used AI for coding (Claude) and I fully understand every change
  I made, including which functions I changed, why I changed them, and
  what side effects they could create

Used Claude for coding. Three changes in Footer.tsx: type annotation
on the links object, badge field on the Leaderboard entry, and
conditional badge render in the map. No logic changed — all other
links render identically to before.

## Screenshots

<img width="1210" height="320" alt="Screenshot 2026-06-11 000231" src="https://github.com/user-attachments/assets/63b48fe4-13f5-45c3-adbd-04f1b2089129" />
<img width="1910" height="903" alt="Screenshot 2026-06-11 000524" src="https://github.com/user-attachments/assets/baa6bafc-16a4-4d35-92b5-69874176da86" />


## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with main
- [x] Code works locally and I have tested it
- [ ] If schema changed — both schema.sql and a new migration file included
- [x] If this is a UI change — I read DESIGN.md and followed the design system
- [x] Docs updated if needed
- [x] PR title follows Conventional Commits format
- [x] This PR description is written in my own words