### PR TITLE
feat(profile): add Contributions card to stats grid (Closes #153)

### DIFF
--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -420,6 +420,7 @@ export function ProfileView({
         </h2>
         <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", gap: "12px" }}>
           {[
+            { label: "Contributions", value: stats.totalContributions },
             { label: "Commits", value: stats.totalCommits },
             { label: "Pull Requests", value: stats.totalPRs },
             { label: "Issues", value: stats.totalIssues },


### PR DESCRIPTION
## Summary

Added the yearly contribution count as a new stat card in the profile's Contribution Stats grid. The data (totalContributions) was already fetched from GitHub's contribution calendar API but never displayed. Placed it first in the grid since it's the broadest activity metric.

## Related Issue

Closes #153

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Chore / dependency update

## Changes Made

- Added `{ label: "Contributions", value: stats.totalContributions }` as the first entry in the stats array in `src/components/profile/ProfileView.tsx` (line 423)
- No new dependencies, no new components - just one additional entry in the existing map array

## AI Usage

- [ ] I did not use AI for any part of the code in this PR
- [x] I used AI for coding (specify which tool below) and I fully understand every change I made, including which functions I changed, why I changed them, and what side effects they could create

Used Cursor (Claude) to help locate the exact line and verify the type definition.

## Screenshots (if UI change)

The stats grid now shows 8 cards instead of 7. The new "Contributions" card appears first.

## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with `main`
- [x] Code works locally and I have tested it
- [x] No `console.log` left in `src/`
- [x] If schema changed - both `schema.sql` and a new migration file are included
- [x] If this is a UI change - I read `DESIGN.md` and followed the design system (colors, spacing, typography, components)
- [x] Docs updated if needed
- [x] PR title follows Conventional Commits format (`feat:`, `fix:`, `docs:`, etc.)
- [x] This PR description is written in my own words
