### PR TITLE
Close #109. ​fix(accessibility): notify screen readers of external links opening in new tab 

### DIFF
--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -149,6 +149,7 @@ export function ProfileView({
                 href={website}
                 target="_blank"
                 rel="noopener noreferrer"
+                aria-label={`Personal website ${website.replace(/^https?:\/\//, "")} (opens in a new tab)`}
                 style={{ fontSize: "13px", color: "#707070", display: "flex", alignItems: "center", gap: "5px", textDecoration: "none" }}
                 onMouseEnter={(e) => (e.currentTarget.style.color = "#171717")}
                 onMouseLeave={(e) => (e.currentTarget.style.color = "#707070")}
@@ -165,6 +166,7 @@ export function ProfileView({
                 href={`https://twitter.com/${user.twitter_username}`}
                 target="_blank"
                 rel="noopener noreferrer"
+                aria-label={`Twitter profile of @${user.twitter_username} (opens in a new tab)`}
                 style={{ fontSize: "13px", color: "#707070", display: "flex", alignItems: "center", gap: "5px", textDecoration: "none" }}
                 onMouseEnter={(e) => (e.currentTarget.style.color = "#171717")}
                 onMouseLeave={(e) => (e.currentTarget.style.color = "#707070")}
@@ -179,6 +181,7 @@ export function ProfileView({
               href={user.html_url}
               target="_blank"
               rel="noopener noreferrer"
+              aria-label={`GitHub profile of ${displayName} (opens in a new tab)`}
               style={{ fontSize: "13px", color: "#707070", display: "flex", alignItems: "center", gap: "5px", textDecoration: "none" }}
               onMouseEnter={(e) => (e.currentTarget.style.color = "#171717")}
               onMouseLeave={(e) => (e.currentTarget.style.color = "#707070")}
@@ -382,6 +385,7 @@ export function ProfileView({
               href={`https://github.com/${user.login}?tab=repositories`}
               target="_blank"
               rel="noopener noreferrer"
+              aria-label="View all repositories on GitHub (opens in a new tab)"
               style={{ fontSize: "13px", color: "#707070", textDecoration: "none", display: "inline-flex", alignItems: "center", gap: "4px" }}
               onMouseEnter={(e) => (e.currentTarget.style.color = "#171717")}
               onMouseLeave={(e) => (e.currentTarget.style.color = "#707070")}
@@ -475,6 +479,7 @@ export function ProfileView({
                 target="_blank"
                 rel="noopener noreferrer"
                 title={org.name ?? org.login}
+                aria-label={`Organization ${org.name ?? org.login} (opens in a new tab)`}
                 style={{ display: "inline-flex", borderRadius: "8px", overflow: "hidden", border: "1px solid #ededed", transition: "border-color 0.15s" }}
                 onMouseEnter={(e) => (e.currentTarget.style.borderColor = "#3ecf8e")}
                 onMouseLeave={(e) => (e.currentTarget.style.borderColor = "#ededed")}

--- a/src/components/profile/TopRepos.tsx
+++ b/src/components/profile/TopRepos.tsx
@@ -21,6 +21,7 @@ export function TopRepos({ repos }: TopReposProps) {
             href={repo.url}
             target="_blank"
             rel="noopener noreferrer"
+            aria-label={`View ${repo.name} repository on GitHub (opens in a new tab)`}
             className="group rounded-lg border border-border p-3 hover:border-primary/50 transition-colors"
           >
             <div className="flex items-start justify-between">


### PR DESCRIPTION
## Summary
Added descriptive `aria-label` attributes to external target="_blank" profile and repository links in `ProfileView.tsx` and `TopRepos.tsx`. This ensures screen reader users are properly notified when a link will open in a new browser tab.

## Related Issue
Closes #109