### PR TITLE
fix(error): add global error boundary

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+/**
+ * src/app/error.tsx
+ *
+ * Global error boundary for unhandled runtime errors. Catches exceptions
+ * that bubble past page-level boundaries and renders a recovery UI.
+ * Inline styles only, matching the DESIGN.md palette:
+ *   canvas #ffffff | ink #171717 | ink-mute #707070 | primary #3ecf8e
+ */
+
+import type { CSSProperties } from "react";
+
+const primaryButton: CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  minWidth: "130px",
+  padding: "10px 28px",
+  borderRadius: "8px",
+  backgroundColor: "#3ecf8e",
+  color: "#171717",
+  fontSize: "16px",
+  fontWeight: 600,
+  border: "none",
+  cursor: "pointer",
+};
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <main
+      style={{
+        backgroundColor: "#ffffff",
+        minHeight: "100vh",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: "24px",
+      }}
+    >
+      <div style={{ textAlign: "center", maxWidth: "28rem" }}>
+        <p
+          style={{
+            fontSize: "72px",
+            fontWeight: 700,
+            lineHeight: 1,
+            color: "#3ecf8e",
+          }}
+        >
+          500
+        </p>
+        <h1
+          style={{
+            marginTop: "16px",
+            fontSize: "24px",
+            fontWeight: 600,
+            color: "#171717",
+          }}
+        >
+          Something went wrong
+        </h1>
+        <p style={{ marginTop: "12px", fontSize: "16px", color: "#707070" }}>
+          An unexpected error occurred. You can try again or head back to the
+          home page.
+        </p>
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "center",
+            gap: "12px",
+            marginTop: "28px",
+          }}
+        >
+          <button onClick={reset} style={primaryButton}>
+            Try again
+          </button>
+          <a
+            href="/"
+            style={{
+              ...primaryButton,
+              backgroundColor: "transparent",
+              border: "1px solid #e2e2e2",
+              color: "#171717",
+              textDecoration: "none",
+            }}
+          >
+            Back to home
+          </a>
+        </div>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a global error boundary (`src/app/error.tsx`) so unhandled runtime errors show a recovery page instead of crashing to a blank screen in production.

## Related Issue

Closes #170

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Chore / dependency update

## Changes Made

- Created `src/app/error.tsx` as a `'use client'` component (required by Next.js for error boundaries)
- Renders a centered error page with a "Try again" button that calls `reset()` to re-render the failed segment
- Added a secondary "Back to home" link as a fallback navigation path
- Follows the same inline-styles approach and color palette as `not-found.tsx`

## AI Usage

- [ ] I did not use AI for any part of the code in this PR
- [x] I used AI for coding (Cursor with Claude) and I fully understand every change I made, including which functions I changed, why I changed them, and what side effects they could create

The file is a single React component. It receives `error` and `reset` props from Next.js App Router's error boundary mechanism. `reset()` re-renders the route segment that threw. No side effects beyond rendering.

## Screenshots (if UI change)

No screenshot needed - this page only appears when an unhandled error occurs. The layout mirrors `not-found.tsx` exactly (centered card, 72px status code in primary green, heading, description, action buttons).

## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with `main`
- [x] Code works locally and I have tested it
- [x] No `console.log` left in `src/`
- [x] If schema changed — both `schema.sql` and a new migration file are included
- [x] If this is a UI change — I read `DESIGN.md` and followed the design system (colors, spacing, typography, components)
- [x] Docs updated if needed
- [x] PR title follows Conventional Commits format (`feat:`, `fix:`, `docs:`, etc.)
- [x] This PR description is written in my own words
