### PR TITLE
I hv Updated AuthModal.tsx

### DIFF
--- a/src/components/auth/AuthModal.tsx
+++ b/src/components/auth/AuthModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { X } from "lucide-react";
+import { X,Eye,EyeOff } from "lucide-react";
 import { supabase } from "@/lib/supabase";
 
 interface AuthModalProps {
@@ -18,6 +18,7 @@ export function AuthModal({ open, onClose, defaultMode = "signin" }: AuthModalPr
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const overlayRef = useRef<HTMLDivElement>(null);
+const [showPassword, setShowPassword] = useState(false);
 
   useEffect(() => {
     document.body.style.overflow = open ? "hidden" : "";
@@ -215,8 +216,9 @@ export function AuthModal({ open, onClose, defaultMode = "signin" }: AuthModalPr
           onMouseLeave={(e) => { if (!loading) e.currentTarget.style.backgroundColor = "var(--color-canvas)"; }}
         >
           <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-            <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23(1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
-          </svg>
+  <path fillRule="evenodd" clipRule="evenodd" d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
+</svg>
+
           {loading ? "Redirecting…" : "Continue with GitHub"}
         </button>
 
@@ -274,18 +276,46 @@ export function AuthModal({ open, onClose, defaultMode = "signin" }: AuthModalPr
           </div>
 
           <div style={{ display: "flex", flexDirection: "column", gap: "6px" }}>
-            <label style={{ fontSize: "13px", fontWeight: 500, color: "var(--color-ink)", transition: "color 0.2s ease" }}>Password</label>
-            <input
-              type="password"
-              placeholder="••••••••"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
-              style={inputStyle}
-              onFocus={(e) => (e.currentTarget.style.borderColor = "var(--color-primary)")}
-              onBlur={(e) => (e.currentTarget.style.borderColor = "var(--color-hairline)")}
-            />
-          </div>
+  <label style={{ fontSize: "13px", fontWeight: 500, color: "var(--color-ink)", transition: "color 0.2s ease" }}>Password</label>
+  
+  {/* Relative wrapper context forces children layers to calculate positions relative to this box */}
+  <div style={{ position: "relative", width: "100%", display: "flex", alignItems: "center" }}>
+    <input
+      type={showPassword ? "text" : "password"}
+      placeholder="••••••••"
+      value={password}
+      onChange={(e) => setPassword(e.target.value)}
+      required
+      
+      style={{ ...inputStyle, paddingRight: "40px" }} 
+      onFocus={(e) => (e.currentTarget.style.borderColor = "var(--color-primary)")}
+      onBlur={(e) => (e.currentTarget.style.borderColor = "var(--color-hairline)")}
+    />
+    
+    {/* Absolute button layer overlays directly on top of the input canvas */}
+    <button
+      type="button"
+      onClick={() => setShowPassword(!showPassword)}
+      style={{
+        position: "absolute",
+        right: "12px", // Pushes the eye inside the right border line
+        background: "none",
+        border: "none",
+        cursor: "pointer",
+        color: "var(--color-ink-mute-2)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: "4px",
+        height: "100%", // Matches the height context to stay perfectly centered vertically
+      }}
+      aria-label={showPassword ? "Hide password" : "Show password"}
+    >
+      {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
+    </button>
+  </div>
+</div>
+
 
           <button
             type="submit"


### PR DESCRIPTION
## 🛠️ Pull Request Description

### 📝 Problem Statement
The user registration and authentication modal lacked crucial visual clarity and standard web accessibility/usability features:
1. **Unclear GitHub Brand Identity**: The "Continue with GitHub" button was not rendering a distinct, recognizable GitHub logo due to a malformed vector string.
2. **Blind Input Masking**: The password field on both forms remained completely masked (`••••••••`) at all times, giving users no way to double-check their credentials for spelling errors or typos.

### 🚀 Proposed Changes
This PR addresses both issues by updating the `AuthModal.tsx` file with the following interface improvements:

* **Fixed Corrupted GitHub SVG**: Replaced the illegal parenthesis symbol (`(1.08`) inside the `<path d="...">` coordinates string with a valid command spacing layout so the brand silhouette renders flawlessly.
* **Integrated Password Visibility Toggle**: Added an absolute-positioned interactive button inside the right boundary of the password input box.
* **State Management**: Used a React `useState` toggle configuration to dynamically swap the input container's standard attribute between `type="password"` and `type="text"`.
* **Clean UI Icons**: Utilized standard `Eye` and `EyeOff` vector assets imported cleanly from `lucide-react`.

### 🔍 Verification & Testing Done
* Tested layout rendering locally on `http://localhost:3000`.
* Verified that the GitHub logo icon prints crisply on the sign-in row button.
* Confirmed that clicking the inner eye icon button successfully masks and unmasks the active text value seamlessly without shifting surrounding input boundaries.
* Verified no structural layout overflow actions occur when maximum character boundary limits are reached inside the text box.

Closes issue #270 
<p align="center">
<img width="587" height="791"  alt="image" src="https://github.com/user-attachments/assets/7291f24a-fe06-482f-a0a2-53ac0eddc581" />

<p>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a password visibility toggle in the sign-in/sign-up form, making it easier to review entered passwords before submitting.
  * Updated the GitHub sign-in button icon appearance.

* **Accessibility**
  * Improved the password toggle control with clearer labels for screen readers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->