### PR TITLE
feat(heatmap): add per-year contribution navigation

### DIFF
--- a/src/app/api/[username]/contributions/route.ts
+++ b/src/app/api/[username]/contributions/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+import { fetchContributionCalendar } from "@/lib/github";
+
+export const runtime = "edge";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ username: string }> }
+) {
+  const { username } = await params;
+  const year = request.nextUrl.searchParams.get("year");
+
+  const from = year ? `${year}-01-01` : undefined;
+  const calendar = await fetchContributionCalendar(username, from);
+
+  if (!calendar) {
+    return NextResponse.json(
+      { error: "Failed to fetch contribution data" },
+      { status: 502 }
+    );
+  }
+
+  return NextResponse.json(calendar, {
+    headers: { "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=600" },
+  });
+}

--- a/src/app/api/[username]/contributions/route.ts
+++ b/src/app/api/[username]/contributions/route.ts
@@ -10,7 +10,18 @@ export async function GET(
   const { username } = await params;
   const year = request.nextUrl.searchParams.get("year");
 
-  const from = year ? `${year}-01-01` : undefined;
+  let from: string | undefined;
+  if (year !== null) {
+    if (!/^\d{4}$/.test(year)) {
+      return NextResponse.json({ error: "Invalid year parameter" }, { status: 400 });
+    }
+    const parsed = parseInt(year, 10);
+    const now = new Date().getFullYear();
+    if (parsed < now - 10 || parsed > now) {
+      return NextResponse.json({ error: "Year out of range" }, { status: 400 });
+    }
+    from = `${year}-01-01`;
+  }
   const calendar = await fetchContributionCalendar(username, from);
 
   if (!calendar) {

--- a/src/components/profile/HeatmapWithYearNav.tsx
+++ b/src/components/profile/HeatmapWithYearNav.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import type { HeatmapWeek } from "@/types";
+import { computeStreaks } from "@/lib/mock";
+
+interface HeatmapWithYearNavProps {
+  username: string;
+  initialWeeks: HeatmapWeek[];
+  initialCurrentStreak: number;
+  initialLongestStreak: number;
+}
+
+const currentYear = new Date().getFullYear();
+const years = Array.from({ length: 5 }, (_, i) => currentYear - i);
+
+export function HeatmapWithYearNav({
+  username,
+  initialWeeks,
+  initialCurrentStreak,
+  initialLongestStreak,
+}: HeatmapWithYearNavProps) {
+  const [selectedYear, setSelectedYear] = useState(currentYear);
+  const [weeks, setWeeks] = useState(initialWeeks);
+  const [currentStreak, setCurrentStreak] = useState(initialCurrentStreak);
+  const [longestStreak, setLongestStreak] = useState(initialLongestStreak);
+  const [loading, setLoading] = useState(false);
+
+  const fetchYear = useCallback(
+    async (year: number) => {
+      if (year === currentYear && initialWeeks.length > 0) {
+        setWeeks(initialWeeks);
+        setCurrentStreak(initialCurrentStreak);
+        setLongestStreak(initialLongestStreak);
+        setSelectedYear(year);
+        return;
+      }
+
+      setLoading(true);
+      setSelectedYear(year);
+      try {
+        const res = await fetch(`/api/${encodeURIComponent(username)}/contributions?year=${year}`);
+        if (!res.ok) throw new Error("fetch failed");
+        const data = await res.json();
+        setWeeks(data.weeks);
+        const streaks = computeStreaks(data.weeks);
+        setCurrentStreak(streaks.current);
+        setLongestStreak(streaks.longest);
+      } catch {
+        setWeeks([]);
+        setCurrentStreak(0);
+        setLongestStreak(0);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [username, initialWeeks, initialCurrentStreak, initialLongestStreak]
+  );
+
+  if (initialWeeks.length === 0 && weeks.length === 0) return null;
+
+  return (
+    <div style={{ marginTop: "44px" }}>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", margin: "0 0 16px 0" }}>
+        <h2 style={{ fontSize: "16px", fontWeight: 600, color: "var(--color-ink)", margin: 0, letterSpacing: "-0.2px" }}>
+          Contribution activity
+        </h2>
+        <div style={{ display: "flex", gap: "6px" }}>
+          {years.map((year) => (
+            <button
+              key={year}
+              type="button"
+              onClick={() => fetchYear(year)}
+              disabled={loading}
+              style={{
+                padding: "4px 10px",
+                fontSize: "12px",
+                fontWeight: selectedYear === year ? 600 : 400,
+                color: selectedYear === year ? "#171717" : "var(--color-ink-mute)",
+                backgroundColor: selectedYear === year ? "#3ecf8e" : "var(--color-canvas-soft)",
+                border: selectedYear === year ? "none" : "1px solid var(--color-hairline)",
+                borderRadius: "9999px",
+                cursor: loading ? "wait" : "pointer",
+                transition: "background-color 0.15s, color 0.15s",
+              }}
+            >
+              {year}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div style={{ display: "flex", flexWrap: "wrap", gap: "8px", margin: "0 0 12px 0" }}>
+        {[
+          { label: "Current streak", value: currentStreak },
+          { label: "Longest streak", value: longestStreak },
+        ].map(({ label, value }) => (
+          <span
+            key={label}
+            style={{
+              display: "inline-flex",
+              alignItems: "baseline",
+              gap: "6px",
+              padding: "6px 12px",
+              border: "1px solid var(--color-hairline)",
+              borderRadius: "9999px",
+              fontSize: "13px",
+              color: "var(--color-ink-mute)",
+              backgroundColor: "var(--color-canvas-soft)",
+            }}
+          >
+            <strong style={{ color: "var(--color-ink)", fontWeight: 600 }}>
+              {value} {value === 1 ? "day" : "days"}
+            </strong>
+            {label}
+          </span>
+        ))}
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          gap: "3px",
+          overflowX: "auto",
+          padding: "16px",
+          border: "1px solid var(--color-hairline)",
+          borderRadius: "12px",
+          backgroundColor: "var(--color-canvas-soft)",
+          opacity: loading ? 0.5 : 1,
+          transition: "opacity 0.2s",
+        }}
+      >
+        {weeks.map((week, wi) => (
+          <div key={wi} style={{ display: "flex", flexDirection: "column", gap: "3px" }}>
+            {week.days.map((day, di) => (
+              <div
+                key={di}
+                title={`${day.count} contributions on ${day.date}`}
+                style={{ width: "11px", height: "11px", borderRadius: "2px", backgroundColor: day.color, flexShrink: 0 }}
+              />
+            ))}
+          </div>
+        ))}
+        {weeks.length === 0 && !loading && (
+          <p style={{ fontSize: "13px", color: "var(--color-ink-mute)", margin: "12px auto" }}>
+            No contribution data available for {selectedYear}.
+          </p>
+        )}
+      </div>
+
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "flex-end", gap: "4px", margin: "10px 0 0 0" }}>
+        <span style={{ fontSize: "12px", color: "var(--color-ink-mute)", marginRight: "2px" }}>Less</span>
+        {["var(--color-hairline)", "#9be9a8", "#40c463", "#30a14e", "#216e39"].map((shade) => (
+          <span
+            key={shade}
+            aria-hidden="true"
+            style={{ width: "11px", height: "11px", borderRadius: "2px", backgroundColor: shade.startsWith("var") ? "rgba(128, 128, 128, 0.1)" : shade, flexShrink: 0 }}
+          />
+        ))}
+        <span style={{ fontSize: "12px", color: "var(--color-ink-mute)", marginLeft: "2px" }}>More</span>
+      </div>
+      <p style={{ fontSize: "12px", color: "var(--color-ink-mute)", margin: "10px 0 0 0" }}>
+        This chart shows an estimate of contribution activity. Exact daily counts are not available for public profiles.
+      </p>
+    </div>
+  );
+}

--- a/src/components/profile/HeatmapWithYearNav.tsx
+++ b/src/components/profile/HeatmapWithYearNav.tsx
@@ -28,7 +28,7 @@ export function HeatmapWithYearNav({
 
   const fetchYear = useCallback(
     async (year: number) => {
-      if (year === selectedYear) return;
+      if (year === selectedYear && weeks.length > 0) return;
       if (year === currentYear && initialWeeks.length > 0) {
         setWeeks(initialWeeks);
         setCurrentStreak(initialCurrentStreak);
@@ -55,7 +55,7 @@ export function HeatmapWithYearNav({
         setLoading(false);
       }
     },
-    [username, selectedYear, initialWeeks, initialCurrentStreak, initialLongestStreak]
+    [username, selectedYear, weeks.length, initialWeeks, initialCurrentStreak, initialLongestStreak]
   );
 
   if (initialWeeks.length === 0 && weeks.length === 0) return null;

--- a/src/components/profile/HeatmapWithYearNav.tsx
+++ b/src/components/profile/HeatmapWithYearNav.tsx
@@ -28,6 +28,7 @@ export function HeatmapWithYearNav({
 
   const fetchYear = useCallback(
     async (year: number) => {
+      if (year === selectedYear) return;
       if (year === currentYear && initialWeeks.length > 0) {
         setWeeks(initialWeeks);
         setCurrentStreak(initialCurrentStreak);
@@ -54,7 +55,7 @@ export function HeatmapWithYearNav({
         setLoading(false);
       }
     },
-    [username, initialWeeks, initialCurrentStreak, initialLongestStreak]
+    [username, selectedYear, initialWeeks, initialCurrentStreak, initialLongestStreak]
   );
 
   if (initialWeeks.length === 0 && weeks.length === 0) return null;

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import Image from "next/image";
 import Link from "next/link";
+import { HeatmapWithYearNav } from "@/components/profile/HeatmapWithYearNav";
 import type { ContributorStats, Org, TechEntry, HeatmapWeek } from "@/types";
 
 interface GitHubUser {
@@ -551,76 +552,14 @@ export function ProfileView({
         </div>
       )}
 
-      {/* Contribution heatmap */}
+      {/* Contribution heatmap with year navigation */}
       {heatmap.length > 0 && (
-        <div style={{ marginTop: "44px" }}>
-          <h2 style={{ fontSize: "16px", fontWeight: 600, color: "var(--color-ink)", margin: "0 0 16px 0", letterSpacing: "-0.2px" }}>
-            Contribution activity
-          </h2>
-          <div style={{ display: "flex", flexWrap: "wrap", gap: "8px", margin: "0 0 12px 0" }}>
-            {[
-              { label: "Current streak", value: currentStreak },
-              { label: "Longest streak", value: longestStreak },
-            ].map(({ label, value }) => (
-              <span
-                key={label}
-                style={{
-                  display: "inline-flex",
-                  alignItems: "baseline",
-                  gap: "6px",
-                  padding: "6px 12px",
-                  border: "1px solid var(--color-hairline)",
-                  borderRadius: "9999px",
-                  fontSize: "13px",
-                  color: "var(--color-ink-mute)",
-                  backgroundColor: "var(--color-canvas-soft)",
-                }}
-              >
-                <strong style={{ color: "var(--color-ink)", fontWeight: 600 }}>
-                  {value} {value === 1 ? "day" : "days"}
-                </strong>
-                {label}
-              </span>
-            ))}
-          </div>
-          <div
-            style={{
-              display: "flex",
-              gap: "3px",
-              overflowX: "auto",
-              padding: "16px",
-              border: "1px solid var(--color-hairline)",
-              borderRadius: "12px",
-              backgroundColor: "var(--color-canvas-soft)",
-            }}
-          >
-            {heatmap.map((week, wi) => (
-              <div key={wi} style={{ display: "flex", flexDirection: "column", gap: "3px" }}>
-                {week.days.map((day, di) => (
-                  <div
-                    key={di}
-                    title={`${day.count} contributions on ${day.date}`}
-                    style={{ width: "11px", height: "11px", borderRadius: "2px", backgroundColor: day.color, flexShrink: 0 }}
-                  />
-                ))}
-              </div>
-            ))}
-          </div>
-          <div style={{ display: "flex", alignItems: "center", justifyContent: "flex-end", gap: "4px", margin: "10px 0 0 0" }}>
-            <span style={{ fontSize: "12px", color: "var(--color-ink-mute)", marginRight: "2px" }}>Less</span>
-            {["var(--color-hairline)", "#9be9a8", "#40c463", "#30a14e", "#216e39"].map((shade) => (
-              <span
-                key={shade}
-                aria-hidden="true"
-                style={{ width: "11px", height: "11px", borderRadius: "2px", backgroundColor: shade.startsWith("var") ? "rgba(128, 128, 128, 0.1)" : shade, flexShrink: 0 }}
-              />
-            ))}
-            <span style={{ fontSize: "12px", color: "var(--color-ink-mute)", marginLeft: "2px" }}>More</span>
-          </div>
-          <p style={{ fontSize: "12px", color: "var(--color-ink-mute)", margin: "10px 0 0 0" }}>
-            This chart shows an estimate of contribution activity. Exact daily counts are not available for public profiles.
-          </p>
-        </div>
+        <HeatmapWithYearNav
+          username={user.login}
+          initialWeeks={heatmap}
+          initialCurrentStreak={currentStreak}
+          initialLongestStreak={longestStreak}
+        />
       )}
 
       {/* Back to top */}

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -220,11 +220,16 @@ export interface ContributionCalendar {
  * fall back gracefully without crashing the page.
  */
 export async function fetchContributionCalendar(
-  username: string
+  username: string,
+  from?: string
 ): Promise<ContributionCalendar | null> {
   try {
+    let url = `https://github.com/users/${encodeURIComponent(username)}/contributions`;
+    if (from) {
+      url += `?from=${encodeURIComponent(from)}`;
+    }
     const res = await fetch(
-      `https://github.com/users/${encodeURIComponent(username)}/contributions`,
+      url,
       {
         headers: {
           // GitHub returns the calendar fragment for a normal browser Accept.


### PR DESCRIPTION
## Summary

Adds year navigation to the contribution heatmap so users can browse their GitHub activity from previous years, not just the current one.

## Related Issue

Closes #154

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Chore / dependency update

## Changes Made

**New files:**
- `src/app/api/[username]/contributions/route.ts` - edge API route that fetches contribution data for a given year by passing `?from=YYYY-01-01` to GitHub's public calendar endpoint
- `src/components/profile/HeatmapWithYearNav.tsx` - client component with year pill selectors and loading state

**Modified files:**
- `src/lib/github.ts` - added optional `from` parameter to `fetchContributionCalendar`
- `src/components/profile/ProfileView.tsx` - replaced the inline heatmap section with the new `HeatmapWithYearNav` component

**How it works:** default view shows the current year (server-rendered, no client fetch). When a user clicks a different year pill, the client component fetches `/api/{username}/contributions?year=YYYY`, which hits GitHub's public contribution endpoint with a `from` date parameter. Streak counts recalculate per selected year.

## AI Usage

- [ ] I did not use AI for any part of the code in this PR
- [x] I used AI for coding (Cursor with Claude) and I fully understand every change I made, including which functions I changed, why I changed them, and what side effects they could create

The API route is an edge function that proxies the existing `fetchContributionCalendar` with a year parameter. The client component uses `useState` + `fetch` to swap heatmap data without a full page reload. The initial render uses server-provided data (zero CLS), and year switches show a loading opacity transition.

## Screenshots (if UI change)

The year selector appears as small green/grey pills above the heatmap (matching DESIGN.md's pill-tag-green/pill-tag-soft pattern). Active year is green (#3ecf8e with dark text), inactive years are grey (canvas-soft with hairline border).

## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with `main`
- [x] Code works locally and I have tested it
- [x] No `console.log` left in `src/`
- [x] If schema changed - both `schema.sql` and a new migration file are included
- [x] If this is a UI change - I read `DESIGN.md` and followed the design system (colors, spacing, typography, components)
- [x] Docs updated if needed
- [x] PR title follows Conventional Commits format (`feat:`, `fix:`, `docs:`, etc.)
- [x] This PR description is written in my own words


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added year navigation to the contributions heatmap (current year plus up to 4 previous years).
  * Selecting a year now loads the corresponding heatmap data and shows streak stats (current and longest).

* **Improvements**
  * Contribution data fetching now supports an optional year filter with validation and improved public caching.
  * The profile view now presents the heatmap through a dedicated year-aware component, including better empty/loading states.

* **Bug Fixes**
  * Hardened year handling to return clear errors for invalid year values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->