### PR TITLE
feat(profile): add Reviews card to contribution stats grid (Closes #58)

### DIFF
--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -424,6 +424,7 @@ export function ProfileView({
             { label: "Commits", value: stats.totalCommits },
             { label: "Pull Requests", value: stats.totalPRs },
             { label: "Issues", value: stats.totalIssues },
+            { label: "Reviews", value: stats.totalReviews },
             { label: "Stars", value: totalStars },
             { label: "Contributor score", value: score },
           ].map((item) => (


### PR DESCRIPTION
## Summary

`stats.totalReviews` is already tracked in the database, fetched
from GitHub's GraphQL `contributionsCollection`, and used in the
contributor score formula (`score.ts` — weighted at 2× because code
reviews are high-value contributions). Despite being tracked and
scored, the Reviews count was never shown on the profile page itself.
This PR adds a Reviews card to the contribution stats grid so users
can see their total review count alongside Commits, Pull Requests,
Issues, Stars, and Contributor score.

Closes #58

## What changed

**`src/components/profile/ProfileView.tsx`** — one line added to the
stats array near line 256:

```ts
// Before
{ label: "Commits", value: stats.totalCommits },
{ label: "Pull Requests", value: stats.totalPRs },
{ label: "Issues", value: stats.totalIssues },
{ label: "Stars", value: totalStars },
{ label: "Contributor score", value: score },

// After
{ label: "Commits", value: stats.totalCommits },
{ label: "Pull Requests", value: stats.totalPRs },
{ label: "Issues", value: stats.totalIssues },
{ label: "Reviews", value: stats.totalReviews },
{ label: "Stars", value: totalStars },
{ label: "Contributor score", value: score },
```

Placed after Issues and before Stars — grouping the core GitHub
contribution metrics (Commits, PRs, Issues, Reviews) together before
the derived stats (Stars, Score).

The grid uses `auto-fit` so the new card reflows correctly at all
viewport widths including mobile — no layout or CSS changes needed.
The new card uses the identical component and styling as all existing
stat cards.

## Why `stats.totalReviews` is available

- `src/types/index.ts` line 24: `totalReviews: number` — typed
- `src/lib/github.ts` line 154: populated from GitHub GraphQL
  `totalPullRequestReviewContributions`
- `src/lib/score.ts` line 10: `stats.totalReviews * 2` — used in
  score formula
- `src/app/auth/callback/page.tsx` line 64: persisted to DB

The value is already in every stats object on every profile page.
This PR just makes it visible.

## AI Usage

- [ ] I did not use AI for any part of the code in this PR
- [x] I used AI for coding (Claude) and I fully understand every
  change I made, including which functions I changed, why I changed
  them, and what side effects they could create

## Screenshots

<img width="1902" height="914" alt="Screenshot 2026-06-14 003753" src="https://github.com/user-attachments/assets/d505a1cd-bcc3-47ae-9cc9-b2380f55aed8" />


## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with main
- [x] Code works locally and I have tested it
- [ ] If schema changed — both schema.sql and a new migration file included
- [x] If this is a UI change — I read DESIGN.md and followed the
      design system
- [x] Grid layout verified on narrow screens — auto-fit handles
      the extra card
- [x] Docs updated if needed
- [x] PR title follows Conventional Commits format
- [x] This PR description is written in my own words