### PR TITLE
fix(skeleton): match stat card count to real grid — 4 to 6 (Closes #157)

### DIFF
--- a/src/app/[username]/loading.tsx
+++ b/src/app/[username]/loading.tsx
@@ -198,7 +198,7 @@ export default function ProfileLoading() {
                 gap: "12px",
               }}
             >
-              {Array.from({ length: 4 }).map((_, i) => (
+              {Array.from({ length: 6 }).map((_, i) => (
                 <div
                   key={i}
                   style={{


### PR DESCRIPTION
## Summary

The profile loading skeleton rendered the Contribution stats section with 4 placeholder cards (`Array.from({ length: 4 })`). But the real `ProfileView.tsx` renders 6 stat cards — Commits, Pull Requests, Issues, Reviews, Stars, and Contributor Score. This mismatch caused a visible layout shift when the real data loaded, as the section expanded from 4 to 6 cards.

The fix changes the skeleton's stat section from `length: 4` to `length: 6` so the placeholder matches the real layout exactly, eliminating the layout shift.

## Related Issue

Closes #157

## Type of Change

- [x] Bug fix

## Changes Made

- `src/app/[username]/loading.tsx` line 201 — `Array.from({ length: 4 })` → `Array.from({ length: 6 })` in the Contribution stats skeleton section
- The repos skeleton at line 151 (`length: 6`) was already correct and is untouched

## AI Usage

- [x] I used AI for coding assistance (Claude Code) and I fully understand every change I made, including which functions I changed, why I changed them, and what side effects they could create

## Screenshots (if UI change)

<img width="1906" height="912" alt="Screenshot 2026-06-21 205259" src="https://github.com/user-attachments/assets/3ffcb23a-c67f-48c9-9997-381b9b010449" />


## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with `main`
- [x] Code works locally and I have tested it
- [x] No `console.log` left in `src/`
- [x] If this is a UI change — I read `DESIGN.md` and followed the design system
- [x] PR title follows Conventional Commits format (`fix:`)
- [x] This PR description is written in my own words

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the contribution statistics loading skeleton to display 6 stat cards instead of 4 for a more accurate loading preview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->