### PR TITLE
feat(profile): add Less–More color legend below contribution heatmap (Closes #59)

### DIFF
--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -562,6 +562,20 @@ export function ProfileView({
               </div>
             ))}
           </div>
+          {/* Color legend — mirrors GitHub's Less→More scale using the same
+              five shades the heatmap cells use (#ebedf0 → #216e39). Kept small
+              and muted per DESIGN.md so it reads as a caption, not a chart element. */}
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "flex-end", gap: "4px", margin: "10px 0 0 0" }}>
+            <span style={{ fontSize: "12px", color: "#707070", marginRight: "2px" }}>Less</span>
+            {["#ebedf0", "#9be9a8", "#40c463", "#30a14e", "#216e39"].map((shade) => (
+              <span
+                key={shade}
+                aria-hidden="true"
+                style={{ width: "11px", height: "11px", borderRadius: "2px", backgroundColor: shade, flexShrink: 0 }}
+              />
+            ))}
+            <span style={{ fontSize: "12px", color: "#707070", marginLeft: "2px" }}>More</span>
+          </div>
           <p style={{ fontSize: "12px", color: "#9a9a9a", margin: "10px 0 0 0" }}>
             This chart shows an estimate of contribution activity. Exact daily counts are not available for public profiles.
           </p>


### PR DESCRIPTION
## Summary

The contribution heatmap uses five shades of green to represent
activity levels but had no legend explaining what the shades mean.
New visitors cannot tell whether a dark cell means "a lot" or "a
little" without prior context. This PR adds a small, right-aligned
"Less → More" color legend directly below the heatmap grid — the
same pattern GitHub itself uses.

Closes #59

## What changed

**`src/components/profile/ProfileView.tsx`** — 14 lines added after
the heatmap grid and before the existing disclaimer paragraph:

```tsx
<div style={{ display: "flex", alignItems: "center",
              justifyContent: "flex-end", gap: "4px",
              margin: "10px 0 0 0" }}>
  <span style={{ fontSize: "12px", color: "#707070", marginRight: "2px" }}>
    Less
  </span>
  {["#ebedf0", "#9be9a8", "#40c463", "#30a14e", "#216e39"].map((shade) => (
    <span
      key={shade}
      aria-hidden="true"
      style={{ width: "11px", height: "11px", borderRadius: "2px",
               backgroundColor: shade, flexShrink: 0 }}
    />
  ))}
  <span style={{ fontSize: "12px", color: "#707070", marginLeft: "2px" }}>
    More
  </span>
</div>
```

**Design decisions (following DESIGN.md):**

- **Colors:** The exact five shades used by the heatmap cells
  themselves — `#ebedf0` (empty) → `#9be9a8` → `#40c463` →
  `#30a14e` → `#216e39` (most active). Sourced from
  `src/lib/mock.ts` `HEATMAP_COLORS` which matches GitHub's
  GraphQL API color output.
- **Size:** 11×11px boxes with 2px border-radius — identical to
  the heatmap cells so the legend reads as a direct key to the
  chart above it.
- **Typography:** 12px, `#707070` — the muted caption weight
  used throughout the profile page, consistent with DESIGN.md.
- **Alignment:** Right-aligned (`justifyContent: "flex-end"`) so
  it sits flush with the right edge of the heatmap, matching
  GitHub's reference layout.
- **Accessibility:** Each box has `aria-hidden="true"` — the
  legend is purely decorative/visual; "Less" and "More" text
  labels convey the meaning to screen readers.
- **Position:** Between the heatmap grid and the existing
  disclaimer paragraph — never before the heatmap, never
  disrupting the streak pills above.

## Scope

- `src/components/profile/ProfileView.tsx` — 14 insertions,
  0 deletions
- No schema changes, no new dependencies, no other files changed

## AI Usage

- [ ] I did not use AI for any part of the code in this PR
- [x] I used AI for coding (Claude) and I fully understand every
  change I made, including which functions I changed, why I
  changed them, and what side effects they could create

## Screenshots

<img width="1906" height="547" alt="Screenshot 2026-06-14 184900" src="https://github.com/user-attachments/assets/e5eb7fc6-eb7f-4593-a71c-e8721a305d74" />

## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with main
- [x] Code works locally and I have tested it
- [ ] If schema changed — both schema.sql and migration file included
- [x] If this is a UI change — I read DESIGN.md and followed the
      design system
- [x] Colors match the exact shades used by the heatmap cells
- [x] Typography is 12px #707070 per DESIGN.md caption style
- [x] Legend boxes have aria-hidden="true" — text labels carry
      the semantic meaning for screen readers
- [x] 14 insertions, 0 deletions — no existing code removed
- [x] Docs updated if needed
- [x] PR title follows Conventional Commits format
- [x] This PR description is written in my own words