### PR TITLE
feat(profile): add GitHub-style language percentage bar to Tech Stack section (Closes #152)

### DIFF
--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -451,6 +451,42 @@ export function ProfileView({
           <h2 style={{ fontSize: "16px", fontWeight: 600, color: "var(--color-ink)", margin: "0 0 16px 0", letterSpacing: "-0.2px" }}>
             Tech stack
           </h2>
+          {(() => {
+            const totalRepoCount = techStack.reduce((sum, t) => sum + t.repoCount, 0);
+            if (totalRepoCount === 0) return null;
+            const summary = techStack
+              .map((t) => `${t.language} ${Math.round((t.repoCount / totalRepoCount) * 100)}%`)
+              .join(", ");
+            return (
+              <div
+                role="img"
+                aria-label={`Language breakdown: ${summary}`}
+                style={{
+                  display: "flex",
+                  width: "100%",
+                  height: "8px",
+                  borderRadius: "9999px",
+                  overflow: "hidden",
+                  marginBottom: "16px",
+                  backgroundColor: "var(--color-canvas-soft)",
+                }}
+              >
+                {techStack.map(({ language, repoCount }, i) => (
+                  <div
+                    key={language}
+                    style={{
+                      width: `${(repoCount / totalRepoCount) * 100}%`,
+                      backgroundColor: LANG_COLORS[language] ?? "#9a9a9a",
+                      borderTopLeftRadius: i === 0 ? "9999px" : 0,
+                      borderBottomLeftRadius: i === 0 ? "9999px" : 0,
+                      borderTopRightRadius: i === techStack.length - 1 ? "9999px" : 0,
+                      borderBottomRightRadius: i === techStack.length - 1 ? "9999px" : 0,
+                    }}
+                  />
+                ))}
+              </div>
+            );
+          })()}
           <div style={{ display: "flex", flexWrap: "wrap", gap: "8px" }}>
             {techStack.map(({ language, repoCount }) => (
               <span


### PR DESCRIPTION
## Summary

The Tech Stack section showed language badges with repo counts but no visual indication of the relative breakdown. This PR adds a GitHub-style horizontal colour bar above the badges — each segment's width is proportional to how many repos use that language, coloured using the existing `LANG_COLORS` map.

## Related Issue

Closes #152

## Type of Change

- [x] New feature / enhancement

## Changes Made

- `src/components/profile/ProfileView.tsx` — added a colour-coded language bar between the "Tech stack" heading and the badge row:
  - Each segment: `width = (repoCount / total) * 100 + '%'`, `backgroundColor = LANG_COLORS[language] ?? '#9a9a9a'`
  - First and last segments get rounded ends (`borderRadius: "9999px"` on the respective corners)
  - Container: `role="img"` with `aria-label` listing each language and its percentage (e.g. "Language breakdown: TypeScript 60%, Python 25%, ...")
  - Height: `8px` — subtle, not dominating, per DESIGN.md guidance
  - Guards against empty techStack (`totalRepoCount === 0` returns null)
  - No new imports, no new API calls — uses existing `LANG_COLORS` and `techStack` prop

## AI Usage

- [x] I used AI for coding assistance (Claude Code) and I fully understand every change I made, including which functions I changed, why I changed them, and what side effects they could create

## Screenshots (if UI change)

<img width="1913" height="901" alt="Screenshot 2026-06-21 210321" src="https://github.com/user-attachments/assets/84ff9dd0-1c8f-4c09-af64-bc90d6063f37" />


## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with `main`
- [x] Code works locally and I have tested it
- [x] No `console.log` left in `src/`
- [x] I read `DESIGN.md` and followed the design system (8px height, existing color tokens)
- [x] PR title follows Conventional Commits format (`feat:`)
- [x] This PR description is written in my own words

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replaced tech stack display with a visual proportion-based language breakdown bar.
  * Added accessibility support with descriptive labels for the breakdown visualization.
  * Tech stack section now hides when there are no repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->