### PR TITLE
feat(profile): add download profile card

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "framer-motion": "^12.11.4",
+        "html-to-image": "^1.11.13",
         "lucide-react": "^0.511.0",
         "next": "^16.2.6",
         "react": "^19.0.0",
@@ -2484,7 +2485,7 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2494,7 +2495,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -5109,6 +5110,12 @@
       "dependencies": {
         "hermes-estree": "0.25.1"
       }
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
+      "license": "MIT"
     },
     "node_modules/iceberg-js": {
       "version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.11.4",
+    "html-to-image": "^1.11.13",
     "lucide-react": "^0.511.0",
     "next": "^16.2.6",
     "react": "^19.0.0",

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import type { ContributorStats, Org, TechEntry, HeatmapWeek } from "@/types";
+import { toPng } from "html-to-image";
 
 interface GitHubUser {
   login: string;
@@ -96,6 +97,8 @@ export function ProfileView({
     : null;
 
   const [copied, setCopied] = useState(false);
+  const [isDownloading, setIsDownloading] = useState(false);
+  const cardRef = useRef<HTMLDivElement>(null);
 
   const handleCopyLink = async () => {
     try {
@@ -104,6 +107,32 @@ export function ProfileView({
       setTimeout(() => setCopied(false), 2000);
     } catch (err) {
       console.error("Copy to clipboard failed:", err);
+    }
+  };
+
+  const handleDownloadCard = async () => {
+    if (!cardRef.current) return;
+    setIsDownloading(true);
+    try {
+      // Small delay to ensure images have finished rendering
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      const dataUrl = await toPng(cardRef.current, {
+        cacheBust: true,
+        pixelRatio: 2,
+        style: {
+          transform: "scale(1)",
+          transformOrigin: "top left",
+        },
+      });
+      const link = document.createElement("a");
+      link.download = `${user.login}-ossfolio-card.png`;
+      link.href = dataUrl;
+      link.click();
+    } catch (err) {
+      console.error("Failed to download profile card:", err);
+    } finally {
+      setIsDownloading(false);
     }
   };
 
@@ -299,6 +328,58 @@ export function ProfileView({
                     <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
                   </svg>
                   Copy link
+                </>
+              )}
+            </button>
+
+            <button
+              type="button"
+              onClick={handleDownloadCard}
+              disabled={isDownloading}
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: "6px",
+                padding: "7px 14px",
+                fontSize: "13px",
+                fontWeight: 500,
+                color: isDownloading ? "var(--color-ink-mute)" : "var(--color-ink)",
+                backgroundColor: "var(--color-canvas-soft)",
+                border: "1px solid var(--color-hairline-strong)",
+                borderRadius: "6px",
+                cursor: isDownloading ? "not-allowed" : "pointer",
+                lineHeight: 1,
+              }}
+              onMouseEnter={(e) => {
+                if (!isDownloading) {
+                  e.currentTarget.style.borderColor = "var(--color-ink)";
+                  e.currentTarget.style.backgroundColor = "var(--color-hairline)";
+                }
+              }}
+              onMouseLeave={(e) => {
+                if (!isDownloading) {
+                  e.currentTarget.style.borderColor = "var(--color-hairline-strong)";
+                  e.currentTarget.style.backgroundColor = "var(--color-canvas-soft)";
+                }
+              }}
+              aria-label="Download profile card as PNG"
+            >
+              {isDownloading ? (
+                <>
+                  <svg className="animate-spin" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+                    <circle cx="12" cy="12" r="10" stroke="var(--color-hairline-strong)" strokeWidth="4" style={{ opacity: 0.25 }} />
+                    <path fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                  </svg>
+                  Generating...
+                </>
+              ) : (
+                <>
+                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+                    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                    <polyline points="7 10 12 15 17 10" />
+                    <line x1="12" y1="15" x2="12" y2="3" />
+                  </svg>
+                  Download card
                 </>
               )}
             </button>
@@ -672,6 +753,109 @@ export function ProfileView({
           </svg>
         </button>
       )}
+
+      {/* Hidden profile card for download */}
+      <div style={{ position: "fixed", left: "-9999px", top: "-9999px", overflow: "hidden", pointerEvents: "none" }}>
+        <div
+          ref={cardRef}
+          style={{
+            width: "600px",
+            height: "300px",
+            padding: "32px",
+            backgroundColor: "#1c1c1c",
+            border: "1px solid rgba(255, 255, 255, 0.1)",
+            borderRadius: "12px",
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "space-between",
+            boxSizing: "border-box",
+            fontFamily: "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
+          }}
+        >
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: "24px" }}>
+            {/* Left section: user & score */}
+            <div style={{ display: "flex", flexDirection: "column", gap: "24px" }}>
+              {/* User */}
+              <div style={{ display: "flex", gap: "16px", alignItems: "center" }}>
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={user.avatar_url}
+                  alt={displayName}
+                  style={{ width: "64px", height: "64px", borderRadius: "9999px", border: "1px solid rgba(255, 255, 255, 0.15)", objectFit: "cover" }}
+                  crossOrigin="anonymous"
+                />
+                <div>
+                  <div style={{ fontSize: "18px", fontWeight: 600, color: "#ffffff", letterSpacing: "-0.3px", lineHeight: 1.2 }}>
+                    {displayName}
+                  </div>
+                  <div style={{ fontSize: "13px", color: "#9a9a9a", marginTop: "2px" }}>
+                    @{user.login}
+                  </div>
+                </div>
+              </div>
+              {/* Score */}
+              <div>
+                <div style={{ fontSize: "10px", textTransform: "uppercase", letterSpacing: "1px", color: "#9a9a9a", fontWeight: 600 }}>
+                  Contributor Score
+                </div>
+                <div style={{ fontSize: "44px", fontWeight: 700, color: "#3ecf8e", marginTop: "4px", lineHeight: 1 }}>
+                  {score}
+                </div>
+              </div>
+            </div>
+
+            {/* Right section: stats grid */}
+            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "12px", width: "260px" }}>
+              {[
+                { label: "Commits", value: stats.totalCommits },
+                { label: "PRs", value: stats.totalPRs },
+                { label: "Issues", value: stats.totalIssues },
+                { label: "Reviews", value: stats.totalReviews },
+              ].map((stat) => (
+                <div
+                  key={stat.label}
+                  style={{
+                    border: "1px solid rgba(255, 255, 255, 0.08)",
+                    borderRadius: "8px",
+                    padding: "12px 14px",
+                    backgroundColor: "#202020",
+                    display: "flex",
+                    flexDirection: "column",
+                    justifyContent: "center",
+                  }}
+                >
+                  <div style={{ fontSize: "20px", fontWeight: 600, color: "#ffffff", lineHeight: 1.1 }}>
+                    {stat.value.toLocaleString("en-US")}
+                  </div>
+                  <div style={{ fontSize: "11px", color: "#9a9a9a", marginTop: "4px", fontWeight: 500 }}>
+                    {stat.label}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Footer branding */}
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              borderTop: "1px solid rgba(255, 255, 255, 0.08)",
+              paddingTop: "16px",
+              marginTop: "16px",
+            }}
+          >
+            <div style={{ display: "flex", alignItems: "center", gap: "6px" }}>
+              <span style={{ width: "8px", height: "8px", borderRadius: "50%", backgroundColor: "#3ecf8e" }} />
+              <span style={{ fontSize: "14px", fontWeight: 600, color: "#ffffff", letterSpacing: "-0.2px" }}>OSSfolio</span>
+            </div>
+            <span style={{ fontSize: "11px", fontFamily: "ui-monospace, Menlo, Monaco, Consolas, monospace", color: "#707070" }}>
+              ossfolio.qzz.io
+            </span>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

This PR adds a "Download profile card" feature on the contributor profile pages. When clicked, it renders a styled 600×300px horizontal card containing the contributor's avatar, name, `@username`, overall contributor score, and their top 4 stats (Commits, PRs, Issues, and Reviews), and downloads it as a PNG file. This allows contributors to easily share their OSSfolio statistics on LinkedIn, Discord, GitHub, or chat groups.

## Related Issue

Closes #148

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Chore / dependency update

## Changes Made

- Installed the `html-to-image` package for client-side DOM-to-PNG rendering.
- Updated `ProfileView.tsx` to include an off-screen card template styled with OSSfolio's dark theme (`#1c1c1c` canvas-night, `#3ecf8e` primary green score and accents, and white text).
- Enabled `crossOrigin="anonymous"` on the avatar element inside the card to prevent canvas tainting errors when exporting from GitHub's image server.
- Added a "Download card" button with loading/disable state support in the action buttons row.
- Verified TypeScript type checking and Next.js production compilation successfully build without errors.

## AI Usage

- [ ] I did not use AI for any part of the code in this PR
- [x] I used AI for coding (Gemini) and I fully understand every change I made, including which functions I changed, why I changed them, and what side effects they could create

## Screenshots (if UI change)
<img width="746" height="301" alt="Screenshot 2026-06-23 at 3 48 39 PM" src="https://github.com/user-attachments/assets/6b163bc2-3656-4391-9a78-b2f9067fa250" />
<img width="1199" height="697" alt="Screenshot 2026-06-23 at 3 49 20 PM" src="https://github.com/user-attachments/assets/28615fc0-ae0b-40f6-bb98-76d276abd82f" />


## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with `main`
- [x] Code works locally and I have tested it
- [x] No `console.log` left in `src/`
- [x] If schema changed — both `schema.sql` and a new migration file are included
- [x] If this is a UI change — I read `DESIGN.md` and followed the design system (colors, spacing, typography, components)
- [x] Docs updated if needed
- [x] PR title follows Conventional Commits format (`feat:`, `fix:`, `docs:`, etc.)
- [x] This PR description is written in my own words


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now download their profile card as a PNG image. A download button in the profile header initiates the process and displays a loading indicator while generating the image file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->