### PR TITLE
perf(components): add React.memo, useDebounce hook, and memoized sub-components

### DIFF
--- a/src/components/discover/ProfileCard.tsx
+++ b/src/components/discover/ProfileCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { memo } from "react";
 import Link from "next/link";
 import Image from "next/image";
 
@@ -16,7 +17,7 @@ interface ProfileCardProps {
   topLanguages: string[];
 }
 
-export function ProfileCard({
+function ProfileCardInner({
   username,
   name,
   avatarUrl,
@@ -43,11 +44,11 @@ export function ProfileCard({
         display: "flex",
         flexDirection: "column",
         padding: "20px",
-        border: "1px solid #ededed",
+        border: "1px solid var(--color-hairline)",
         borderRadius: "12px",
         textDecoration: "none",
-        backgroundColor: "#ffffff",
-        transition: "border-color 0.15s",
+        backgroundColor: "var(--color-canvas)",
+        transition: "border-color 0.15s, background-color 0.2s",
       }}
     >
       <div style={{ display: "flex", alignItems: "center", gap: "12px", marginBottom: "12px" }}>
@@ -56,14 +57,14 @@ export function ProfileCard({
           alt={`${displayName} avatar`}
           width={44}
           height={44}
-          style={{ borderRadius: "9999px", border: "1px solid #ededed", flexShrink: 0 }}
+          style={{ borderRadius: "9999px", border: "1px solid var(--color-hairline)", flexShrink: 0 }}
         />
         <div style={{ minWidth: 0, flex: 1 }}>
           <p
             style={{
               fontSize: "15px",
               fontWeight: 600,
-              color: "#171717",
+              color: "var(--color-ink)",
               margin: 0,
               overflow: "hidden",
               textOverflow: "ellipsis",
@@ -75,7 +76,7 @@ export function ProfileCard({
           <p
             style={{
               fontSize: "13px",
-              color: "#9a9a9a",
+              color: "var(--color-ink-mute-2)",
               margin: "2px 0 0 0",
               overflow: "hidden",
               textOverflow: "ellipsis",
@@ -86,10 +87,10 @@ export function ProfileCard({
           </p>
         </div>
         <div style={{ textAlign: "right", flexShrink: 0 }}>
-          <p style={{ fontSize: "20px", fontWeight: 600, color: "#171717", margin: 0, lineHeight: 1 }}>
+          <p style={{ fontSize: "20px", fontWeight: 600, color: "var(--color-ink)", margin: 0, lineHeight: 1 }}>
             {score}
           </p>
-          <p style={{ fontSize: "11px", color: "#9a9a9a", margin: "2px 0 0 0" }}>score</p>
+          <p style={{ fontSize: "11px", color: "var(--color-ink-mute-2)", margin: "2px 0 0 0" }}>score</p>
         </div>
       </div>
 
@@ -97,7 +98,7 @@ export function ProfileCard({
         <p
           style={{
             fontSize: "13px",
-            color: "#707070",
+            color: "var(--color-ink-mute)",
             margin: "0 0 12px 0",
             overflow: "hidden",
             textOverflow: "ellipsis",
@@ -118,8 +119,8 @@ export function ProfileCard({
               style={{
                 fontSize: "11px",
                 fontWeight: 500,
-                color: "#4a4a4a",
-                backgroundColor: "#fafafa",
+                color: "var(--color-ink-mute)",
+                backgroundColor: "var(--color-canvas-soft)",
                 borderRadius: "4px",
                 padding: "2px 8px",
               }}
@@ -130,7 +131,7 @@ export function ProfileCard({
         </div>
       )}
 
-      <div style={{ display: "flex", gap: "16px", fontSize: "12px", color: "#9a9a9a" }}>
+      <div style={{ display: "flex", gap: "16px", fontSize: "12px", color: "var(--color-ink-mute-2)" }}>
         <span>{totalPrs} PRs</span>
         <span>{totalCommits} commits</span>
         <span>{totalIssues} issues</span>
@@ -139,3 +140,5 @@ export function ProfileCard({
     </Link>
   );
 }
+
+export const ProfileCard = memo(ProfileCardInner);

--- a/src/components/discover/SearchFilters.tsx
+++ b/src/components/discover/SearchFilters.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import { useDebounce } from "@/hooks/useDebounce";
 
 const SORT_OPTIONS = [
   { value: "score", label: "Score" },
@@ -28,8 +29,9 @@ export function SearchFilters() {
 
   const [query, setQuery] = useState(searchParams.get("q") || "");
   const [minScoreInput, setMinScoreInput] = useState(searchParams.get("min_score") || "");
-  const queryDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const scoreDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const debouncedQuery = useDebounce(query, 300);
+  const debouncedMinScore = useDebounce(minScoreInput, 500);
+  const initialRender = useRef(true);
 
   const lang = searchParams.get("lang") || "";
   const sort = searchParams.get("sort") || "score";
@@ -38,48 +40,46 @@ export function SearchFilters() {
   const pushParams = useCallback(
     (overrides: Record<string, string>) => {
       const params = new URLSearchParams();
-      const merged = { q: query, lang, sort, min_score: minScore, ...overrides };
+      const merged = { q: debouncedQuery, lang, sort, min_score: debouncedMinScore, ...overrides };
       Object.entries(merged).forEach(([key, val]) => {
         if (val) params.set(key, val);
       });
       router.replace(`/discover?${params.toString()}`);
     },
-    [query, lang, sort, minScore, router]
+    [debouncedQuery, lang, sort, debouncedMinScore, router]
   );
 
-  const handleQueryChange = (value: string) => {
-    setQuery(value);
-    if (queryDebounceRef.current) clearTimeout(queryDebounceRef.current);
-    queryDebounceRef.current = setTimeout(() => {
-      pushParams({ q: value, page: "" });
-    }, 300);
-  };
+  useEffect(() => {
+    if (initialRender.current) {
+      initialRender.current = false;
+      return;
+    }
+    pushParams({ q: debouncedQuery, page: "" });
+  }, [debouncedQuery, pushParams]);
 
   useEffect(() => {
-    return () => {
-      if (queryDebounceRef.current) clearTimeout(queryDebounceRef.current);
-      if (scoreDebounceRef.current) clearTimeout(scoreDebounceRef.current);
-    };
-  }, []);
+    if (initialRender.current) return;
+    pushParams({ min_score: debouncedMinScore, page: "" });
+  }, [debouncedMinScore, pushParams]);
 
   const inputStyle: React.CSSProperties = {
     width: "100%",
     fontSize: "15px",
     padding: "12px 16px",
-    border: "1px solid #ededed",
+    border: "1px solid var(--color-hairline)",
     borderRadius: "6px",
     outline: "none",
-    backgroundColor: "#fafafa",
-    color: "#171717",
+    backgroundColor: "var(--color-canvas-soft)",
+    color: "var(--color-ink)",
   };
 
   const selectStyle: React.CSSProperties = {
     fontSize: "14px",
     padding: "8px 12px",
-    border: "1px solid #ededed",
+    border: "1px solid var(--color-hairline)",
     borderRadius: "6px",
-    backgroundColor: "#ffffff",
-    color: "#171717",
+    backgroundColor: "var(--color-canvas)",
+    color: "var(--color-ink)",
     cursor: "pointer",
   };
 
@@ -89,7 +89,7 @@ export function SearchFilters() {
         type="text"
         placeholder="Search by username, name, or language..."
         value={query}
-        onChange={(e) => handleQueryChange(e.target.value)}
+        onChange={(e) => setQuery(e.target.value)}
         style={inputStyle}
         aria-label="Search profiles"
       />
@@ -98,7 +98,10 @@ export function SearchFilters() {
         <select
           value={lang}
           onChange={(e) => {
-            pushParams({ lang: e.target.value, page: "" });
+            const params = new URLSearchParams(searchParams.toString());
+            params.set("lang", e.target.value);
+            params.delete("page");
+            router.replace(`/discover?${params.toString()}`);
           }}
           style={selectStyle}
           aria-label="Filter by language"
@@ -114,7 +117,10 @@ export function SearchFilters() {
         <select
           value={sort}
           onChange={(e) => {
-            pushParams({ sort: e.target.value, page: "" });
+            const params = new URLSearchParams(searchParams.toString());
+            params.set("sort", e.target.value);
+            params.delete("page");
+            router.replace(`/discover?${params.toString()}`);
           }}
           style={selectStyle}
           aria-label="Sort by"
@@ -130,13 +136,7 @@ export function SearchFilters() {
           type="number"
           placeholder="Min score"
           value={minScoreInput}
-          onChange={(e) => {
-            setMinScoreInput(e.target.value);
-            if (scoreDebounceRef.current) clearTimeout(scoreDebounceRef.current);
-            scoreDebounceRef.current = setTimeout(() => {
-              pushParams({ min_score: e.target.value, page: "" });
-            }, 500);
-          }}
+          onChange={(e) => setMinScoreInput(e.target.value)}
           min={0}
           style={{ ...selectStyle, width: "100px" }}
           aria-label="Minimum score filter"
@@ -152,7 +152,7 @@ export function SearchFilters() {
             style={{
               fontSize: "13px",
               fontWeight: 500,
-              color: "#707070",
+              color: "var(--color-ink-mute)",
               background: "none",
               border: "none",
               cursor: "pointer",

--- a/src/components/profile/HeatmapWithYearNav.tsx
+++ b/src/components/profile/HeatmapWithYearNav.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, memo } from "react";
 import type { HeatmapWeek } from "@/types";
 import { computeStreaks } from "@/lib/mock";
 
@@ -14,7 +14,69 @@ interface HeatmapWithYearNavProps {
 const currentYear = new Date().getFullYear();
 const years = Array.from({ length: 5 }, (_, i) => currentYear - i);
 
-export function HeatmapWithYearNav({
+const YearButton = memo(function YearButton({
+  year,
+  selectedYear,
+  loading,
+  onClick,
+}: {
+  year: number;
+  selectedYear: number;
+  loading: boolean;
+  onClick: (year: number) => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onClick(year)}
+      disabled={loading}
+      style={{
+        padding: "4px 10px",
+        fontSize: "12px",
+        fontWeight: selectedYear === year ? 600 : 400,
+        color: selectedYear === year ? "#171717" : "var(--color-ink-mute)",
+        backgroundColor: selectedYear === year ? "#3ecf8e" : "var(--color-canvas-soft)",
+        border: selectedYear === year ? "none" : "1px solid var(--color-hairline)",
+        borderRadius: "9999px",
+        cursor: loading ? "wait" : "pointer",
+        transition: "background-color 0.15s, color 0.15s",
+      }}
+    >
+      {year}
+    </button>
+  );
+});
+
+const StreakBadge = memo(function StreakBadge({
+  label,
+  value,
+}: {
+  label: string;
+  value: number;
+}) {
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "baseline",
+        gap: "6px",
+        padding: "6px 12px",
+        border: "1px solid var(--color-hairline)",
+        borderRadius: "9999px",
+        fontSize: "13px",
+        color: "var(--color-ink-mute)",
+        backgroundColor: "var(--color-canvas-soft)",
+      }}
+    >
+      <strong style={{ color: "var(--color-ink)", fontWeight: 600 }}>
+        {value} {value === 1 ? "day" : "days"}
+      </strong>
+      {label}
+    </span>
+  );
+});
+
+function HeatmapWithYearNavInner({
   username,
   initialWeeks,
   initialCurrentStreak,
@@ -68,54 +130,20 @@ export function HeatmapWithYearNav({
         </h2>
         <div style={{ display: "flex", gap: "6px" }}>
           {years.map((year) => (
-            <button
+            <YearButton
               key={year}
-              type="button"
-              onClick={() => fetchYear(year)}
-              disabled={loading}
-              style={{
-                padding: "4px 10px",
-                fontSize: "12px",
-                fontWeight: selectedYear === year ? 600 : 400,
-                color: selectedYear === year ? "#171717" : "var(--color-ink-mute)",
-                backgroundColor: selectedYear === year ? "#3ecf8e" : "var(--color-canvas-soft)",
-                border: selectedYear === year ? "none" : "1px solid var(--color-hairline)",
-                borderRadius: "9999px",
-                cursor: loading ? "wait" : "pointer",
-                transition: "background-color 0.15s, color 0.15s",
-              }}
-            >
-              {year}
-            </button>
+              year={year}
+              selectedYear={selectedYear}
+              loading={loading}
+              onClick={fetchYear}
+            />
           ))}
         </div>
       </div>
 
       <div style={{ display: "flex", flexWrap: "wrap", gap: "8px", margin: "0 0 12px 0" }}>
-        {[
-          { label: "Current streak", value: currentStreak },
-          { label: "Longest streak", value: longestStreak },
-        ].map(({ label, value }) => (
-          <span
-            key={label}
-            style={{
-              display: "inline-flex",
-              alignItems: "baseline",
-              gap: "6px",
-              padding: "6px 12px",
-              border: "1px solid var(--color-hairline)",
-              borderRadius: "9999px",
-              fontSize: "13px",
-              color: "var(--color-ink-mute)",
-              backgroundColor: "var(--color-canvas-soft)",
-            }}
-          >
-            <strong style={{ color: "var(--color-ink)", fontWeight: 600 }}>
-              {value} {value === 1 ? "day" : "days"}
-            </strong>
-            {label}
-          </span>
-        ))}
+        <StreakBadge label="Current streak" value={currentStreak} />
+        <StreakBadge label="Longest streak" value={longestStreak} />
       </div>
 
       <div
@@ -166,3 +194,5 @@ export function HeatmapWithYearNav({
     </div>
   );
 }
+
+export const HeatmapWithYearNav = memo(HeatmapWithYearNavInner);

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,12 @@
+import { useState, useEffect } from "react";
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(id);
+  }, [value, delay]);
+
+  return debounced;
+}

--- a/src/hooks/useMounted.ts
+++ b/src/hooks/useMounted.ts
@@ -1,0 +1,12 @@
+import { useEffect, useRef } from "react";
+
+export function useMounted(): boolean {
+  const mounted = useRef(false);
+
+  useEffect(() => {
+    mounted.current = true;
+    return () => { mounted.current = false; };
+  }, []);
+
+  return mounted.current;
+}

--- a/src/hooks/useMounted.ts
+++ b/src/hooks/useMounted.ts
@@ -1,12 +1,11 @@
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
+
+const emptySubscribe = () => () => {};
 
 export function useMounted(): boolean {
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => {
-    setMounted(true);
-    return () => setMounted(false);
-  }, []);
-
-  return mounted;
+  return useSyncExternalStore(
+    emptySubscribe,
+    () => true,
+    () => false
+  );
 }

--- a/src/hooks/useMounted.ts
+++ b/src/hooks/useMounted.ts
@@ -1,12 +1,12 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useState } from "react";
 
 export function useMounted(): boolean {
-  const mounted = useRef(false);
+  const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
-    mounted.current = true;
-    return () => { mounted.current = false; };
+    setMounted(true);
+    return () => setMounted(false);
   }, []);
 
-  return mounted.current;
+  return mounted;
 }


### PR DESCRIPTION
## Summary

Performance optimization: two new hooks, React.memo on heavy components, and declarative debounce in SearchFilters.

### Changes

| File | Change |
|------|--------|
| `src/hooks/useDebounce.ts` | **Created** — Generic debounce hook with configurable delay |
| `src/hooks/useMounted.ts` | **Created** — Boolean hook for client-side mounting |
| `src/components/profile/HeatmapWithYearNav.tsx` | Updated — React.memo wrapper, memoized YearButton/StreakBadge |
| `src/components/discover/ProfileCard.tsx` | Updated — React.memo wrapper |
| `src/components/discover/SearchFilters.tsx` | Updated — Declarative useDebounce instead of manual setTimeout |

### Impact

Reduces unnecessary re-renders on:
- Profile heatmap (365 cells × year changes)
- Discover search results grid
- Filter panel on keystroke

### Related Issue
Closes #237

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search filters now update more smoothly, with delayed syncing for text and score changes.
  * Profile and heatmap sections were refreshed to better support faster, more responsive interactions.

* **Bug Fixes**
  * Improved filter behavior so the page URL updates more reliably when changing language or sorting options.
  * Updated card and profile visuals to use the app’s shared theme colors for more consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->