### PR TITLE
fix(footer): add How scoring works link to Product column (Closes #106)

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -8,6 +8,7 @@ const links: Record<string, { label: string; href: string; badge?: string }[]> =
     { label: "Features", href: "#features" },
     { label: "How it works", href: "#how-it-works" },
     { label: "Leaderboard", href: "/explore", badge: "New" },
+    { label: "How scoring works", href: "/score-explained" },
   ],
   Developers: [
     { label: "GitHub", href: "https://github.com/PRODHOSH/ossfolio" },


### PR DESCRIPTION
## Summary

The `/score-explained` page is fully built but had no entry point
anywhere on the site. Visitors could only reach it by typing the URL
directly. The Footer's Product column is the most natural location —
users who want to understand their score will look there after seeing
it on a profile page.

Closes #106

## What changed

**`src/components/layout/Footer.tsx`** — One line added:

Added `{ label: "How scoring works", href: "/score-explained" }` to
the Product column in the `links` data structure, immediately after
the existing "Leaderboard" entry.

The new link:
- Uses the same `Link` component and inline style as every other
  footer link (`fontSize: "13px"`, `color: "#707070"`)
- Has the same `onMouseEnter`/`onMouseLeave` hover behaviour
  (`#707070` → `#171717` on hover)
- Opens in the same tab (no `target="_blank"`)
- Has no badge — it is a permanent page, not a new feature

The existing type annotation on `links` already supports optional
`badge` fields so no type changes were needed. No other files changed.

## AI Usage

- [ ] I did not use AI for any part of the code in this PR
- [x] I used AI for coding (Claude) and I fully understand every
  change I made, including which functions I changed, why I changed
  them, and what side effects they could create

## Screenshots

No visual layout change beyond one new link appearing in the footer
Product column.

## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with main
- [x] Code works locally and I have tested it
- [ ] If schema changed — both schema.sql and a new migration file included
- [x] If this is a UI change — I read DESIGN.md and followed the design system
- [x] Docs updated if needed
- [x] PR title follows Conventional Commits format
- [x] This PR description is written in my own words