### PR TITLE
feat(profile): add background refresh system with freshness indicator

### DIFF
--- a/src/app/api/[username]/refresh/route.ts
+++ b/src/app/api/[username]/refresh/route.ts
@@ -6,6 +6,7 @@ const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
 const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
 
 const RATE_LIMIT_MS = 10 * 60 * 1000;
+const GITHUB_USERNAME_REGEX = /^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$/;
 
 export async function POST(
   request: NextRequest,
@@ -13,7 +14,7 @@ export async function POST(
 ) {
   const { username } = await params;
 
-  if (!username || username.length > 39) {
+  if (!username || username.length > 39 || !GITHUB_USERNAME_REGEX.test(username)) {
     return NextResponse.json(
       { error: "Invalid username" },
       { status: 400 }
@@ -22,40 +23,43 @@ export async function POST(
 
   const supabase = createClient(supabaseUrl, supabaseServiceKey);
 
-  const { data: profile, error } = await supabase
+  const cutoff = new Date(Date.now() - RATE_LIMIT_MS).toISOString();
+
+  const { data, error, count } = await supabase
     .from("profiles")
-    .select("username, last_refreshed_at")
+    .update({
+      last_refreshed_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    })
     .eq("username", username)
+    .or(`last_refreshed_at.is.null,last_refreshed_at.lt.${cutoff}`)
+    .select("username")
     .single();
 
-  if (error || !profile) {
-    return NextResponse.json(
-      { error: "Profile not found" },
-      { status: 404 }
-    );
-  }
+  if (error && error.code === "PGRST116") {
+    const { data: exists } = await supabase
+      .from("profiles")
+      .select("username, last_refreshed_at")
+      .eq("username", username)
+      .single();
 
-  const lastRefresh = profile.last_refreshed_at
-    ? new Date(profile.last_refreshed_at).getTime()
-    : 0;
-  const now = Date.now();
+    if (!exists) {
+      return NextResponse.json({ error: "Profile not found" }, { status: 404 });
+    }
 
-  if (now - lastRefresh < RATE_LIMIT_MS) {
-    const retryAfter = Math.ceil((RATE_LIMIT_MS - (now - lastRefresh)) / 1000);
+    const lastRefresh = exists.last_refreshed_at
+      ? new Date(exists.last_refreshed_at).getTime()
+      : 0;
+    const retryAfter = Math.ceil((RATE_LIMIT_MS - (Date.now() - lastRefresh)) / 1000);
     return NextResponse.json(
-      { error: "Rate limited. Try again later.", retryAfterSeconds: retryAfter },
+      { error: "Rate limited. Try again later.", retryAfterSeconds: Math.max(retryAfter, 1) },
       { status: 429 }
     );
   }
 
-  const { error: updateError } = await supabase
-    .from("profiles")
-    .update({ last_refreshed_at: new Date().toISOString(), updated_at: new Date().toISOString() })
-    .eq("username", username);
-
-  if (updateError) {
+  if (error) {
     return NextResponse.json(
-      { error: "Failed to update refresh timestamp" },
+      { error: "Failed to refresh profile" },
       { status: 500 }
     );
   }

--- a/src/app/api/[username]/refresh/route.ts
+++ b/src/app/api/[username]/refresh/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
+import { createClient } from "@supabase/supabase-js";
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+
+const RATE_LIMIT_MS = 10 * 60 * 1000;
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ username: string }> }
+) {
+  const { username } = await params;
+
+  if (!username || username.length > 39) {
+    return NextResponse.json(
+      { error: "Invalid username" },
+      { status: 400 }
+    );
+  }
+
+  const supabase = createClient(supabaseUrl, supabaseServiceKey);
+
+  const { data: profile, error } = await supabase
+    .from("profiles")
+    .select("username, last_refreshed_at")
+    .eq("username", username)
+    .single();
+
+  if (error || !profile) {
+    return NextResponse.json(
+      { error: "Profile not found" },
+      { status: 404 }
+    );
+  }
+
+  const lastRefresh = profile.last_refreshed_at
+    ? new Date(profile.last_refreshed_at).getTime()
+    : 0;
+  const now = Date.now();
+
+  if (now - lastRefresh < RATE_LIMIT_MS) {
+    const retryAfter = Math.ceil((RATE_LIMIT_MS - (now - lastRefresh)) / 1000);
+    return NextResponse.json(
+      { error: "Rate limited. Try again later.", retryAfterSeconds: retryAfter },
+      { status: 429 }
+    );
+  }
+
+  const { error: updateError } = await supabase
+    .from("profiles")
+    .update({ last_refreshed_at: new Date().toISOString(), updated_at: new Date().toISOString() })
+    .eq("username", username);
+
+  if (updateError) {
+    return NextResponse.json(
+      { error: "Failed to update refresh timestamp" },
+      { status: 500 }
+    );
+  }
+
+  revalidatePath(`/${username}`);
+
+  return NextResponse.json({
+    success: true,
+    message: `Profile ${username} refresh triggered`,
+    refreshedAt: new Date().toISOString(),
+  });
+}

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback, useMemo } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
@@ -101,26 +101,25 @@ function formatUpdatedAt(iso: string): string {
 function ProfileFreshness({ username, updatedAt }: { username: string; updatedAt?: string }) {
   const [refreshing, setRefreshing] = useState(false);
   const [lastRefresh, setLastRefresh] = useState(updatedAt);
-  const [tick, setTick] = useState(0);
+  const [relativeTime, setRelativeTime] = useState("...");
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
   useEffect(() => {
-    const interval = setInterval(() => setTick((t) => t + 1), 60000);
-    return () => clearInterval(interval);
-  }, []);
-
-  const relativeTime = useMemo(() => {
-    void tick;
-    if (!lastRefresh) return "Unknown";
-    const diff = Date.now() - new Date(lastRefresh).getTime();
-    const minutes = Math.floor(diff / 60000);
-    if (minutes < 1) return "Just now";
-    if (minutes < 60) return `${minutes}m ago`;
-    const hours = Math.floor(minutes / 60);
-    if (hours < 24) return `${hours}h ago`;
-    const days = Math.floor(hours / 24);
-    return `${days}d ago`;
-  }, [lastRefresh, tick]);
+    const compute = () => {
+      if (!lastRefresh) return "Unknown";
+      const diff = Date.now() - new Date(lastRefresh).getTime();
+      const minutes = Math.floor(diff / 60000);
+      if (minutes < 1) return "Just now";
+      if (minutes < 60) return `${minutes}m ago`;
+      const hours = Math.floor(minutes / 60);
+      if (hours < 24) return `${hours}h ago`;
+      const days = Math.floor(hours / 24);
+      return `${days}d ago`;
+    };
+    const id = setTimeout(() => setRelativeTime(compute()), 0);
+    const interval = setInterval(() => setRelativeTime(compute()), 60000);
+    return () => { clearTimeout(id); clearInterval(interval); };
+  }, [lastRefresh]);
 
   const handleRefresh = async () => {
     setRefreshing(true);

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -102,6 +102,7 @@ function ProfileFreshness({ username, updatedAt }: { username: string; updatedAt
   const [refreshing, setRefreshing] = useState(false);
   const [lastRefresh, setLastRefresh] = useState(updatedAt);
   const [tick, setTick] = useState(0);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
   useEffect(() => {
     const interval = setInterval(() => setTick((t) => t + 1), 60000);
@@ -123,22 +124,29 @@ function ProfileFreshness({ username, updatedAt }: { username: string; updatedAt
 
   const handleRefresh = async () => {
     setRefreshing(true);
+    setErrorMsg(null);
     try {
       const res = await fetch(`/api/${username}/refresh`, { method: "POST" });
       if (res.ok) {
         const data = await res.json();
         setLastRefresh(data.refreshedAt);
-        setTimeout(() => window.location.reload(), 1500);
+      } else {
+        const payload = await res.json().catch(() => ({ error: "Refresh failed" }));
+        if (res.status === 429 && payload.retryAfterSeconds) {
+          setErrorMsg(`Try again in ${Math.ceil(payload.retryAfterSeconds / 60)} min`);
+        } else {
+          setErrorMsg(payload.error || "Refresh failed");
+        }
       }
     } catch {
-      // Silently fail - the page will show stale data which is fine
+      setErrorMsg("Network error");
     } finally {
       setRefreshing(false);
     }
   };
 
   return (
-    <div style={{ display: "flex", alignItems: "center", gap: "8px", marginTop: "8px" }}>
+    <div style={{ display: "flex", alignItems: "center", gap: "8px", marginTop: "8px", flexWrap: "wrap" }}>
       <span style={{ fontSize: "12px", color: "var(--color-ink-mute)" }}>
         Updated {relativeTime}
       </span>
@@ -159,6 +167,9 @@ function ProfileFreshness({ username, updatedAt }: { username: string; updatedAt
       >
         {refreshing ? "Refreshing..." : "Refresh"}
       </button>
+      {errorMsg && (
+        <span style={{ fontSize: "11px", color: "var(--color-error, #dc2626)" }}>{errorMsg}</span>
+      )}
     </div>
   );
 }
@@ -803,11 +814,6 @@ export function ProfileView({
             </span>
           </div>
 
-          {updatedAt && (
-            <p style={{ fontSize: "12px", color: "var(--color-ink-mute)", margin: "10px 0 0 0", lineHeight: 1.45 }}>
-              Last updated {formatUpdatedAt(updatedAt)}
-            </p>
-          )}
         </div>
       </div>
 

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -101,18 +101,24 @@ function formatUpdatedAt(iso: string): string {
 function ProfileFreshness({ username, updatedAt }: { username: string; updatedAt?: string }) {
   const [refreshing, setRefreshing] = useState(false);
   const [lastRefresh, setLastRefresh] = useState(updatedAt);
+  const [relativeTime, setRelativeTime] = useState("...");
 
-  const getRelativeTime = (dateStr?: string) => {
-    if (!dateStr) return "Unknown";
-    const diff = Date.now() - new Date(dateStr).getTime();
-    const minutes = Math.floor(diff / 60000);
-    if (minutes < 1) return "Just now";
-    if (minutes < 60) return `${minutes}m ago`;
-    const hours = Math.floor(minutes / 60);
-    if (hours < 24) return `${hours}h ago`;
-    const days = Math.floor(hours / 24);
-    return `${days}d ago`;
-  };
+  useEffect(() => {
+    const computeRelative = () => {
+      if (!lastRefresh) return "Unknown";
+      const diff = Date.now() - new Date(lastRefresh).getTime();
+      const minutes = Math.floor(diff / 60000);
+      if (minutes < 1) return "Just now";
+      if (minutes < 60) return `${minutes}m ago`;
+      const hours = Math.floor(minutes / 60);
+      if (hours < 24) return `${hours}h ago`;
+      const days = Math.floor(hours / 24);
+      return `${days}d ago`;
+    };
+    setRelativeTime(computeRelative());
+    const interval = setInterval(() => setRelativeTime(computeRelative()), 60000);
+    return () => clearInterval(interval);
+  }, [lastRefresh]);
 
   const handleRefresh = async () => {
     setRefreshing(true);
@@ -133,7 +139,7 @@ function ProfileFreshness({ username, updatedAt }: { username: string; updatedAt
   return (
     <div style={{ display: "flex", alignItems: "center", gap: "8px", marginTop: "8px" }}>
       <span style={{ fontSize: "12px", color: "var(--color-ink-mute)" }}>
-        Updated {getRelativeTime(lastRefresh)}
+        Updated {relativeTime}
       </span>
       <button
         onClick={handleRefresh}

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import Image from "next/image";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { HeatmapWithYearNav } from "@/components/profile/HeatmapWithYearNav";
 import type { ContributorStats, Org, TechEntry, HeatmapWeek, BadgeItem } from "@/types";
@@ -99,6 +100,7 @@ function formatUpdatedAt(iso: string): string {
 }
 
 function ProfileFreshness({ username, updatedAt }: { username: string; updatedAt?: string }) {
+  const router = useRouter();
   const [refreshing, setRefreshing] = useState(false);
   const [lastRefresh, setLastRefresh] = useState(updatedAt);
   const [relativeTime, setRelativeTime] = useState("...");
@@ -129,6 +131,7 @@ function ProfileFreshness({ username, updatedAt }: { username: string; updatedAt
       if (res.ok) {
         const data = await res.json();
         setLastRefresh(data.refreshedAt);
+        router.refresh();
       } else {
         const payload = await res.json().catch(() => ({ error: "Refresh failed" }));
         if (res.status === 429 && payload.retryAfterSeconds) {

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -98,6 +98,64 @@ function formatUpdatedAt(iso: string): string {
   return years === 1 ? "1 year ago" : `${years} years ago`;
 }
 
+function ProfileFreshness({ username, updatedAt }: { username: string; updatedAt?: string }) {
+  const [refreshing, setRefreshing] = useState(false);
+  const [lastRefresh, setLastRefresh] = useState(updatedAt);
+
+  const getRelativeTime = (dateStr?: string) => {
+    if (!dateStr) return "Unknown";
+    const diff = Date.now() - new Date(dateStr).getTime();
+    const minutes = Math.floor(diff / 60000);
+    if (minutes < 1) return "Just now";
+    if (minutes < 60) return `${minutes}m ago`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours}h ago`;
+    const days = Math.floor(hours / 24);
+    return `${days}d ago`;
+  };
+
+  const handleRefresh = async () => {
+    setRefreshing(true);
+    try {
+      const res = await fetch(`/api/${username}/refresh`, { method: "POST" });
+      if (res.ok) {
+        const data = await res.json();
+        setLastRefresh(data.refreshedAt);
+        setTimeout(() => window.location.reload(), 1500);
+      }
+    } catch {
+      // Silently fail - the page will show stale data which is fine
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: "8px", marginTop: "8px" }}>
+      <span style={{ fontSize: "12px", color: "var(--color-ink-mute)" }}>
+        Updated {getRelativeTime(lastRefresh)}
+      </span>
+      <button
+        onClick={handleRefresh}
+        disabled={refreshing}
+        style={{
+          fontSize: "11px",
+          padding: "2px 8px",
+          borderRadius: "6px",
+          border: "1px solid var(--color-hairline-cool)",
+          background: "var(--color-canvas-soft)",
+          color: "var(--color-primary)",
+          cursor: refreshing ? "not-allowed" : "pointer",
+          opacity: refreshing ? 0.6 : 1,
+        }}
+        aria-label="Refresh profile data"
+      >
+        {refreshing ? "Refreshing..." : "Refresh"}
+      </button>
+    </div>
+  );
+}
+
 export function ProfileView({
   user,
   repos,
@@ -398,6 +456,9 @@ export function ProfileView({
               {user.bio}
             </p>
           )}
+
+          {/* Profile Freshness Indicator */}
+          <ProfileFreshness username={user.login} updatedAt={updatedAt} />
 
           {/* Dynamic Contributor Tier Badge */}
           {(() => {

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -475,7 +475,7 @@ export function ProfileView({
           )}
 
           {/* Profile Freshness Indicator */}
-          <ProfileFreshness username={user.login} updatedAt={updatedAt} />
+          <ProfileFreshness username={user.login} updatedAt={updatedAt ?? undefined} />
 
           {/* Dynamic Contributor Tier Badge */}
           {(() => {

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
@@ -101,24 +101,25 @@ function formatUpdatedAt(iso: string): string {
 function ProfileFreshness({ username, updatedAt }: { username: string; updatedAt?: string }) {
   const [refreshing, setRefreshing] = useState(false);
   const [lastRefresh, setLastRefresh] = useState(updatedAt);
-  const [relativeTime, setRelativeTime] = useState("...");
+  const [tick, setTick] = useState(0);
 
   useEffect(() => {
-    const computeRelative = () => {
-      if (!lastRefresh) return "Unknown";
-      const diff = Date.now() - new Date(lastRefresh).getTime();
-      const minutes = Math.floor(diff / 60000);
-      if (minutes < 1) return "Just now";
-      if (minutes < 60) return `${minutes}m ago`;
-      const hours = Math.floor(minutes / 60);
-      if (hours < 24) return `${hours}h ago`;
-      const days = Math.floor(hours / 24);
-      return `${days}d ago`;
-    };
-    setRelativeTime(computeRelative());
-    const interval = setInterval(() => setRelativeTime(computeRelative()), 60000);
+    const interval = setInterval(() => setTick((t) => t + 1), 60000);
     return () => clearInterval(interval);
-  }, [lastRefresh]);
+  }, []);
+
+  const relativeTime = useMemo(() => {
+    void tick;
+    if (!lastRefresh) return "Unknown";
+    const diff = Date.now() - new Date(lastRefresh).getTime();
+    const minutes = Math.floor(diff / 60000);
+    if (minutes < 1) return "Just now";
+    if (minutes < 60) return `${minutes}m ago`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours}h ago`;
+    const days = Math.floor(hours / 24);
+    return `${days}d ago`;
+  }, [lastRefresh, tick]);
 
   const handleRefresh = async () => {
     setRefreshing(true);

--- a/supabase/functions/refresh-profile/index.ts
+++ b/supabase/functions/refresh-profile/index.ts
@@ -19,27 +19,40 @@ serve(async (req) => {
     const supabaseKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
     const supabase = createClient(supabaseUrl, supabaseKey);
 
-    const { data: profile } = await supabase
+    const { data: profile, error: fetchError } = await supabase
       .from("profiles")
       .select("username, last_refreshed_at")
       .eq("username", username)
       .single();
 
-    if (!profile) {
-      return new Response(JSON.stringify({ error: "Profile not found" }), {
-        status: 404,
+    if (fetchError) {
+      if (fetchError.code === "PGRST116") {
+        return new Response(JSON.stringify({ error: "Profile not found" }), {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify({ error: fetchError.message }), {
+        status: 500,
         headers: { "Content-Type": "application/json" },
       });
     }
 
-    if (profile.last_refreshed_at) {
-      const elapsed = Date.now() - new Date(profile.last_refreshed_at).getTime();
-      if (elapsed < RATE_LIMIT_MS) {
-        return new Response(JSON.stringify({ error: "Rate limited", retryAfterSeconds: Math.ceil((RATE_LIMIT_MS - elapsed) / 1000) }), {
-          status: 429,
-          headers: { "Content-Type": "application/json" },
-        });
-      }
+    const cutoff = new Date(Date.now() - RATE_LIMIT_MS).toISOString();
+
+    const { data: claimed, error: claimError } = await supabase
+      .from("profiles")
+      .update({ last_refreshed_at: new Date().toISOString() })
+      .eq("username", username)
+      .or(`last_refreshed_at.is.null,last_refreshed_at.lt.${cutoff}`)
+      .select("username")
+      .single();
+
+    if (claimError || !claimed) {
+      return new Response(JSON.stringify({ error: "Rate limited", retryAfterSeconds: 600 }), {
+        status: 429,
+        headers: { "Content-Type": "application/json" },
+      });
     }
 
     const ghRes = await fetch(`${GITHUB_API}/users/${encodeURIComponent(username)}`, {
@@ -55,14 +68,13 @@ serve(async (req) => {
 
     const ghUser = await ghRes.json();
 
-    const { error, count } = await supabase
+    const { error } = await supabase
       .from("profiles")
       .update({
         name: ghUser.name,
         avatar_url: ghUser.avatar_url,
         bio: ghUser.bio,
         followers: ghUser.followers,
-        last_refreshed_at: new Date().toISOString(),
         updated_at: new Date().toISOString(),
       })
       .eq("username", username);

--- a/supabase/functions/refresh-profile/index.ts
+++ b/supabase/functions/refresh-profile/index.ts
@@ -2,12 +2,14 @@ import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
 const GITHUB_API = "https://api.github.com";
+const GITHUB_USERNAME_REGEX = /^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$/;
+const RATE_LIMIT_MS = 10 * 60 * 1000;
 
 serve(async (req) => {
   try {
     const { username } = await req.json();
-    if (!username) {
-      return new Response(JSON.stringify({ error: "username is required" }), {
+    if (!username || !GITHUB_USERNAME_REGEX.test(username) || username.length > 39) {
+      return new Response(JSON.stringify({ error: "Invalid username format" }), {
         status: 400,
         headers: { "Content-Type": "application/json" },
       });
@@ -17,7 +19,30 @@ serve(async (req) => {
     const supabaseKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
     const supabase = createClient(supabaseUrl, supabaseKey);
 
-    const ghRes = await fetch(`${GITHUB_API}/users/${username}`, {
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("username, last_refreshed_at")
+      .eq("username", username)
+      .single();
+
+    if (!profile) {
+      return new Response(JSON.stringify({ error: "Profile not found" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (profile.last_refreshed_at) {
+      const elapsed = Date.now() - new Date(profile.last_refreshed_at).getTime();
+      if (elapsed < RATE_LIMIT_MS) {
+        return new Response(JSON.stringify({ error: "Rate limited", retryAfterSeconds: Math.ceil((RATE_LIMIT_MS - elapsed) / 1000) }), {
+          status: 429,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+    }
+
+    const ghRes = await fetch(`${GITHUB_API}/users/${encodeURIComponent(username)}`, {
       headers: { Accept: "application/vnd.github.v3+json" },
     });
 
@@ -30,7 +55,7 @@ serve(async (req) => {
 
     const ghUser = await ghRes.json();
 
-    const { error } = await supabase
+    const { error, count } = await supabase
       .from("profiles")
       .update({
         name: ghUser.name,

--- a/supabase/functions/refresh-profile/index.ts
+++ b/supabase/functions/refresh-profile/index.ts
@@ -1,0 +1,62 @@
+import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const GITHUB_API = "https://api.github.com";
+
+serve(async (req) => {
+  try {
+    const { username } = await req.json();
+    if (!username) {
+      return new Response(JSON.stringify({ error: "username is required" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const supabaseKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+    const supabase = createClient(supabaseUrl, supabaseKey);
+
+    const ghRes = await fetch(`${GITHUB_API}/users/${username}`, {
+      headers: { Accept: "application/vnd.github.v3+json" },
+    });
+
+    if (!ghRes.ok) {
+      return new Response(
+        JSON.stringify({ error: `GitHub API returned ${ghRes.status}` }),
+        { status: 502, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    const ghUser = await ghRes.json();
+
+    const { error } = await supabase
+      .from("profiles")
+      .update({
+        name: ghUser.name,
+        avatar_url: ghUser.avatar_url,
+        bio: ghUser.bio,
+        followers: ghUser.followers,
+        last_refreshed_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      })
+      .eq("username", username);
+
+    if (error) {
+      return new Response(JSON.stringify({ error: error.message }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    return new Response(
+      JSON.stringify({ success: true, username, refreshedAt: new Date().toISOString() }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    );
+  } catch (err) {
+    return new Response(
+      JSON.stringify({ error: err.message || "Internal error" }),
+      { status: 500, headers: { "Content-Type": "application/json" } }
+    );
+  }
+});

--- a/supabase/functions/scheduled-refresh/index.ts
+++ b/supabase/functions/scheduled-refresh/index.ts
@@ -6,14 +6,19 @@ const BATCH_SIZE = 50;
 
 serve(async (req) => {
   const schedulerSecret = Deno.env.get("SCHEDULER_SECRET");
-  if (schedulerSecret) {
-    const authHeader = req.headers.get("Authorization") || "";
-    if (authHeader !== `Bearer ${schedulerSecret}`) {
-      return new Response(JSON.stringify({ error: "Unauthorized" }), {
-        status: 401,
-        headers: { "Content-Type": "application/json" },
-      });
-    }
+  if (!schedulerSecret) {
+    return new Response(JSON.stringify({ error: "SCHEDULER_SECRET not configured" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const authHeader = req.headers.get("Authorization") || "";
+  if (authHeader !== `Bearer ${schedulerSecret}`) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
   }
 
   try {

--- a/supabase/functions/scheduled-refresh/index.ts
+++ b/supabase/functions/scheduled-refresh/index.ts
@@ -1,0 +1,69 @@
+import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const GITHUB_API = "https://api.github.com";
+const BATCH_SIZE = 50;
+
+serve(async (_req) => {
+  try {
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const supabaseKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+    const supabase = createClient(supabaseUrl, supabaseKey);
+
+    const { data: profiles, error } = await supabase
+      .from("profiles")
+      .select("username")
+      .order("view_count", { ascending: false })
+      .limit(BATCH_SIZE);
+
+    if (error || !profiles) {
+      return new Response(
+        JSON.stringify({ error: error?.message || "No profiles found" }),
+        { status: 500, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    const results: { username: string; status: string }[] = [];
+
+    for (const profile of profiles) {
+      try {
+        const ghRes = await fetch(`${GITHUB_API}/users/${profile.username}`, {
+          headers: { Accept: "application/vnd.github.v3+json" },
+        });
+
+        if (!ghRes.ok) {
+          results.push({ username: profile.username, status: `github_error_${ghRes.status}` });
+          continue;
+        }
+
+        const ghUser = await ghRes.json();
+
+        await supabase
+          .from("profiles")
+          .update({
+            name: ghUser.name,
+            avatar_url: ghUser.avatar_url,
+            bio: ghUser.bio,
+            followers: ghUser.followers,
+            last_refreshed_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+          })
+          .eq("username", profile.username);
+
+        results.push({ username: profile.username, status: "refreshed" });
+      } catch {
+        results.push({ username: profile.username, status: "error" });
+      }
+    }
+
+    return new Response(
+      JSON.stringify({ refreshed: results.filter((r) => r.status === "refreshed").length, total: profiles.length, results }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    );
+  } catch (err) {
+    return new Response(
+      JSON.stringify({ error: err.message || "Internal error" }),
+      { status: 500, headers: { "Content-Type": "application/json" } }
+    );
+  }
+});

--- a/supabase/functions/scheduled-refresh/index.ts
+++ b/supabase/functions/scheduled-refresh/index.ts
@@ -4,7 +4,18 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 const GITHUB_API = "https://api.github.com";
 const BATCH_SIZE = 50;
 
-serve(async (_req) => {
+serve(async (req) => {
+  const schedulerSecret = Deno.env.get("SCHEDULER_SECRET");
+  if (schedulerSecret) {
+    const authHeader = req.headers.get("Authorization") || "";
+    if (authHeader !== `Bearer ${schedulerSecret}`) {
+      return new Response(JSON.stringify({ error: "Unauthorized" }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+  }
+
   try {
     const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
     const supabaseKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
@@ -27,7 +38,7 @@ serve(async (_req) => {
 
     for (const profile of profiles) {
       try {
-        const ghRes = await fetch(`${GITHUB_API}/users/${profile.username}`, {
+        const ghRes = await fetch(`${GITHUB_API}/users/${encodeURIComponent(profile.username)}`, {
           headers: { Accept: "application/vnd.github.v3+json" },
         });
 
@@ -38,7 +49,7 @@ serve(async (_req) => {
 
         const ghUser = await ghRes.json();
 
-        await supabase
+        const { error: updateError } = await supabase
           .from("profiles")
           .update({
             name: ghUser.name,
@@ -50,7 +61,11 @@ serve(async (_req) => {
           })
           .eq("username", profile.username);
 
-        results.push({ username: profile.username, status: "refreshed" });
+        if (updateError) {
+          results.push({ username: profile.username, status: "db_write_failed" });
+        } else {
+          results.push({ username: profile.username, status: "refreshed" });
+        }
       } catch {
         results.push({ username: profile.username, status: "error" });
       }

--- a/supabase/migrations/20260628000001_add_profile_refresh_columns.sql
+++ b/supabase/migrations/20260628000001_add_profile_refresh_columns.sql
@@ -1,0 +1,10 @@
+-- Add view_count and last_refreshed_at columns for background refresh system.
+-- view_count tracks profile visits (for scheduled refresh prioritization).
+-- last_refreshed_at tracks when GitHub data was last fetched (distinct from updated_at).
+
+alter table public.profiles
+  add column if not exists view_count integer not null default 0,
+  add column if not exists last_refreshed_at timestamptz default now();
+
+create index if not exists idx_profiles_view_count_desc
+  on public.profiles (view_count desc nulls last);

--- a/supabase/migrations/20260628000001_add_profile_refresh_columns.sql
+++ b/supabase/migrations/20260628000001_add_profile_refresh_columns.sql
@@ -4,7 +4,7 @@
 
 alter table public.profiles
   add column if not exists view_count integer not null default 0,
-  add column if not exists last_refreshed_at timestamptz default now();
+  add column if not exists last_refreshed_at timestamptz;
 
 create index if not exists idx_profiles_view_count_desc
   on public.profiles (view_count desc nulls last);

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -38,7 +38,7 @@ create table public.profiles (
   created_at timestamptz default now(),
   updated_at timestamptz default now(),
   view_count integer not null default 0,
-  last_refreshed_at timestamptz default now()
+  last_refreshed_at timestamptz
 );
 
 alter table public.profiles enable row level security;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -36,7 +36,9 @@ create table public.profiles (
     )
   ) stored,
   created_at timestamptz default now(),
-  updated_at timestamptz default now()
+  updated_at timestamptz default now(),
+  view_count integer not null default 0,
+  last_refreshed_at timestamptz default now()
 );
 
 alter table public.profiles enable row level security;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,6 +36,7 @@
     ".next/dev/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "supabase/functions"
   ]
 }


### PR DESCRIPTION
## Summary

Implements a background profile refresh system with a freshness indicator, on-demand revalidation API, and Supabase Edge Functions for scheduled batch updates.

Closes #191

## What Changed and Why

Profiles currently only update when ISR revalidation triggers (every hour on page visit). This PR adds:

1. A visible "Updated Xh ago" badge on every profile so users know data freshness
2. A "Refresh" button that triggers immediate re-fetch via Next.js `revalidatePath`
3. A rate-limited API route preventing abuse (max 1 refresh per 10 min per profile)
4. Supabase Edge Functions for programmatic and scheduled refresh of popular profiles

I built this because the issue identified a real gap: users with significant GitHub activity changes had no way to force-refresh their OSSfolio page, and there was no visibility into data staleness.

## Files

| File | What |
|------|------|
| `src/app/api/[username]/refresh/route.ts` | NEW - POST endpoint that rate-limits, updates timestamps, and calls `revalidatePath` |
| `src/components/profile/ProfileView.tsx` | MODIFIED - Added `ProfileFreshness` component (relative time + refresh button) |
| `supabase/functions/refresh-profile/index.ts` | NEW - Edge Function that fetches fresh GitHub data for one profile |
| `supabase/functions/scheduled-refresh/index.ts` | NEW - Cron-triggered function that batch-refreshes top 50 profiles by view count |
| `supabase/migrations/20260628000001_add_profile_refresh_columns.sql` | NEW - Adds `view_count` and `last_refreshed_at` columns |
| `supabase/schema.sql` | MODIFIED - Reflects new columns in master schema |

## How to Test

1. Visit any profile page - "Updated Xm ago" badge appears below the bio
2. Click "Refresh" - triggers API call, page reloads with fresh data after 1.5s
3. Click "Refresh" again within 10 minutes - returns 429 rate limit response
4. Deploy Edge Functions via `supabase functions deploy refresh-profile` and `scheduled-refresh`

## AI Disclosure

Used Claude Code for implementation assistance. I understand every change: the API route uses `revalidatePath` for ISR cache busting, the Edge Functions use the Supabase client with service role key for direct DB updates, and the rate limiter checks `last_refreshed_at` timestamp delta.

## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] Code works locally
- [x] No `console.log` left in `src/`
- [x] Schema changed - both `schema.sql` and a new migration file are included
- [x] PR title follows Conventional Commits format
- [x] PR description is written in my own words
- [x] AI usage mentioned clearly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manual **Refresh** action on profile pages to update details from GitHub.
  * Added an **“Updated …”** freshness indicator that auto-updates and updates after refresh.
  * Introduced background/scheduled profile refresh using stored refresh timestamps (with optional authorization).
* **Bug Fixes**
  * Improved refresh endpoint validation and cooldown behavior, including correct handling of **not found (404)** vs **rate limited (429)** with retry timing.
  * Better timestamp accuracy and clearer UI error messaging during refresh failures.
* **Chores**
  * Added/extended profile refresh tracking fields and an index to support refresh batching. Updated TypeScript configuration to exclude edge functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->