### PR TITLE
feat(profile): add Copy link button with 2s Copied! feedback (Closes #62)

### DIFF
--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import Image from "next/image";
 import type { ContributorStats, Org, TechEntry, HeatmapWeek } from "@/types";
 
@@ -93,6 +94,18 @@ export function ProfileView({
       : `https://${user.blog}`
     : null;
 
+  const [copied, setCopied] = useState(false);
+
+  const handleCopyLink = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard API unavailable — fail silently.
+    }
+  };
+
   // Total stars across the repos shown on this page (the top repos fetched for
   // display). Derived from the `repos` prop already passed in.
   const totalStars = repos.reduce((sum, r) => sum + (r.stargazers_count ?? 0), 0);
@@ -177,9 +190,9 @@ export function ProfileView({
             </a>
           </div>
 
-          {/* Share on X button — opens a pre-filled tweet with the contributor
-              score and profile URL, consistent with DESIGN.md button-secondary-outline */}
-          <div style={{ marginTop: "14px" }}>
+          {/* Action buttons — Share on X and Copy link, consistent with
+              DESIGN.md button-secondary-outline: white bg, ink border, 6px radius */}
+          <div style={{ marginTop: "14px", display: "flex", gap: "8px", flexWrap: "wrap" }}>
             <button
               type="button"
               onClick={() => {
@@ -219,6 +232,60 @@ export function ProfileView({
                 <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
               </svg>
               Share on X
+            </button>
+
+            {/* Copy link button — copies window.location.href to clipboard,
+                shows "Copied!" with green accent for 2 s then resets.
+                Uses {colors.primary} (#3ecf8e) for the confirmed state to
+                signal success without adding a new chromatic event. */}
+            <button
+              type="button"
+              onClick={handleCopyLink}
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: "6px",
+                padding: "7px 14px",
+                fontSize: "13px",
+                fontWeight: 500,
+                color: copied ? "#3ecf8e" : "#171717",
+                backgroundColor: "#ffffff",
+                border: `1px solid ${copied ? "#3ecf8e" : "#c7c7c7"}`,
+                borderRadius: "6px",
+                cursor: "pointer",
+                lineHeight: 1,
+                transition: "border-color 0.15s, color 0.15s",
+              }}
+              onMouseEnter={(e) => {
+                if (!copied) {
+                  e.currentTarget.style.borderColor = "#171717";
+                  e.currentTarget.style.backgroundColor = "#fafafa";
+                }
+              }}
+              onMouseLeave={(e) => {
+                if (!copied) {
+                  e.currentTarget.style.borderColor = "#c7c7c7";
+                  e.currentTarget.style.backgroundColor = "#ffffff";
+                }
+              }}
+              aria-label="Copy profile link to clipboard"
+            >
+              {copied ? (
+                <>
+                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" aria-hidden="true">
+                    <polyline points="20 6 9 17 4 12" />
+                  </svg>
+                  Copied!
+                </>
+              ) : (
+                <>
+                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+                    <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+                  </svg>
+                  Copy link
+                </>
+              )}
             </button>
           </div>
 

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -101,8 +101,8 @@ export function ProfileView({
       await navigator.clipboard.writeText(window.location.href);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // Clipboard API unavailable — fail silently.
+    } catch (err) {
+      console.error("Copy to clipboard failed:", err);
     }
   };
 


### PR DESCRIPTION
## Summary

Users who want to share their OSSfolio profile on a resume or LinkedIn
had to manually copy the URL from the browser address bar. This PR adds
a "Copy link" button in the profile header, placed directly beside the
existing "Share on X" button, so the full profile URL is one click away.

Clicking the button calls `navigator.clipboard.writeText(window.location.href)`,
the label immediately switches to "Copied!" with a green checkmark and
green border for 2 seconds, then resets back to "Copy link". If the
Clipboard API is unavailable the handler fails silently — the button
stays functional and the page never breaks.

Closes #62

## What changed

**`src/components/profile/ProfileView.tsx`** — one file, four additions:

1. **`import { useState } from "react"`** — added at the top. The file
   previously had no React import; `useState` is required for the
   copied/reset toggle.

2. **`const [copied, setCopied] = useState(false)`** — declared inside
   the component. `handleCopyLink` writes to the clipboard, sets
   `copied` to `true`, and schedules a `setTimeout` to flip it back
   to `false` after 2000 ms.

3. **Button wrapper `<div>` updated** — added `display: "flex"`,
   `gap: "8px"`, and `flexWrap: "wrap"` so the "Copy link" button
   sits beside "Share on X" on wide viewports and wraps cleanly on
   narrow ones.

4. **"Copy link" button** — placed immediately after the "Share on X"
   button, inside the same flex row. Identical base style to
   `button-secondary-outline` from DESIGN.md. In the `copied` state
   the label becomes "Copied!", the border turns `{colors.primary}`
   `#3ecf8e`, and the text turns `#3ecf8e`. Hover effects are
   suppressed while `copied` is `true` so the green state is not
   disrupted by mouse movement. A clipboard icon shows in the default
   state; a checkmark icon shows in the confirmed state.

## Design decisions

I read `DESIGN.md` before touching any UI:

- **Base style** — matches `button-secondary-outline` exactly:
  `background #ffffff`, `color #171717`, `border 1px solid #c7c7c7`,
  `borderRadius 6px` (`{rounded.sm}`), `padding 7px 14px` — identical
  to the "Share on X" button it sits beside.
- **Confirmed state** — uses `{colors.primary}` (`#3ecf8e`) for both
  the border and the text. The green is the only chromatic event in the
  system; using it here signals success without introducing a new color.
- **`transition: "border-color 0.15s, color 0.15s"`** — smooth visual
  transition when the state flips, consistent with the existing hover
  transitions across the codebase.
- **`flexWrap: "wrap"`** on the button row — both buttons stay on one
  line at normal widths and stack gracefully on narrow viewports without
  any media query.
- **No new imports beyond `useState`** — no new components, no new
  dependencies.

## AI Usage

- [ ] I did not use AI for any part of the code in this PR
- [x] I used AI for coding (Claude) and I fully understand every change
  I made, including which functions I changed, why I changed them, and
  what side effects they could create
  

## Screenshots

<img width="1903" height="912" alt="Screenshot 2026-06-11 181950" src="https://github.com/user-attachments/assets/ea7f7b61-5b51-4f68-b794-b6812b55d201" />
<img width="1900" height="907" alt="Screenshot 2026-06-11 182002" src="https://github.com/user-attachments/assets/f381ebdc-40cd-4dc3-8c4e-fa35069ab48c" />


## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with main
- [x] Code works locally and I have tested it
- [ ] If schema changed — both schema.sql and a new migration file included
- [x] If this is a UI change — I read DESIGN.md and followed the design system
- [x] Docs updated if needed
- [x] PR title follows Conventional Commits format
- [x] This PR description is written in my own words