### PR TITLE
feat: implement visual side-by-side stats comparison dashboard 

### DIFF
--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -416,9 +416,57 @@ export default async function ComparePage({ searchParams }: ComparePageProps) {
               })}
             </div>
           )}
+
+          {profileA && profileB && (
+            <div style={{ marginTop: "32px", border: "1px solid var(--color-hairline)", borderRadius: "12px", padding: "24px", backgroundColor: "var(--color-canvas-soft)" }}>
+              <h3 style={{ fontSize: "16px", fontWeight: 600, color: "var(--color-ink)", marginBottom: "16px" }}>Visual Stats Comparison</h3>
+              <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: "16px" }}>
+                {[
+                  { label: "Score", valA: profileA.score, valB: profileB.score },
+                  { label: "Commits", valA: profileA.stats.totalCommits, valB: profileB.stats.totalCommits },
+                  { label: "PRs", valA: profileA.stats.totalPRs, valB: profileB.stats.totalPRs },
+                  { label: "Issues", valA: profileA.stats.totalIssues, valB: profileB.stats.totalIssues },
+                  { label: "Reviews", valA: profileA.stats.totalReviews, valB: profileB.stats.totalReviews }
+                ].map((item) => {
+                  const maxVal = Math.max(item.valA, item.valB, 1);
+                  const pctA = Math.round((item.valA / maxVal) * 100);
+                  const pctB = Math.round((item.valB / maxVal) * 100);
+
+                  return (
+                    <div key={item.label} style={{ display: "flex", flexDirection: "column", gap: "8px", padding: "16px", border: "1px solid var(--color-hairline)", borderRadius: "8px", backgroundColor: "var(--color-canvas)" }}>
+                      <span style={{ fontSize: "13px", fontWeight: 600, color: "var(--color-ink-mute)" }}>{item.label}</span>
+                      
+                      {/* Contributor A Bar */}
+                      <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+                        <div style={{ display: "flex", justifyContent: "space-between", fontSize: "11px" }}>
+                          <span style={{ color: "var(--color-ink)", fontWeight: 500 }}>@{a}</span>
+                          <span style={{ color: "var(--color-ink)" }}>{item.valA}</span>
+                        </div>
+                        <div style={{ height: "6px", width: "100%", backgroundColor: "var(--color-hairline)", borderRadius: "3px", overflow: "hidden" }}>
+                          <div style={{ height: "100%", width: `${pctA}%`, backgroundColor: "var(--color-primary)", borderRadius: "3px" }} />
+                        </div>
+                      </div>
+
+                      {/* Contributor B Bar */}
+                      <div style={{ display: "flex", flexDirection: "column", gap: "4px", marginTop: "4px" }}>
+                        <div style={{ display: "flex", justifyContent: "space-between", fontSize: "11px" }}>
+                          <span style={{ color: "var(--color-ink)", fontWeight: 500 }}>@{b}</span>
+                          <span style={{ color: "var(--color-ink)" }}>{item.valB}</span>
+                        </div>
+                        <div style={{ height: "6px", width: "100%", backgroundColor: "var(--color-hairline)", borderRadius: "3px", overflow: "hidden" }}>
+                          <div style={{ height: "100%", width: `${pctB}%`, backgroundColor: "var(--color-accent-violet)", borderRadius: "3px" }} />
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
         </div>
       </main>
       <Footer />
+
 
       {/* Responsive: stack columns on mobile */}
       <style>{`


### PR DESCRIPTION
# Related Issue
Closes #206

# Summary
This PR integrates a new "Visual Stats Comparison" card layout on the comparison screen to compare two users side-by-side.

# Changes Made
- Added a visual compare section beneath the comparison table.
- Computed percentage ratios for Score, Commits, PRs, Issues, and Reviews.
- Designed dynamic, themed progress bars responsive to mobile scaling.

# Testing
- Tested rendering with various user pairs.
- Checked theme support (light and dark modes).
- Validated build success.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visual stats comparison section to the compare results view when both profiles load successfully.
  * Introduced side-by-side bar indicators and percentage-based stat cards for score, commits, PRs, issues, and reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->