### PR TITLE
feat(profile): add Score explained link on Contributor Score stat card (Closes #147)

### DIFF
--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import Image from "next/image";
+import Link from "next/link";
 import type { ContributorStats, Org, TechEntry, HeatmapWeek } from "@/types";
 
 interface GitHubUser {
@@ -440,6 +441,14 @@ export function ProfileView({
                 {item.value.toLocaleString("en-US")}
               </span>
               <span style={{ fontSize: "12px", color: "var(--color-ink-mute)", marginTop: "4px" }}>{item.label}</span>
+              {item.label === "Contributor score" && (
+                <Link
+                  href="/score-explained"
+                  style={{ fontSize: "11px", color: "var(--color-ink-mute-2)", marginTop: "4px", textDecoration: "none" }}
+                >
+                  Score explained →
+                </Link>
+              )}
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary

The Contributor Score stat card shows a number but gives no context about what it means or how it is calculated. The `/score-explained` page already exists and breaks down the formula in detail, but nothing on the profile page links to it. This PR adds a small "Score explained →" link below the label on the Contributor Score card so users can discover the page directly from their profile.

## Related Issue

Closes #147

## Type of Change

- [x] New feature / enhancement

## Changes Made

- `src/components/profile/ProfileView.tsx`:
  - Added `import Link from "next/link"` (Next.js navigation)
  - Added a conditional `<Link href="/score-explained">` rendered below the label span, gated on `item.label === "Contributor score"` — all other 5 stat cards are unaffected
  - Styled using `--color-ink-mute-2` (tertiary text, `#9a9a9a`) at `11px` per DESIGN.md tokens

## AI Usage

- [x] I used AI for coding assistance (Claude Code) and I fully understand every change I made, including which functions I changed, why I changed them, and what side effects they could create

## Screenshots (if UI change)

<img width="1902" height="918" alt="Screenshot 2026-06-21 203339" src="https://github.com/user-attachments/assets/309a1ba7-a446-4ded-a726-43a6330e82d1" />
<img width="1538" height="905" alt="Screenshot 2026-06-21 203356" src="https://github.com/user-attachments/assets/529e14b8-d190-4101-9123-740b7386f79f" />


## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with `main`
- [x] Code works locally and I have tested it
- [x] No `console.log` left in `src/`
- [x] I read `DESIGN.md` and used the correct color tokens and font sizes
- [x] PR title follows Conventional Commits format (`feat:`)
- [x] This PR description is written in my own words

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Score explained" link in the profile view under the Contributor score statistic, allowing users to learn how their contributor score is calculated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->