### PR TITLE
feat(profile): add empty state when user has no public repositories (Closes #61)

### DIFF
--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -320,12 +320,17 @@ export function ProfileView({
       </div>
 
       {/* Repos */}
-      {repos.length > 0 && (
-        <div style={{ marginTop: "40px" }}>
-          <h2 style={{ fontSize: "16px", fontWeight: 600, color: "var(--color-ink)", margin: "0 0 20px 0", letterSpacing: "-0.2px" }}>
-            Popular repositories
-          </h2>
+      <div style={{ marginTop: "40px" }}>
+        <h2 style={{ fontSize: "16px", fontWeight: 600, color: "var(--color-ink)", margin: "0 0 20px 0", letterSpacing: "-0.2px" }}>
+          Popular repositories
+        </h2>
 
+        {repos.length === 0 ? (
+          <p style={{ fontSize: "13px", color: "var(--color-ink-mute)", margin: 0 }}>
+            No public repositories yet.
+          </p>
+        ) : (
+          <>
           <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))", gap: "16px" }}>
             {repos.map((repo) => (
               <a
@@ -399,8 +404,9 @@ export function ProfileView({
               </svg>
             </a>
           </div>
-        </div>
-      )}
+          </>
+        )}
+      </div>
 
       {/* Contribution stats */}
       <div style={{ marginTop: "44px" }}>


### PR DESCRIPTION
## Summary

When a GitHub user has no public repositories, the entire
"Popular repositories" section was completely hidden — no heading,
no message, nothing. A visitor landing on that profile has no way
to tell whether the section failed to load, is still loading, or
simply does not exist yet. This PR always renders the section
heading and shows a clear "No public repositories yet." message
when the array is empty.

Closes #61

## What changed

**`src/components/profile/ProfileView.tsx`** — the repos block
restructured from a conditional render to an always-visible section:

```tsx
// Before — entire section hidden when repos is empty
{repos.length > 0 && (
  <div style={{ marginTop: "40px" }}>
    <h2>Popular repositories</h2>
    <div>…repo cards…</div>
  </div>
)}

// After — heading always visible, empty state shown when needed
<div style={{ marginTop: "40px" }}>
  <h2>Popular repositories</h2>

  {repos.length === 0 ? (
    <p style={{ fontSize: "13px", color: "var(--color-ink-mute)", margin: 0 }}>
      No public repositories yet.
    </p>
  ) : (
    <>
      <div>…repo cards…</div>
      <a href="…">View all repositories on GitHub</a>
    </>
  )}
</div>
```

**Design decisions (following DESIGN.md):**

- `color: "var(--color-ink-mute)"` — the CSS variable used by all
  secondary and caption text throughout the profile page. Consistent
  with the language, star count, fork count, and repo description
  text.
- `fontSize: "13px"` — matches the "View all repositories" link
  and repo description text directly below the grid.
- `margin: 0` — no extra spacing; the section heading's own
  `margin: "0 0 20px 0"` provides enough separation.
- The "View all repositories on GitHub" link is intentionally
  hidden in the empty state — there is nothing useful to link to
  when the user has no public repos.

## Scope

- `src/components/profile/ProfileView.tsx` — 13 insertions,
  7 deletions
- No schema changes, no API changes, no other files changed

## AI Usage

- [ ] I did not use AI for any part of the code in this PR
- [x] I used AI for coding (Claude) and I fully understand every
  change I made, including which functions I changed, why I changed
  them, and what side effects they could create

## Screenshots

<img width="1919" height="918" alt="Screenshot 2026-06-17 005523" src="https://github.com/user-attachments/assets/fbb9b206-08eb-4275-90c1-39b2a5c79c4f" />


## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with main
- [x] Code works locally and I have tested it
- [ ] If schema changed — both schema.sql and a new migration file
      included
- [x] If this is a UI change — I read DESIGN.md and followed the
      design system
- [x] CSS variables used — `var(--color-ink-mute)` matches all
      secondary text on the page
- [x] Empty state message is clear and non-alarming
- [x] "View all repositories" link correctly hidden in empty state
- [x] Docs updated if needed
- [x] PR title follows Conventional Commits format
- [x] This PR description is written in my own words

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the "Popular repositories" section in profile view to display a dedicated empty-state message when no repositories are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->