### PR TITLE
fix(nav): route Leaderboard link to /explore instead of broken anchor (Closes #136)

### DIFF
--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -12,7 +12,11 @@ interface NavbarProps {
   onGetStarted?: () => void;
 }
 
-const navLinks = ["Features", "How it works", "Leaderboard"];
+const navLinks = [
+  { label: "Features", href: "#features" },
+  { label: "How it works", href: "#how-it-works" },
+  { label: "Leaderboard", href: "/explore" },
+];
 
 // System Theme Design Tokens Mapping
 const tokens = {
@@ -176,11 +180,11 @@ export function Navbar({ onSignIn, onGetStarted }: NavbarProps) {
         <nav style={{ display: "flex", alignItems: "center", gap: "28px" }} className="hide-on-mobile">
           {navLinks.map((item) => (
             <Link
-              key={item}
-              href={`#${item.toLowerCase().replace(/\s+/g, "-")}`}
+              key={item.label}
+              href={item.href}
               style={{ fontSize: "14px", fontWeight: 500, color: isDarkMode ? tokens.textMutedDark : tokens.textMutedLight, textDecoration: "none" }}
             >
-              {item}
+              {item.label}
             </Link>
           ))}
         </nav>


### PR DESCRIPTION
## Summary

The Leaderboard nav link used `href="#leaderboard"` — generated automatically from the label string. This anchor does not exist on any page, so clicking it did nothing (the URL changed to `<current-page>#leaderboard` but nothing scrolled). The leaderboard lives at `/explore`. This PR gives each nav link an explicit `href` so Leaderboard routes correctly.

## Related Issue

Closes #136

## Type of Change

- [x] Bug fix

## Changes Made

- `src/components/layout/Navbar.tsx` — converted `navLinks` from a plain string array to an array of `{ label, href }` objects, giving each link an explicit destination
- Leaderboard: `#leaderboard` → `/explore`
- Features and How it works keep their existing anchor hrefs (`#features`, `#how-it-works`) — those are scoped to issue #139
- Updated the `.map()` to use `item.href` and `item.label` instead of auto-generating anchors from the label string

## AI Usage

- [x] I used AI for coding (Claude Code) and I fully understand every change I made, including which functions I changed, why I changed them, and what side effects they could create

## Screenshots (if UI change)

<img width="1911" height="918" alt="Screenshot 2026-06-20 194455" src="https://github.com/user-attachments/assets/6ffa07b7-c8cc-4685-8ee4-64da5b364971" />
<img width="1906" height="909" alt="Screenshot 2026-06-20 194508" src="https://github.com/user-attachments/assets/01bda100-66c9-418d-8126-2a4f3d1ce8e3" />


## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with `main`
- [x] Code works locally and I have tested it
- [x] No `console.log` left in `src/`
- [x] If this is a UI change — I read `DESIGN.md` and followed the design system (colors, spacing, typography, components)
- [x] PR title follows Conventional Commits format (`fix:`)
- [x] This PR description is written in my own words

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Navigation Updates**
  * Updated Leaderboard navigation link to route to the Explore page instead of an in-page anchor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->