### PR TITLE
feat: enforce client-side form validations in authentication modal 

### DIFF
--- a/src/components/auth/AuthModal.tsx
+++ b/src/components/auth/AuthModal.tsx
@@ -53,6 +53,20 @@ export function AuthModal({ open, onClose, defaultMode = "signin" }: AuthModalPr
     setLoading(true);
     setError("");
 
+    // Form inputs client side validation
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      setError("Please enter a valid email address.");
+      setLoading(false);
+      return;
+    }
+
+    if (password.length < 8) {
+      setError("Password must be at least 8 characters long.");
+      setLoading(false);
+      return;
+    }
+
     if (mode === "signin") {
       const { error } = await supabase.auth.signInWithPassword({ email, password });
       if (error) {
@@ -62,6 +76,11 @@ export function AuthModal({ open, onClose, defaultMode = "signin" }: AuthModalPr
         onClose();
       }
     } else {
+      if (!name.trim()) {
+        setError("Please enter your full name.");
+        setLoading(false);
+        return;
+      }
       const { error } = await supabase.auth.signUp({
         email,
         password,


### PR DESCRIPTION
# Related Issue
Closes #225

# Summary
This PR implements strict email syntax checks and password length safeguards on client-side authentication forms.

# Changes Made
- Added regex constraints on input emails.
- Restricted password entries to at least 8 characters.
- Validated required name fields on signup forms.

# Testing
- Tested entering invalid formatting options.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added client-side checks for email format, password length, and required name on sign-up.
  * Invalid submissions now show an error immediately and stop the auth flow before sending requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->