### PR TITLE
feat: add /compare page to compare two contributor profiles side by side (Closes - #156)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -301,14 +301,14 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
@@ -323,9 +323,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2485,7 +2485,7 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2495,7 +2495,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -3067,10 +3067,33 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/runtime": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,

--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -1,0 +1,521 @@
+import Image from "next/image";
+import Link from "next/link";
+import type { Metadata } from "next";
+import { Navbar } from "@/components/layout/Navbar";
+import { Footer } from "@/components/layout/Footer";
+import {
+  fetchLiveStats,
+  fetchOrganizations,
+  deriveTechStack,
+  mapRepos,
+} from "@/lib/profile-data";
+import { fetchContributionCalendar } from "@/lib/github";
+import { generateMockHeatmap } from "@/lib/mock";
+import { calculateScore } from "@/lib/score";
+import { supabase } from "@/lib/supabase";
+import type { ContributorStats, Repo } from "@/types";
+import { CompareForm } from "@/components/profile/CompareForm";
+
+export const runtime = "edge";
+
+export const metadata: Metadata = {
+  title: "Compare Contributors - OSSfolio",
+  description:
+    "Compare two open-source contributor profiles side by side on OSSfolio.",
+};
+
+/* -------------------------------------------------------------------------- */
+/* Data fetching — mirrors [username]/page.tsx but wrapped in try/catch        */
+/* -------------------------------------------------------------------------- */
+
+interface ProfileData {
+  user: Record<string, unknown>;
+  stats: ContributorStats;
+  repos: Repo[];
+  score: number;
+}
+
+async function fetchGitHubUser(username: string) {
+  const encodedUsername = encodeURIComponent(username);
+  const res = await fetch(`https://api.github.com/users/${encodedUsername}`, {
+    headers: { Accept: "application/vnd.github.v3+json" },
+    next: { revalidate: 3600 },
+  });
+  if (res.status === 404) return null;
+  if (!res.ok) {
+    throw new Error(`GitHub user lookup failed (${res.status})`);
+  }
+  return res.json();
+}
+
+async function fetchGitHubRepos(username: string) {
+  // GitHub's /users/{username}/repos endpoint does not support sort=stars
+  // (only created, updated, pushed, full_name). Fetch a page of repos with a
+  // supported sort, then order by stargazers_count client-side for the top 6.
+  const res = await fetch(
+    `https://api.github.com/users/${encodeURIComponent(username)}/repos?sort=updated&per_page=100&type=owner`,
+    {
+      headers: { Accept: "application/vnd.github.v3+json" },
+      next: { revalidate: 3600 },
+    }
+  );
+  if (!res.ok) {
+    throw new Error(`GitHub repositories lookup failed (${res.status})`);
+  }
+  const repos = await res.json();
+  return repos
+    .filter((r: { fork: boolean }) => !r.fork)
+    .sort(
+      (a: { stargazers_count: number }, b: { stargazers_count: number }) =>
+        (b.stargazers_count ?? 0) - (a.stargazers_count ?? 0)
+    )
+    .slice(0, 6);
+}
+
+async function fetchProfile(username: string): Promise<ProfileData> {
+  const [user, repos, liveStats, contributionCalendar] = await Promise.all([
+    fetchGitHubUser(username),
+    fetchGitHubRepos(username),
+    fetchLiveStats(username),
+    fetchContributionCalendar(username),
+  ]);
+
+  if (!user) throw new Error(`GitHub user "${username}" not found`);
+
+  const mappedRepos = mapRepos(repos);
+
+  const { totalContributions } = contributionCalendar
+    ? contributionCalendar
+    : generateMockHeatmap(username);
+
+  const stats = { ...liveStats, totalContributions };
+  const liveScore = calculateScore(stats, mappedRepos);
+
+  let score = liveScore;
+  try {
+    const { data: profileRow } = await supabase
+      .from("profiles")
+      .select("score")
+      .eq("username", username)
+      .maybeSingle();
+    if (profileRow && typeof profileRow.score === "number") {
+      score = profileRow.score;
+    }
+  } catch {
+    // Soft fallback to live score
+  }
+
+  return { user, stats, repos: mappedRepos, score };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Page component                                                             */
+/* -------------------------------------------------------------------------- */
+
+interface ComparePageProps {
+  searchParams: Promise<{ a?: string | string[]; b?: string | string[] }>;
+}
+
+export default async function ComparePage({ searchParams }: ComparePageProps) {
+  const raw = await searchParams;
+  const pick = (v: string | string[] | undefined) =>
+    Array.isArray(v) ? v[0] : v;
+  const a = pick(raw.a)?.trim();
+  const b = pick(raw.b)?.trim();
+
+  // ── No params → show the entry form ──────────────────────────────────────
+  if (!a || !b) {
+    return (
+      <>
+        <Navbar />
+        <main
+          style={{
+            backgroundColor: "var(--color-canvas)",
+            color: "var(--color-ink)",
+            minHeight: "100vh",
+            transition: "background-color 0.2s ease, color 0.2s ease",
+          }}
+        >
+          <div style={{ maxWidth: "72rem", margin: "0 auto", padding: "56px 20px" }}>
+            <header style={{ marginBottom: "32px" }}>
+              <h1
+                style={{
+                  fontSize: "28px",
+                  fontWeight: 500,
+                  color: "var(--color-ink)",
+                  letterSpacing: "-0.42px",
+                  margin: 0,
+                }}
+              >
+                Compare Contributors
+              </h1>
+              <p
+                style={{
+                  fontSize: "15px",
+                  color: "var(--color-ink-mute)",
+                  margin: "8px 0 0 0",
+                }}
+              >
+                Enter two GitHub usernames to compare their open-source stats side by side.
+              </p>
+            </header>
+
+            <CompareForm />
+          </div>
+        </main>
+        <Footer />
+      </>
+    );
+  }
+
+  // ── Fetch both profiles in parallel; each wrapped in its own try/catch ───
+  const normalizeError = (err: unknown) =>
+      err instanceof Error ? err : new Error("Failed to load profile");
+
+    const [resultA, resultB] = await Promise.all([
+    fetchProfile(a).catch(normalizeError),
+    fetchProfile(b).catch(normalizeError),
+  ]);
+
+  const profileA = resultA instanceof Error ? null : resultA;
+  const profileB = resultB instanceof Error ? null : resultB;
+  const errorA = resultA instanceof Error ? resultA.message : null;
+  const errorB = resultB instanceof Error ? resultB.message : null;
+
+  // ── Stat rows to compare ────────────────────────────────────────────────
+  const statRows: { label: string; key: keyof ContributorStats }[] = [
+    { label: "Commits", key: "totalCommits" },
+    { label: "Pull Requests", key: "totalPRs" },
+    { label: "Issues", key: "totalIssues" },
+    { label: "Reviews", key: "totalReviews" },
+    { label: "Contributions", key: "totalContributions" },
+  ];
+
+  const numberFormatter = new Intl.NumberFormat("en-US");
+
+  const winnerScore =
+    profileA && profileB
+      ? profileA.score > profileB.score
+        ? "a"
+        : profileA.score < profileB.score
+          ? "b"
+          : null
+      : null;
+
+  return (
+    <>
+      <Navbar />
+      <main
+        style={{
+          backgroundColor: "var(--color-canvas)",
+          color: "var(--color-ink)",
+          minHeight: "100vh",
+          transition: "background-color 0.2s ease, color 0.2s ease",
+        }}
+      >
+        <div style={{ maxWidth: "72rem", margin: "0 auto", padding: "56px 20px" }}>
+          {/* Header */}
+          <header style={{ marginBottom: "32px" }}>
+            <h1
+              style={{
+                fontSize: "28px",
+                fontWeight: 500,
+                color: "var(--color-ink)",
+                letterSpacing: "-0.42px",
+                margin: 0,
+              }}
+            >
+              Compare Contributors
+            </h1>
+            <p
+              style={{
+                fontSize: "15px",
+                color: "var(--color-ink-mute)",
+                margin: "8px 0 0 0",
+              }}
+            >
+              {a} vs {b}
+            </p>
+          </header>
+
+          {/* Search again */}
+          <CompareForm defaultA={a} defaultB={b} />
+
+          {/* Two-column profile headers */}
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "1fr 1fr",
+              gap: "24px",
+              marginTop: "32px",
+            }}
+            className="compare-grid"
+          >
+            {/* ── Column A ──────────────────────────────────────────── */}
+            {errorA ? (
+              <div
+                style={{
+                  border: "1px solid var(--color-hairline)",
+                  borderRadius: "12px",
+                  padding: "32px 24px",
+                  textAlign: "center",
+                }}
+              >
+                <p style={{ fontSize: "15px", fontWeight: 500, color: "var(--color-ink)", margin: 0 }}>
+                  Could not load @{a}
+                </p>
+                <p style={{ fontSize: "13px", color: "var(--color-ink-mute)", margin: "6px 0 0 0" }}>
+                  {errorA}
+                </p>
+              </div>
+            ) : profileA ? (
+              <ProfileColumn
+                user={profileA.user}
+                score={profileA.score}
+                isWinner={winnerScore === "a"}
+              />
+            ) : null}
+
+            {/* ── Column B ──────────────────────────────────────────── */}
+            {errorB ? (
+              <div
+                style={{
+                  border: "1px solid var(--color-hairline)",
+                  borderRadius: "12px",
+                  padding: "32px 24px",
+                  textAlign: "center",
+                }}
+              >
+                <p style={{ fontSize: "15px", fontWeight: 500, color: "var(--color-ink)", margin: 0 }}>
+                  Could not load @{b}
+                </p>
+                <p style={{ fontSize: "13px", color: "var(--color-ink-mute)", margin: "6px 0 0 0" }}>
+                  {errorB}
+                </p>
+              </div>
+            ) : profileB ? (
+              <ProfileColumn
+                user={profileB.user}
+                score={profileB.score}
+                isWinner={winnerScore === "b"}
+              />
+            ) : null}
+          </div>
+
+          {/* Comparison table */}
+          {profileA && profileB && (
+            <div
+              style={{
+                marginTop: "32px",
+                border: "1px solid var(--color-hairline)",
+                borderRadius: "12px",
+                overflow: "hidden",
+              }}
+            >
+              {/* Score row */}
+              <div
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "1fr 1fr 1fr",
+                  borderBottom: "1px solid var(--color-hairline)",
+                  backgroundColor: "var(--color-canvas-soft)",
+                }}
+              >
+                <span
+                  style={{
+                    padding: "14px 18px",
+                    fontSize: "18px",
+                    fontWeight: 600,
+                    color: winnerScore === "a" ? "var(--color-primary)" : "var(--color-ink)",
+                    textAlign: "center",
+                  }}
+                >
+                  {profileA.score}
+                </span>
+                <span
+                  style={{
+                    padding: "14px 18px",
+                    fontSize: "14px",
+                    fontWeight: 500,
+                    color: "var(--color-ink-mute)",
+                    textAlign: "center",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                  }}
+                >
+                  Score
+                </span>
+                <span
+                  style={{
+                    padding: "14px 18px",
+                    fontSize: "18px",
+                    fontWeight: 600,
+                    color: winnerScore === "b" ? "var(--color-primary)" : "var(--color-ink)",
+                    textAlign: "center",
+                  }}
+                >
+                  {profileB.score}
+                </span>
+              </div>
+
+              {/* Stat rows */}
+              {statRows.map((row) => {
+                const valA = profileA.stats[row.key];
+                const valB = profileB.stats[row.key];
+                const aWins = valA > valB;
+                const bWins = valB > valA;
+
+                return (
+                  <div
+                    key={row.key}
+                    style={{
+                      display: "grid",
+                      gridTemplateColumns: "1fr 1fr 1fr",
+                      borderBottom: "1px solid var(--color-hairline)",
+                    }}
+                  >
+                    <span
+                      style={{
+                        padding: "12px 18px",
+                        fontSize: "15px",
+                        fontWeight: aWins ? 600 : 400,
+                        color: aWins ? "var(--color-primary)" : "var(--color-ink)",
+                        textAlign: "center",
+                      }}
+                    >
+                      {numberFormatter.format(valA)}
+                    </span>
+                    <span
+                      style={{
+                        padding: "12px 18px",
+                        fontSize: "13px",
+                        fontWeight: 500,
+                        color: "var(--color-ink-mute)",
+                        textAlign: "center",
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                      }}
+                    >
+                      {row.label}
+                    </span>
+                    <span
+                      style={{
+                        padding: "12px 18px",
+                        fontSize: "15px",
+                        fontWeight: bWins ? 600 : 400,
+                        color: bWins ? "var(--color-primary)" : "var(--color-ink)",
+                        textAlign: "center",
+                      }}
+                    >
+                      {numberFormatter.format(valB)}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </main>
+      <Footer />
+
+      {/* Responsive: stack columns on mobile */}
+      <style>{`
+        @media (max-width: 767px) {
+          .compare-grid { grid-template-columns: 1fr !important; }
+        }
+      `}</style>
+    </>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Profile column sub-component                                               */
+/* -------------------------------------------------------------------------- */
+
+function ProfileColumn({
+  user,
+  score,
+  isWinner,
+}: {
+  user: Record<string, unknown>;
+  score: number;
+  isWinner: boolean;
+}) {
+  const username = user.login as string;
+  const name = (user.name as string | null) || username;
+  const avatarUrl = user.avatar_url as string;
+
+  return (
+    <div
+      style={{
+        border: `1px solid ${isWinner ? "var(--color-primary)" : "var(--color-hairline)"}`,
+        borderRadius: "12px",
+        padding: "24px",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: "12px",
+        textAlign: "center",
+        transition: "border-color 0.2s ease",
+      }}
+    >
+      <Link href={`/${username}`}>
+        <Image
+          src={avatarUrl}
+          alt={`${name} avatar`}
+          width={72}
+          height={72}
+          style={{
+            borderRadius: "9999px",
+            border: "1px solid var(--color-hairline)",
+          }}
+        />
+      </Link>
+      <div>
+        <Link
+          href={`/${username}`}
+          style={{
+            fontSize: "16px",
+            fontWeight: 600,
+            color: "var(--color-ink)",
+            textDecoration: "none",
+          }}
+        >
+          {name}
+        </Link>
+        <p
+          style={{
+            fontSize: "13px",
+            color: "var(--color-ink-mute)",
+            margin: "2px 0 0 0",
+          }}
+        >
+          @{username}
+        </p>
+      </div>
+      <div>
+        <span
+          style={{
+            fontSize: "22px",
+            fontWeight: 500,
+            color: isWinner ? "var(--color-primary)" : "var(--color-ink)",
+            letterSpacing: "-0.42px",
+          }}
+        >
+          {score}
+        </span>
+        <p
+          style={{
+            fontSize: "12px",
+            color: "var(--color-ink-mute)",
+            margin: "2px 0 0 0",
+          }}
+        >
+          contributor score
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/profile/CompareForm.tsx
+++ b/src/components/profile/CompareForm.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+interface CompareFormProps {
+  defaultA?: string;
+  defaultB?: string;
+}
+
+const inputStyle: React.CSSProperties = {
+  flex: 1,
+  minWidth: 0,
+  padding: "10px 12px",
+  fontSize: "14px",
+  fontWeight: 400,
+  color: "var(--color-ink)",
+  backgroundColor: "var(--color-canvas)",
+  border: "1px solid var(--color-hairline)",
+  borderRadius: "6px",
+  outline: "none",
+  transition: "border-color 0.2s ease",
+};
+
+export function CompareForm({ defaultA = "", defaultB = "" }: CompareFormProps) {
+  const router = useRouter();
+  const [a, setA] = useState(defaultA);
+  const [b, setB] = useState(defaultB);
+
+  function handleSubmit() {
+    const trimA = a.trim();
+    const trimB = b.trim();
+    if (!trimA || !trimB) return;
+    router.push(`/compare?a=${encodeURIComponent(trimA)}&b=${encodeURIComponent(trimB)}`);
+  }
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexWrap: "wrap",
+        gap: "12px",
+        alignItems: "center",
+      }}
+    >
+      <input
+        type="text"
+        value={a}
+        onChange={(e) => setA(e.target.value)}
+        placeholder="Username A"
+        aria-label="First GitHub username"
+        style={inputStyle}
+        onFocus={(e) => (e.currentTarget.style.borderColor = "var(--color-primary)")}
+        onBlur={(e) => (e.currentTarget.style.borderColor = "var(--color-hairline)")}
+        onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
+      />
+      <span
+        style={{
+          fontSize: "14px",
+          fontWeight: 500,
+          color: "var(--color-ink-mute)",
+        }}
+      >
+        vs
+      </span>
+      <input
+        type="text"
+        value={b}
+        onChange={(e) => setB(e.target.value)}
+        placeholder="Username B"
+        aria-label="Second GitHub username"
+        style={inputStyle}
+        onFocus={(e) => (e.currentTarget.style.borderColor = "var(--color-primary)")}
+        onBlur={(e) => (e.currentTarget.style.borderColor = "var(--color-hairline)")}
+        onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
+      />
+      <button
+        type="button"
+        onClick={handleSubmit}
+        style={{
+          fontSize: "14px",
+          fontWeight: 500,
+          backgroundColor: "var(--color-primary)",
+          color: "var(--color-on-primary)",
+          border: "none",
+          borderRadius: "6px",
+          padding: "10px 20px",
+          cursor: "pointer",
+          flexShrink: 0,
+          transition: "background-color 0.2s ease, outline-color 0.2s ease",
+          outline: "2px solid transparent",
+          outlineOffset: "2px",
+        }}
+        onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = "var(--color-primary-deep)")}
+        onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = "var(--color-primary)")}
+        onFocus={(e) => (e.currentTarget.style.outlineColor = "var(--color-primary)")}
+        onBlur={(e) => (e.currentTarget.style.outlineColor = "transparent")}
+      >
+        Compare
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Built the `/compare` page requested in #156. It accepts two GitHub usernames via URL params (`/compare?a=user1&b=user2`) and renders their contributor profiles side by side with a stat-by-stat comparison table. Visiting `/compare` with no params shows a form to enter two usernames.

The page follows the same server-component data pipeline as the existing `[username]/page.tsx` — fetching both profiles in parallel via `Promise.all`, each wrapped in its own `try/catch` so one failing username only errors its own column while the other still renders. Styling uses the project's CSS variable tokens from DESIGN.md throughout, with the emerald primary (#3ecf8e) highlighting the winner's score and higher stat values.

## Related Issue

Closes #156

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Chore / dependency update

## Changes Made

- Added `src/app/compare/page.tsx` — server component with edge runtime that reads `a` and `b` from `searchParams`, fetches both profiles in parallel (GitHub REST + Search API + Supabase score override, same pipeline as the profile page), and renders a two-column comparison layout at max-width 72rem
- Added `src/components/profile/CompareForm.tsx` — client component (`"use client"`) with two inputs and a Compare button that navigates via `useRouter.push`
- Profile cards show avatar (linked to OSSfolio profile), display name, username, and contributor score — the winner's score is highlighted in emerald
- Comparison table rows: Score, Commits, PRs, Issues, Reviews, Contributions — each row highlights the higher value in green (#3ecf8e)
- Error handling: each profile fetch is independently `try/catch`-wrapped; a failed profile shows an error message in its column without crashing the page or the other column
- Responsive: two-column grid collapses to single-column below 768px
- No new dependencies added

## AI Usage

- [x] I used AI for coding (specify which tool below) and I fully understand every change I made, including which functions I changed, why I changed them, and what side effects they could create

Used Claude for coding. The page follows the same data-fetching pattern as the existing `[username]/page.tsx` (fetchGitHubUser, fetchGitHubRepos, fetchLiveStats, fetchContributionCalendar, calculateScore with Supabase override). The CompareForm is a standard `"use client"` component using `useRouter` for client-side navigation. I understand the full data flow and can explain any part of the implementation.

## Screenshots (if UI change)

<img width="1915" height="991" alt="Screenshot 2026-06-24 042428" src="https://github.com/user-attachments/assets/a250d1e8-98b5-4aa7-b60a-05b1e7cdf952" />
<img width="1898" height="987" alt="Screenshot 2026-06-24 042500" src="https://github.com/user-attachments/assets/2e1756c2-1987-470e-9306-111c9b66f6d2" />


## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with `main`
- [x] Code works locally and I have tested it
- [x] No `console.log` left in `src/`
- [ ] If schema changed — both `schema.sql` and a new migration file are included
- [x] If this is a UI change — I read `DESIGN.md` and followed the design system (colors, spacing, typography, components)
- [ ] Docs updated if needed
- [x] PR title follows Conventional Commits format (`feat:`, `fix:`, `docs:`, etc.)
- [x] This PR description is written in my own words

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Edge-runtime contributor comparison page to enter two GitHub usernames, fetch their stats concurrently, and display side-by-side scores, key metrics, contribution activity, and top repositories.
  * Added a comparison form with optional prefilled usernames; it navigates only when both trimmed values are provided (Enter or button).
* **UI Improvements**
  * Improved responsiveness by stacking the comparison layout on smaller screens and visually highlighting the winner.
* **Bug Fixes**
  * Added graceful per-profile error states, a fallback for missing contribution calendars, and non-blocking handling of optional score overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->