### PR TITLE
feat(repos): add sort options (stars/forks/recently updated) to Popular Repositories

### DIFF
--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -809,11 +809,12 @@ export function ProfileView({
           <h2 style={{ fontSize: "16px", fontWeight: 600, color: "var(--color-ink)", margin: 0, letterSpacing: "-0.2px" }}>
             Popular repositories
           </h2>
-          <div style={{ display: "flex", gap: "6px" }}>
+          <div role="group" aria-label="Sort popular repositories" style={{ display: "flex", gap: "6px" }}>
             {(["stars", "forks", "updated"] as const).map((option) => (
               <button
                 key={option}
                 type="button"
+                aria-pressed={repoSort === option}
                 onClick={() => setRepoSort(option)}
                 style={{
                   padding: "4px 10px",

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -32,6 +32,7 @@ interface GitHubRepo {
   forks_count: number;
   language: string | null;
   topics?: string[];
+  pushed_at?: string;
 }
 
 
@@ -112,6 +113,7 @@ export function ProfileView({
   rateLimited,
 }: { user: GitHubUser; repos: GitHubRepo[] } & ProfileExtras & { rateLimited?: boolean }) {
   const [copied, setCopied] = useState(false);
+  const [repoSort, setRepoSort] = useState<"stars" | "forks" | "updated">("stars");
   const [isDownloading, setIsDownloading] = useState(false);
   const cardRef = useRef<HTMLDivElement>(null);
   const [showBackToTop, setShowBackToTop] = useState(false);
@@ -803,9 +805,32 @@ export function ProfileView({
 
       {/* Repos */}
       <div style={{ marginTop: "40px" }}>
-        <h2 style={{ fontSize: "16px", fontWeight: 600, color: "var(--color-ink)", margin: "0 0 20px 0", letterSpacing: "-0.2px" }}>
-          Popular repositories
-        </h2>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", margin: "0 0 20px 0", flexWrap: "wrap", gap: "12px" }}>
+          <h2 style={{ fontSize: "16px", fontWeight: 600, color: "var(--color-ink)", margin: 0, letterSpacing: "-0.2px" }}>
+            Popular repositories
+          </h2>
+          <div style={{ display: "flex", gap: "6px" }}>
+            {(["stars", "forks", "updated"] as const).map((option) => (
+              <button
+                key={option}
+                type="button"
+                onClick={() => setRepoSort(option)}
+                style={{
+                  padding: "4px 10px",
+                  fontSize: "12px",
+                  fontWeight: repoSort === option ? 600 : 400,
+                  color: repoSort === option ? "#171717" : "var(--color-ink-mute)",
+                  backgroundColor: repoSort === option ? "#3ecf8e" : "var(--color-canvas-soft)",
+                  border: repoSort === option ? "none" : "1px solid var(--color-hairline)",
+                  borderRadius: "9999px",
+                  cursor: "pointer",
+                }}
+              >
+                {option === "stars" ? "Stars" : option === "forks" ? "Forks" : "Recent"}
+              </button>
+            ))}
+          </div>
+        </div>
 
         {repos.length === 0 ? (
           <p style={{ fontSize: "13px", color: "var(--color-ink-mute)", margin: 0 }}>
@@ -814,7 +839,11 @@ export function ProfileView({
         ) : (
           <>
           <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))", gap: "16px" }}>
-            {repos.map((repo) => (
+            {[...repos].sort((a, b) => {
+              if (repoSort === "forks") return b.forks_count - a.forks_count;
+              if (repoSort === "updated") return (b.pushed_at || "").localeCompare(a.pushed_at || "");
+              return b.stargazers_count - a.stargazers_count;
+            }).map((repo) => (
               <a
                 key={repo.id}
                 href={repo.html_url}


### PR DESCRIPTION
## Summary

Adds sort controls to the Popular Repositories section so users can reorder by stars, forks, or most recently updated.

## Related Issue

Closes #144

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Chore / dependency update

## Changes Made

Single file: `src/components/profile/ProfileView.tsx`

1. Added `pushed_at?: string` to `GitHubRepo` interface (GitHub REST API always returns this field)
2. Added `repoSort` state variable (stars/forks/updated, defaults to stars)
3. Replaced the "Popular repositories" heading with a heading + pill sort buttons row
4. Sort is applied client-side using `[...repos].sort()` on a copy (never mutates the prop)
5. Pill buttons use the same green/grey style as the year navigation pills (DESIGN.md pill-tag-green for active, pill-tag-soft for inactive)

## AI Usage

- [ ] I did not use AI for any part of the code in this PR
- [x] I used AI for coding (Cursor with Claude) and I fully understand every change I made, including which functions I changed, why I changed them, and what side effects they could create

The sort creates a shallow copy with spread to avoid mutating the prop. `pushed_at` is an ISO date string so `localeCompare` gives correct chronological ordering. Stars/forks use numeric subtraction for descending sort.

## Screenshots (if UI change)

Three small pill buttons ("Stars" | "Forks" | "Recent") appear to the right of the "Popular repositories" heading. The active one is green, inactive ones are grey with a hairline border.

## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with `main`
- [x] Code works locally and I have tested it
- [x] No `console.log` left in `src/`
- [x] If schema changed - both `schema.sql` and a new migration file are included
- [x] If this is a UI change - I read `DESIGN.md` and followed the design system (colors, spacing, typography, components)
- [x] Docs updated if needed
- [x] PR title follows Conventional Commits format (`feat:`, `fix:`, `docs:`, etc.)
- [x] This PR description is written in my own words


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added client-side pill sorting for the “Popular repositories” section (Stars, Forks, Recent).
  * Sorting updates instantly and visually indicates the active mode for better accessibility.
* **UI Improvements**
  * Refreshed the repositories header layout so the sort controls sit alongside the section title, while the displayed list continues to follow the existing text filter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->