### PR TITLE
Add custom links and owner check to profile page #137

### DIFF
--- a/src/app/[username]/page.tsx
+++ b/src/app/[username]/page.tsx
@@ -109,17 +109,31 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
 
   let score = liveScore;
   let updatedAt: string | null = null;
+  let customLinks = [];
+  let isOwner = false;
+
   try {
+    // Fetch profile data including the new custom_links column
     const { data: profileRow } = await supabase
       .from("profiles")
-      .select("score, updated_at")
+      .select("score, updated_at, custom_links")
       .eq("username", username)
       .maybeSingle();
+
     if (profileRow && typeof profileRow.score === "number") {
       score = profileRow.score;
     }
     if (profileRow && typeof profileRow.updated_at === "string") {
       updatedAt = profileRow.updated_at;
+    }
+    if (profileRow && profileRow.custom_links) {
+      customLinks = profileRow.custom_links;
+    }
+
+    // Check if the current viewer is the profile owner
+    const { data: { session } } = await supabase.auth.getSession();
+    if (session?.user?.user_metadata?.user_name === username) {
+      isOwner = true;
     }
   } catch {
     // Soft isolation fallback
@@ -137,18 +151,20 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
           transition: "background-color 0.2s ease, color 0.2s ease"
         }}
       >
-        <ProfileView
-          user={user}
-          repos={repos}
-          stats={stats}
-          techStack={techStack}
-          orgs={orgs}
-          heatmap={heatmap}
-          currentStreak={currentStreak}
-          longestStreak={longestStreak}
-          score={score}
-          updatedAt={updatedAt}
-        />
+       <ProfileView
+            user={user}
+            repos={repos}
+            stats={stats}
+            techStack={techStack}
+            orgs={orgs}
+            heatmap={heatmap}
+            currentStreak={currentStreak}
+            longestStreak={longestStreak}
+            score={score}
+            updatedAt={updatedAt}
+            isOwner={isOwner}
+            customLinks={customLinks}
+          />
       </main>
       <Footer />
     </>


### PR DESCRIPTION
Resolves #137

This PR updates the server-side data fetching for the dynamic profile page to support custom user links and edit permissions.

Changes included:
- Updated the Supabase query in `page.tsx` to fetch the new `custom_links` column from the `profiles` table.
- Implemented an authentication check using `supabase.auth.getSession()` to determine if the current viewer is the profile owner (`isOwner`).
- Passed both `customLinks` and `isOwner` down as props to the `<ProfileView>` component to prepare for the frontend UI implementation.

## Summary

<!-- Describe what this PR does and why. Write this in your own words. Do not paste an AI-generated summary here. -->

## Related Issue

Closes #<!-- issue number -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Chore / dependency update

## Changes Made

<!-- Bullet points of what changed and why you made each change -->
- 

## AI Usage

- [ ] I did not use AI for any part of the code in this PR
- [ ] I used AI for coding (specify which tool below) and I fully understand every change I made, including which functions I changed, why I changed them, and what side effects they could create

<!-- If you used AI, write the tool name here, e.g. "Used Claude Code for coding" -->

## Screenshots (if UI change)

<!-- Add before/after screenshots for any visual changes -->

## Checklist

- [ ] I was assigned to the issue before opening this PR
- [ ] My branch is up to date with `main`
- [ ] Code works locally and I have tested it
- [ ] No `console.log` left in `src/`
- [ ] If schema changed — both `schema.sql` and a new migration file are included
- [ ] If this is a UI change — I read `DESIGN.md` and followed the design system (colors, spacing, typography, components)
- [ ] Docs updated if needed
- [ ] PR title follows Conventional Commits format (`feat:`, `fix:`, `docs:`, etc.)
- [ ] This PR description is written in my own words
