### PR TITLE
fix(ui): add error boundaries and loading states for compare, explore, discover pages

### DIFF
--- a/src/app/compare/error.tsx
+++ b/src/app/compare/error.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import Link from "next/link";
+import { Navbar } from "@/components/layout/Navbar";
+import { Footer } from "@/components/layout/Footer";
+
+export default function CompareError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <>
+      <Navbar />
+      <main
+        style={{
+          backgroundColor: "var(--color-canvas)",
+          color: "var(--color-ink)",
+          minHeight: "100vh",
+          transition: "background-color 0.2s ease, color 0.2s ease",
+        }}
+      >
+        <div style={{ maxWidth: "72rem", margin: "0 auto", padding: "56px 20px", textAlign: "center" }}>
+          <div
+            style={{
+              maxWidth: "28rem",
+              margin: "0 auto",
+              padding: "48px 24px",
+              border: "1px solid var(--color-hairline)",
+              borderRadius: "12px",
+              backgroundColor: "var(--color-canvas-soft)",
+            }}
+          >
+            <svg
+              width="40"
+              height="40"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="var(--color-ink-mute-2)"
+              strokeWidth="2"
+              style={{ margin: "0 auto 16px", display: "block" }}
+            >
+              <circle cx="12" cy="12" r="10" />
+              <line x1="12" y1="8" x2="12" y2="12" />
+              <line x1="12" y1="16" x2="12.01" y2="16" />
+            </svg>
+            <h1
+              style={{
+                fontSize: "20px",
+                fontWeight: 600,
+                color: "var(--color-ink)",
+                margin: "0 0 8px",
+              }}
+            >
+              Comparison failed
+            </h1>
+            <p style={{ fontSize: "14px", color: "var(--color-ink-mute)", margin: "0 0 24px" }}>
+              {error.message || "Could not load comparison data. Please try again."}
+            </p>
+            <div style={{ display: "flex", justifyContent: "center", gap: "12px" }}>
+              <button
+                onClick={reset}
+                style={{
+                  fontSize: "14px",
+                  fontWeight: 500,
+                  color: "#ffffff",
+                  backgroundColor: "#3ecf8e",
+                  border: "none",
+                  borderRadius: "6px",
+                  padding: "10px 20px",
+                  cursor: "pointer",
+                }}
+              >
+                Try again
+              </button>
+              <Link
+                href="/compare"
+                style={{
+                  fontSize: "14px",
+                  fontWeight: 500,
+                  color: "var(--color-ink)",
+                  border: "1px solid var(--color-hairline-strong)",
+                  borderRadius: "6px",
+                  padding: "10px 20px",
+                  textDecoration: "none",
+                }}
+              >
+                New comparison
+              </Link>
+            </div>
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/src/app/compare/loading.tsx
+++ b/src/app/compare/loading.tsx
@@ -1,0 +1,58 @@
+import { Navbar } from "@/components/layout/Navbar";
+import { Footer } from "@/components/layout/Footer";
+import { SkeletonCard } from "@/components/ui/skeleton-card";
+
+export default function CompareLoading() {
+  return (
+    <>
+      <Navbar />
+      <main
+        style={{
+          backgroundColor: "var(--color-canvas)",
+          color: "var(--color-ink)",
+          minHeight: "100vh",
+          transition: "background-color 0.2s ease, color 0.2s ease",
+        }}
+      >
+        <div style={{ maxWidth: "72rem", margin: "0 auto", padding: "56px 20px" }}>
+          <header style={{ marginBottom: "32px" }}>
+            <div
+              style={{
+                width: "280px",
+                height: "28px",
+                backgroundColor: "var(--color-hairline-cool)",
+                borderRadius: "6px",
+                animation: "sk-pulse 1.5s ease-in-out infinite",
+                marginBottom: "8px",
+              }}
+            />
+            <div
+              style={{
+                width: "400px",
+                height: "15px",
+                backgroundColor: "var(--color-hairline-cool)",
+                borderRadius: "6px",
+                animation: "sk-pulse 1.5s ease-in-out infinite",
+              }}
+            />
+          </header>
+
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "1fr 1fr",
+              gap: "24px",
+              marginTop: "32px",
+            }}
+            className="compare-grid"
+          >
+            <SkeletonCard variant="profile-header" />
+            <SkeletonCard variant="profile-header" />
+          </div>
+        </div>
+      </main>
+      <Footer />
+      <style>{`@keyframes sk-pulse { 0%,100% { opacity: 0.4; } 50% { opacity: 0.8; } }`}</style>
+    </>
+  );
+}

--- a/src/app/discover/loading.tsx
+++ b/src/app/discover/loading.tsx
@@ -1,0 +1,30 @@
+import { SkeletonCard } from "@/components/ui/skeleton-card";
+
+export default function DiscoverLoading() {
+  return (
+    <div style={{ padding: "24px 0" }}>
+      <div
+        style={{
+          width: "100%",
+          height: "44px",
+          backgroundColor: "var(--color-hairline-cool)",
+          borderRadius: "6px",
+          animation: "sk-pulse 1.5s ease-in-out infinite",
+          marginBottom: "24px",
+        }}
+      />
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fill, minmax(300px, 1fr))",
+          gap: "16px",
+        }}
+      >
+        {Array.from({ length: 6 }).map((_, i) => (
+          <SkeletonCard key={i} lines={2} />
+        ))}
+      </div>
+      <style>{`@keyframes sk-pulse { 0%,100% { opacity: 0.4; } 50% { opacity: 0.8; } }`}</style>
+    </div>
+  );
+}

--- a/src/app/explore/error.tsx
+++ b/src/app/explore/error.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import Link from "next/link";
+import { Navbar } from "@/components/layout/Navbar";
+import { Footer } from "@/components/layout/Footer";
+
+export default function ExploreError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <>
+      <Navbar />
+      <main
+        style={{
+          backgroundColor: "var(--color-canvas)",
+          color: "var(--color-ink)",
+          minHeight: "100vh",
+          transition: "background-color 0.2s ease, color 0.2s ease",
+        }}
+      >
+        <div style={{ maxWidth: "56rem", margin: "0 auto", padding: "56px 20px", textAlign: "center" }}>
+          <div
+            style={{
+              maxWidth: "28rem",
+              margin: "0 auto",
+              padding: "48px 24px",
+              border: "1px solid var(--color-hairline)",
+              borderRadius: "12px",
+              backgroundColor: "var(--color-canvas-soft)",
+            }}
+          >
+            <svg
+              width="40"
+              height="40"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="var(--color-ink-mute-2)"
+              strokeWidth="2"
+              style={{ margin: "0 auto 16px", display: "block" }}
+            >
+              <circle cx="12" cy="12" r="10" />
+              <line x1="12" y1="8" x2="12" y2="12" />
+              <line x1="12" y1="16" x2="12.01" y2="16" />
+            </svg>
+            <h1
+              style={{
+                fontSize: "20px",
+                fontWeight: 600,
+                color: "var(--color-ink)",
+                margin: "0 0 8px",
+              }}
+            >
+              Leaderboard unavailable
+            </h1>
+            <p style={{ fontSize: "14px", color: "var(--color-ink-mute)", margin: "0 0 24px" }}>
+              {error.message || "Could not load the leaderboard. Please try again later."}
+            </p>
+            <div style={{ display: "flex", justifyContent: "center", gap: "12px" }}>
+              <button
+                onClick={reset}
+                style={{
+                  fontSize: "14px",
+                  fontWeight: 500,
+                  color: "#ffffff",
+                  backgroundColor: "#3ecf8e",
+                  border: "none",
+                  borderRadius: "6px",
+                  padding: "10px 20px",
+                  cursor: "pointer",
+                }}
+              >
+                Try again
+              </button>
+              <Link
+                href="/"
+                style={{
+                  fontSize: "14px",
+                  fontWeight: 500,
+                  color: "var(--color-ink)",
+                  border: "1px solid var(--color-hairline-strong)",
+                  borderRadius: "6px",
+                  padding: "10px 20px",
+                  textDecoration: "none",
+                }}
+              >
+                Back to home
+              </Link>
+            </div>
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/src/app/explore/loading.tsx
+++ b/src/app/explore/loading.tsx
@@ -1,0 +1,87 @@
+import { Navbar } from "@/components/layout/Navbar";
+import { Footer } from "@/components/layout/Footer";
+import { SkeletonCard } from "@/components/ui/skeleton-card";
+
+export default function ExploreLoading() {
+  return (
+    <>
+      <Navbar />
+      <main
+        style={{
+          backgroundColor: "var(--color-canvas)",
+          color: "var(--color-ink)",
+          minHeight: "100vh",
+          transition: "background-color 0.2s ease, color 0.2s ease",
+        }}
+      >
+        <div style={{ maxWidth: "56rem", margin: "0 auto", padding: "56px 20px" }}>
+          <header style={{ marginBottom: "32px" }}>
+            <div
+              style={{
+                width: "280px",
+                height: "28px",
+                backgroundColor: "var(--color-hairline-cool)",
+                borderRadius: "6px",
+                animation: "sk-pulse 1.5s ease-in-out infinite",
+                marginBottom: "8px",
+              }}
+            />
+            <div
+              style={{
+                width: "420px",
+                height: "15px",
+                backgroundColor: "var(--color-hairline-cool)",
+                borderRadius: "6px",
+                animation: "sk-pulse 1.5s ease-in-out infinite",
+              }}
+            />
+          </header>
+
+          <div
+            style={{
+              display: "flex",
+              gap: "12px",
+              marginBottom: "24px",
+            }}
+          >
+            <div
+              style={{
+                flex: 1,
+                height: "44px",
+                backgroundColor: "var(--color-hairline-cool)",
+                borderRadius: "6px",
+                animation: "sk-pulse 1.5s ease-in-out infinite",
+              }}
+            />
+            <div
+              style={{
+                width: "160px",
+                height: "44px",
+                backgroundColor: "var(--color-hairline-cool)",
+                borderRadius: "6px",
+                animation: "sk-pulse 1.5s ease-in-out infinite",
+              }}
+            />
+            <div
+              style={{
+                width: "80px",
+                height: "44px",
+                backgroundColor: "var(--color-hairline-cool)",
+                borderRadius: "6px",
+                animation: "sk-pulse 1.5s ease-in-out infinite",
+              }}
+            />
+          </div>
+
+          <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+            {Array.from({ length: 6 }).map((_, i) => (
+              <SkeletonCard key={i} variant="list" />
+            ))}
+          </div>
+        </div>
+      </main>
+      <Footer />
+      <style>{`@keyframes sk-pulse { 0%,100% { opacity: 0.4; } 50% { opacity: 0.8; } }`}</style>
+    </>
+  );
+}

--- a/src/components/ui/error-boundary.tsx
+++ b/src/components/ui/error-boundary.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { Component, createElement } from "react";
+import Link from "next/link";
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+  onError?: (error: Error, errorInfo: React.ErrorInfo) => void;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    console.error("[ErrorBoundary]", error.message, errorInfo.componentStack);
+    this.props.onError?.(error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) return this.props.fallback;
+      return (
+        <div
+          style={{
+            padding: "40px 24px",
+            textAlign: "center",
+            border: "1px solid var(--color-hairline)",
+            borderRadius: "12px",
+            backgroundColor: "var(--color-canvas-soft)",
+            margin: "24px 0",
+          }}
+        >
+          <svg
+            width="32"
+            height="32"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="var(--color-ink-mute-2)"
+            strokeWidth="2"
+            style={{ margin: "0 auto 12px", display: "block" }}
+          >
+            <circle cx="12" cy="12" r="10" />
+            <line x1="12" y1="8" x2="12" y2="12" />
+            <line x1="12" y1="16" x2="12.01" y2="16" />
+          </svg>
+          <p style={{ fontSize: "15px", fontWeight: 600, color: "var(--color-ink)", margin: "0 0 4px" }}>
+            Something went wrong
+          </p>
+          <p style={{ fontSize: "13px", color: "var(--color-ink-mute)", margin: "0 0 16px" }}>
+            {this.state.error?.message || "An unexpected error occurred in this section."}
+          </p>
+          <button
+            onClick={() => this.setState({ hasError: false, error: null })}
+            style={{
+              fontSize: "13px",
+              fontWeight: 500,
+              color: "#ffffff",
+              backgroundColor: "#3ecf8e",
+              border: "none",
+              borderRadius: "6px",
+              padding: "8px 16px",
+              cursor: "pointer",
+              marginRight: "8px",
+            }}
+          >
+            Try again
+          </button>
+          <Link
+            href="/"
+            style={{
+              fontSize: "13px",
+              fontWeight: 500,
+              color: "var(--color-ink)",
+              border: "1px solid var(--color-hairline-strong)",
+              borderRadius: "6px",
+              padding: "8px 16px",
+              textDecoration: "none",
+              display: "inline-block",
+            }}
+          >
+            Back to home
+          </Link>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/src/components/ui/skeleton-card.tsx
+++ b/src/components/ui/skeleton-card.tsx
@@ -1,0 +1,116 @@
+interface SkeletonCardProps {
+  lines?: number;
+  height?: string;
+  variant?: "card" | "list" | "profile-header";
+}
+
+export function SkeletonCard({ lines = 3, height, variant = "card" }: SkeletonCardProps) {
+  const pulseKeyframes = `
+    @keyframes sk-pulse {
+      0%, 100% { opacity: 0.4; }
+      50% { opacity: 0.8; }
+    }
+  `;
+
+  const skeletonStyle: React.CSSProperties = {
+    backgroundColor: "var(--color-hairline-cool)",
+    borderRadius: "6px",
+    animation: "sk-pulse 1.5s ease-in-out infinite",
+    height: height || "14px",
+  };
+
+  if (variant === "profile-header") {
+    return (
+      <>
+        <style>{pulseKeyframes}</style>
+        <div
+          style={{
+            display: "flex",
+            gap: "24px",
+            alignItems: "flex-start",
+            padding: "24px",
+            border: "1px solid var(--color-hairline)",
+            borderRadius: "12px",
+            backgroundColor: "var(--color-canvas-soft)",
+          }}
+        >
+          <div style={{ ...skeletonStyle, width: "88px", height: "88px", borderRadius: "9999px", flexShrink: 0 }} />
+          <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: "12px" }}>
+            <div style={{ ...skeletonStyle, width: "200px", height: "24px" }} />
+            <div style={{ ...skeletonStyle, width: "140px", height: "14px" }} />
+            <div style={{ ...skeletonStyle, width: "100%", height: "14px" }} />
+            <div style={{ display: "flex", gap: "12px" }}>
+              <div style={{ ...skeletonStyle, width: "80px", height: "14px" }} />
+              <div style={{ ...skeletonStyle, width: "80px", height: "14px" }} />
+            </div>
+          </div>
+        </div>
+      </>
+    );
+  }
+
+  if (variant === "list") {
+    return (
+      <>
+        <style>{pulseKeyframes}</style>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "16px",
+            padding: "14px 18px",
+            border: "1px solid var(--color-hairline)",
+            borderRadius: "12px",
+            backgroundColor: "var(--color-canvas-soft)",
+          }}
+        >
+          <div style={{ ...skeletonStyle, width: "40px", height: "40px", borderRadius: "9999px", flexShrink: 0 }} />
+          <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: "6px" }}>
+            <div style={{ ...skeletonStyle, width: "160px", height: "16px" }} />
+            <div style={{ ...skeletonStyle, width: "100px", height: "12px" }} />
+          </div>
+          <div style={{ ...skeletonStyle, width: "60px", height: "40px", borderRadius: "8px" }} />
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <style>{pulseKeyframes}</style>
+      <div
+        style={{
+          padding: "20px",
+          border: "1px solid var(--color-hairline)",
+          borderRadius: "12px",
+          backgroundColor: "var(--color-canvas-soft)",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: "12px", marginBottom: "12px" }}>
+          <div style={{ ...skeletonStyle, width: "44px", height: "44px", borderRadius: "9999px", flexShrink: 0 }} />
+          <div style={{ flex: 1 }}>
+            <div style={{ ...skeletonStyle, width: "140px", height: "16px", marginBottom: "6px" }} />
+            <div style={{ ...skeletonStyle, width: "100px", height: "12px" }} />
+          </div>
+          <div style={{ ...skeletonStyle, width: "50px", height: "40px" }} />
+        </div>
+        {Array.from({ length: lines }).map((_, i) => (
+          <div
+            key={i}
+            style={{
+              ...skeletonStyle,
+              width: i === lines - 1 ? "60%" : "100%",
+              height: "12px",
+              marginBottom: "8px",
+            }}
+          />
+        ))}
+        <div style={{ display: "flex", gap: "8px", marginTop: "8px" }}>
+          {[1, 2, 3].map((i) => (
+            <div key={i} style={{ ...skeletonStyle, width: "60px", height: "20px", borderRadius: "4px" }} />
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

Adds reusable ErrorBoundary and SkeletonCard components with per-page loading and error states for compare, explore, and discover pages.

### Changes

| File | Change |
|------|--------|
| `src/components/ui/error-boundary.tsx` | **Created** — Class-based error boundary with retry + fallback |
| `src/components/ui/skeleton-card.tsx` | **Created** — Card/list/profile-header skeleton variants |
| `src/app/compare/error.tsx` | **Created** — Error page with retry + home link |
| `src/app/compare/loading.tsx` | **Created** — Two-column skeleton layout |
| `src/app/explore/error.tsx` | **Created** — Error page with retry |
| `src/app/explore/loading.tsx` | **Created** — Leaderboard row skeletons |
| `src/app/discover/loading.tsx` | **Created** — Grid skeleton with filter bar |

### Before/After

Pages that previously crashed on fetch failures now gracefully show error states with a "Try Again" action.

### Related Issue
Closes #234