### PR TITLE
fix(hero): correct domain from ossfolio.me to ossfolio.qzz.io (Closes #132)

### DIFF
--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -118,7 +118,7 @@ export function Hero({ onGetStarted }: HeroProps) {
         >
           Sign in once. Get a shareable profile at{" "}
           <span style={{ color: "var(--color-ink)", fontWeight: 500 }}>
-            ossfolio.me/username
+            ossfolio.qzz.io/username
           </span>{" "}
           showing your real open-source impact — merged PRs, streaks, orgs,
           badges, and more.


### PR DESCRIPTION
## Summary

The homepage hero subtitle text displayed `ossfolio.me/username` as the shareable profile URL. The real domain is `ossfolio.qzz.io`. Any visitor who read that text and tried visiting `ossfolio.me` would land on the wrong site. This PR corrects the string to match the actual domain.

## Related Issue

Closes #132

## Type of Change

- [x] Bug fix

## Changes Made

- `src/components/home/Hero.tsx` line 121 — changed `ossfolio.me/username` to `ossfolio.qzz.io/username` in the hero subtitle span

## AI Usage

- [x] I used AI for coding (Claude Code) and I fully understand every change I made, including which functions I changed, why I changed them, and what side effects they could create

The change is a single string literal inside a `<span>` in the Hero component subtitle. No logic, no imports, no styling affected.

## Screenshots (if UI change)

<img width="1898" height="910" alt="Screenshot 2026-06-20 193212" src="https://github.com/user-attachments/assets/bbafb162-a2a2-4e40-9d78-3f658649c02a" />


## Note on Other Occurrences

While scoping this fix I found `ossfolio.me` also appears in three other home components and `layout.tsx`. I kept this PR scoped to the assigned issue (Hero.tsx only). Happy to fix the remaining files in follow-up issues if needed.

## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with `main`
- [x] Code works locally and I have tested it
- [x] No `console.log` left in `src/`
- [x] If this is a UI change — I read `DESIGN.md` and followed the design system (colors, spacing, typography, components)
- [x] PR title follows Conventional Commits format (`fix:`)
- [x] This PR description is written in my own words