### PR TITLE
fix: normalize GitHub rate limit handling with typed errors

### DIFF
--- a/src/app/[username]/page.tsx
+++ b/src/app/[username]/page.tsx
@@ -117,13 +117,45 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
     if (e instanceof RateLimitError) rateLimited = true;
     user = null;
   }
-  // Other fetches can also error on rate limit; we treat them similarly.
-  try { repos = await fetchGitHubRepos(username); } catch (e) { if (e instanceof RateLimitError) rateLimited = true; }
-  try { liveStats = await fetchLiveStats(username); } catch (e) { if (e instanceof RateLimitError) rateLimited = true; }
+  const [reposResult, liveStatsResult, mergedPRsResult, orgsResult, contributionCalendarResult] =
+    await Promise.allSettled([
+      fetchGitHubRepos(username),
+      fetchLiveStats(username),
+      fetchMergedPRs(username, 10),
+      fetchOrganizations(username),
+      fetchContributionCalendar(username),
+    ]);
+
+  if (reposResult.status === "fulfilled") {
+    repos = reposResult.value;
+  } else if (reposResult.reason instanceof RateLimitError) {
+    rateLimited = true;
+  }
+
+  if (liveStatsResult.status === "fulfilled") {
+    liveStats = liveStatsResult.value;
+  } else if (liveStatsResult.reason instanceof RateLimitError) {
+    rateLimited = true;
+  }
+
   let mergedPRs: any[] = [];
-  try { mergedPRs = await fetchMergedPRs(username, 10); } catch (e) { if (e instanceof RateLimitError) rateLimited = true; }
-  try { orgs = await fetchOrganizations(username); } catch (e) { if (e instanceof RateLimitError) rateLimited = true; }
-  try { contributionCalendar = await fetchContributionCalendar(username); } catch (e) { if (e instanceof RateLimitError) rateLimited = true; }
+  if (mergedPRsResult.status === "fulfilled") {
+    mergedPRs = mergedPRsResult.value;
+  } else if (mergedPRsResult.reason instanceof RateLimitError) {
+    rateLimited = true;
+  }
+
+  if (orgsResult.status === "fulfilled") {
+    orgs = orgsResult.value;
+  } else if (orgsResult.reason instanceof RateLimitError) {
+    rateLimited = true;
+  }
+
+  if (contributionCalendarResult.status === "fulfilled") {
+    contributionCalendar = contributionCalendarResult.value;
+  } else if (contributionCalendarResult.reason instanceof RateLimitError) {
+    rateLimited = true;
+  }
 
   if (!user && !rateLimited) return notFound();
 

--- a/src/app/[username]/page.tsx
+++ b/src/app/[username]/page.tsx
@@ -14,6 +14,7 @@ import { generateMockHeatmap, computeStreaks } from "@/lib/mock";
 import { fetchContributionCalendar } from "@/lib/github";
 import { calculateScore } from "@/lib/score";
 import { supabase } from "@/lib/supabase";
+import { createGitHubApiError, RateLimitError } from "@/lib/errors";
 
 export const runtime = "edge";
 
@@ -41,17 +42,8 @@ async function fetchGitHubUser(username: string): Promise<GitHubUser | null> {
     next: { revalidate: 3600 },
     signal: AbortSignal.timeout(10000),
   });
-  if (!res.ok) {
-    try {
-      const err = await res.json();
-      if (err.message && err.message.toLowerCase().includes("rate limit")) {
-        throw new Error("RateLimit");
-      }
-    } catch (e) {
-      if (e instanceof Error && e.message === "RateLimit") throw e;
-    }
-    return null;
-  }
+  if (res.status === 404) return null;
+  if (!res.ok) throw await createGitHubApiError(res);
   return res.json() as Promise<GitHubUser>;
 }
 
@@ -63,7 +55,7 @@ async function fetchGitHubRepos(username: string) {
       next: { revalidate: 3600 },
     }
   );
-  if (!res.ok) return [];
+  if (!res.ok) throw await createGitHubApiError(res);
   const repos = await res.json();
   return repos.filter((r: { fork: boolean }) => !r.fork).slice(0, 6);
 }
@@ -122,16 +114,16 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
   try {
     user = await fetchGitHubUser(username);
   } catch (e) {
-    if (e instanceof Error && e.message === "RateLimit") rateLimited = true;
+    if (e instanceof RateLimitError) rateLimited = true;
     user = null;
   }
   // Other fetches can also error on rate limit; we treat them similarly.
-  try { repos = await fetchGitHubRepos(username); } catch (e) { if (e instanceof Error && e.message === "RateLimit") rateLimited = true; }
-  try { liveStats = await fetchLiveStats(username); } catch (e) { if (e instanceof Error && e.message === "RateLimit") rateLimited = true; }
+  try { repos = await fetchGitHubRepos(username); } catch (e) { if (e instanceof RateLimitError) rateLimited = true; }
+  try { liveStats = await fetchLiveStats(username); } catch (e) { if (e instanceof RateLimitError) rateLimited = true; }
   let mergedPRs: any[] = [];
-  try { mergedPRs = await fetchMergedPRs(username, 10); } catch (e) { if (e instanceof Error && e.message === "RateLimit") rateLimited = true; }
-  try { orgs = await fetchOrganizations(username); } catch (e) { if (e instanceof Error && e.message === "RateLimit") rateLimited = true; }
-  try { contributionCalendar = await fetchContributionCalendar(username); } catch (e) { if (e instanceof Error && e.message === "RateLimit") rateLimited = true; }
+  try { mergedPRs = await fetchMergedPRs(username, 10); } catch (e) { if (e instanceof RateLimitError) rateLimited = true; }
+  try { orgs = await fetchOrganizations(username); } catch (e) { if (e instanceof RateLimitError) rateLimited = true; }
+  try { contributionCalendar = await fetchContributionCalendar(username); } catch (e) { if (e instanceof RateLimitError) rateLimited = true; }
 
   if (!user && !rateLimited) return notFound();
 

--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -15,6 +15,7 @@ import { calculateScore } from "@/lib/score";
 import { supabase } from "@/lib/supabase";
 import type { ContributorStats, Repo } from "@/types";
 import { CompareForm } from "@/components/profile/CompareForm";
+import { createGitHubApiError } from "@/lib/errors";
 
 export const runtime = "edge";
 
@@ -42,9 +43,7 @@ async function fetchGitHubUser(username: string) {
     next: { revalidate: 3600 },
   });
   if (res.status === 404) return null;
-  if (!res.ok) {
-    throw new Error(`GitHub user lookup failed (${res.status})`);
-  }
+  if (!res.ok) throw await createGitHubApiError(res);
   return res.json();
 }
 
@@ -59,9 +58,7 @@ async function fetchGitHubRepos(username: string) {
       next: { revalidate: 3600 },
     }
   );
-  if (!res.ok) {
-    throw new Error(`GitHub repositories lookup failed (${res.status})`);
-  }
+  if (!res.ok) throw await createGitHubApiError(res);
   const repos = await res.json();
   return repos
     .filter((r: { fork: boolean }) => !r.fork)
@@ -73,14 +70,15 @@ async function fetchGitHubRepos(username: string) {
 }
 
 async function fetchProfile(username: string): Promise<ProfileData> {
-  const [user, repos, liveStats, contributionCalendar] = await Promise.all([
-    fetchGitHubUser(username),
+  const user = await fetchGitHubUser(username);
+
+  if (!user) throw new Error(`GitHub user "${username}" not found`);
+
+  const [repos, liveStats, contributionCalendar] = await Promise.all([
     fetchGitHubRepos(username),
     fetchLiveStats(username),
     fetchContributionCalendar(username),
   ]);
-
-  if (!user) throw new Error(`GitHub user "${username}" not found`);
 
   const mappedRepos = mapRepos(repos);
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,66 @@
+export class RateLimitError extends Error {
+  constructor(message: string = "GitHub API rate limit reached.") {
+    super(message);
+    this.name = "RateLimitError";
+  }
+}
+
+export class GitHubApiError extends Error {
+  status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "GitHubApiError";
+    this.status = status;
+  }
+}
+
+function getGitHubErrorMessage(body: unknown): string | null {
+  if (typeof body === "string") {
+    const trimmed = body.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  if (!body || typeof body !== "object") return null;
+
+  const message = (body as { message?: unknown }).message;
+  if (typeof message === "string" && message.trim().length > 0) {
+    return message.trim();
+  }
+
+  return null;
+}
+
+export function isGitHubRateLimitedResponse(
+  response: Response,
+  body: unknown
+): boolean {
+  if (response.status === 403 && response.headers.get("x-ratelimit-remaining") === "0") {
+    return true;
+  }
+
+  const message = getGitHubErrorMessage(body);
+  return typeof message === "string" && message.toLowerCase().includes("rate limit");
+}
+
+export async function createGitHubApiError(
+  response: Response
+): Promise<RateLimitError | GitHubApiError> {
+  let body: unknown = null;
+  const text = await response.text();
+
+  if (text.length > 0) {
+    try {
+      body = JSON.parse(text) as unknown;
+    } catch {
+      body = text;
+    }
+  }
+
+  if (isGitHubRateLimitedResponse(response, body)) {
+    return new RateLimitError();
+  }
+
+  const message = getGitHubErrorMessage(body) ?? `GitHub API request failed (${response.status})`;
+  return new GitHubApiError(message, response.status);
+}

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,4 +1,5 @@
 import type { ContributorStats, Repo } from "@/types";
+import { createGitHubApiError } from "@/lib/errors";
 
 const GITHUB_GRAPHQL_URL = "https://api.github.com/graphql";
 
@@ -216,9 +217,9 @@ export interface ContributionCalendar {
 /**
  * Fetch and parse a user's real contribution calendar from GitHub's public
  * (unauthenticated) HTML endpoint. Returns weeks ordered oldest → newest, each
- * with seven days ordered Sunday → Saturday, plus the year's total. Returns
- * `null` if the request fails or the markup cannot be parsed, so callers can
- * fall back gracefully without crashing the page.
+ * with seven days ordered Sunday → Saturday, plus the year's total. Request
+ * failures are promoted to typed GitHub API errors; malformed markup still
+ * returns `null` so callers can fall back gracefully without crashing.
  */
 export async function fetchContributionCalendar(
   username: string,
@@ -240,7 +241,7 @@ export async function fetchContributionCalendar(
         next: { revalidate: 3600 }, // cache for 1 hour, like the other GitHub calls
       }
     );
-    if (!res.ok) return null;
+    if (!res.ok) throw await createGitHubApiError(res);
 
     const html = await res.text();
 

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -225,26 +225,35 @@ export async function fetchContributionCalendar(
   username: string,
   from?: string
 ): Promise<ContributionCalendar | null> {
+  let url = `https://github.com/users/${encodeURIComponent(username)}/contributions`;
+  if (from) {
+    url += `?from=${encodeURIComponent(from)}`;
+  }
+
+  let res: Response;
   try {
-    let url = `https://github.com/users/${encodeURIComponent(username)}/contributions`;
-    if (from) {
-      url += `?from=${encodeURIComponent(from)}`;
-    }
-    const res = await fetch(
-      url,
-      {
-        headers: {
-          // GitHub returns the calendar fragment for a normal browser Accept.
-          Accept: "text/html",
-          "User-Agent": "ossfolio (+https://ossfolio.qzz.io)",
-        },
-        next: { revalidate: 3600 }, // cache for 1 hour, like the other GitHub calls
-      }
-    );
-    if (!res.ok) throw await createGitHubApiError(res);
+    res = await fetch(url, {
+      headers: {
+        // GitHub returns the calendar fragment for a normal browser Accept.
+        Accept: "text/html",
+        "User-Agent": "ossfolio (+https://ossfolio.qzz.io)",
+      },
+      next: { revalidate: 3600 }, // cache for 1 hour, like the other GitHub calls
+    });
+  } catch {
+    return null;
+  }
 
-    const html = await res.text();
+  if (!res.ok) throw await createGitHubApiError(res);
 
+  let html: string;
+  try {
+    html = await res.text();
+  } catch {
+    return null;
+  }
+
+  try {
     // Step 1: build a map of cell id → exact contribution count from the
     // accessible tool-tip labels. "No contributions" labels stay at 0.
     const countById = new Map<string, number>();

--- a/src/lib/profile-data.ts
+++ b/src/lib/profile-data.ts
@@ -1,5 +1,6 @@
 import type { ContributorStats, Org, Repo, TechEntry, MergedPR } from "@/types";
 import { LANG_COLORS } from "@/lib/languages";
+import { createGitHubApiError } from "@/lib/errors";
 
 /**
  * Live profile "extras" derived from the public (unauthenticated) GitHub REST
@@ -62,24 +63,20 @@ export function deriveTechStack(repos: GitHubRepoLike[]): TechEntry[] {
     .sort((a, b) => b.repoCount - a.repoCount);
 }
 
-/** A single Search API count call. Returns 0 on any failure (rate limit, etc.). */
+/** A single Search API count call. Non-OK responses are promoted to typed GitHub API errors. */
 async function searchCount(query: string, accept?: string): Promise<number> {
-  try {
-    const res = await fetch(
-      `https://api.github.com/search/${query}&per_page=1`,
-      {
-        headers: {
-          Accept: accept ?? "application/vnd.github.v3+json",
-        },
-        next: { revalidate: 3600 },
-      }
-    );
-    if (!res.ok) return 0;
-    const json = await res.json();
-    return typeof json.total_count === "number" ? json.total_count : 0;
-  } catch {
-    return 0;
-  }
+  const res = await fetch(
+    `https://api.github.com/search/${query}&per_page=1`,
+    {
+      headers: {
+        Accept: accept ?? "application/vnd.github.v3+json",
+      },
+      next: { revalidate: 3600 },
+    }
+  );
+  if (!res.ok) throw await createGitHubApiError(res);
+  const json = await res.json();
+  return typeof json.total_count === "number" ? json.total_count : 0;
 }
 
 /**
@@ -116,46 +113,38 @@ interface GitHubOrgLike {
 
 /** Fetch the user's public organizations and map to the `Org` type. */
 export async function fetchOrganizations(username: string): Promise<Org[]> {
-  try {
-    const res = await fetch(
-      `https://api.github.com/users/${encodeURIComponent(username)}/orgs`,
-      {
-        headers: { Accept: "application/vnd.github.v3+json" },
-        next: { revalidate: 3600 },
-      }
-    );
-    if (!res.ok) return [];
-    const orgs = (await res.json()) as GitHubOrgLike[];
-    if (!Array.isArray(orgs)) return [];
-    return orgs.map((o) => ({
-      login: o.login,
-      name: o.description,
-      avatarUrl: o.avatar_url,
-      url: `https://github.com/${o.login}`,
-    }));
-  } catch {
-    return [];
-  }
+  const res = await fetch(
+    `https://api.github.com/users/${encodeURIComponent(username)}/orgs`,
+    {
+      headers: { Accept: "application/vnd.github.v3+json" },
+      next: { revalidate: 3600 },
+    }
+  );
+  if (!res.ok) throw await createGitHubApiError(res);
+  const orgs = (await res.json()) as GitHubOrgLike[];
+  if (!Array.isArray(orgs)) return [];
+  return orgs.map((o) => ({
+    login: o.login,
+    name: o.description,
+    avatarUrl: o.avatar_url,
+    url: `https://github.com/${o.login}`,
+  }));
 }
 
 /** Fetch recent merged pull requests for a user */
 export async function fetchMergedPRs(username: string, limit: number = 10): Promise<MergedPR[]> {
   const query = `search/issues?q=author:${encodeURIComponent(username)}+type:pr+is:merged&sort=updated&order=desc&per_page=${limit}`;
-  try {
-    const res = await fetch(`https://api.github.com/${query}`, {
-      headers: { Accept: "application/vnd.github.v3+json" },
-      next: { revalidate: 3600 },
-    });
-    if (!res.ok) return [];
-    const json = await res.json();
-    if (!Array.isArray(json.items)) return [];
-    return json.items.map((item: any) => ({
-      title: item.title,
-      url: item.html_url,
-      repoName: item.repository_url.split('/').slice(-1)[0],
-      mergedAt: item.closed_at,
-    }));
-  } catch {
-    return [];
-  }
+  const res = await fetch(`https://api.github.com/${query}`, {
+    headers: { Accept: "application/vnd.github.v3+json" },
+    next: { revalidate: 3600 },
+  });
+  if (!res.ok) throw await createGitHubApiError(res);
+  const json = await res.json();
+  if (!Array.isArray(json.items)) return [];
+  return json.items.map((item: any) => ({
+    title: item.title,
+    url: item.html_url,
+    repoName: item.repository_url.split('/').slice(-1)[0],
+    mergedAt: item.closed_at,
+  }));
 }


### PR DESCRIPTION
## Summary

This PR replaces the existing string-based `"RateLimit"` contract with typed GitHub API errors and centralizes rate-limit normalization across GitHub integrations.

## What changed

* Added `RateLimitError` and `GitHubApiError`
* Centralized GitHub REST error normalization
* Replaced `error.message === "RateLimit"` checks with `instanceof RateLimitError`
* Updated profile and compare flows to use typed errors
* Removed manual string sentinel propagation
* Preserved the existing user-facing fallback UI

## Why

Previously, rate limiting was propagated through a manually injected `"RateLimit"` error string and detected through message comparison.

This approach was fragile because:

* It tightly coupled UI logic with internal error strings
* It was not derived from actual GitHub API semantics
* It made it difficult to distinguish rate limits from authentication, network, or other API failures

## Benefits

* Strongly typed error handling
* Consistent behavior across GitHub integrations
* Better maintainability and observability
* Easier future extension for additional providers or APIs

## Validation

* Removed all `"RateLimit"` string checks from the codebase
* Verified TypeScript type checks pass
* Preserved existing fallback behavior for end users

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub error handling on profile and comparison pages.
  * Rate-limit situations are now detected more reliably, reducing incorrect fallback states.
  * Failed data loads now surface more consistent “temporarily unavailable” behavior instead of partial or misleading results.

* **New Features**
  * Added standardized handling for GitHub API failures across profile data, repositories, organizations, merged PRs, live stats, and contribution data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->