### PR TITLE
feat(webhooks): GitHub push webhook receiver with signature verification (Closes #305)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,5 +11,11 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=
 # GH_CLIENT_ID=
 # GH_CLIENT_SECRET=
 
+# ── GitHub Webhooks (automatic profile refresh) ──────────────────────
+# Shared secret used to verify the X-Hub-Signature-256 header on incoming
+# GitHub push webhooks (POST /api/webhooks/github). Set the same value as the
+# "Secret" field when creating the webhook in your repo/org settings.
+# GITHUB_WEBHOOK_SECRET=
+
 # ── AI Features (optional) ───────────────────────────────────────────
 # ANTHROPIC_API_KEY=

--- a/src/app/api/[username]/refresh/route.ts
+++ b/src/app/api/[username]/refresh/route.ts
@@ -1,12 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
-import { revalidatePath } from "next/cache";
-import { createClient } from "@supabase/supabase-js";
+import { NextRequest } from "next/server";
 import { sanitizeUsername, createApiResponse, createErrorResponse } from "@/lib/api-validation";
-
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
-
-const RATE_LIMIT_MS = 10 * 60 * 1000;
+import { refreshProfile } from "@/lib/refresh-profile";
 
 export async function POST(
   request: NextRequest,
@@ -19,50 +13,22 @@ export async function POST(
     return createErrorResponse("Invalid GitHub username format", 400);
   }
 
-  const supabase = createClient(supabaseUrl, supabaseServiceKey);
+  const result = await refreshProfile(username);
 
-  const cutoff = new Date(Date.now() - RATE_LIMIT_MS).toISOString();
-
-  const { data, error } = await supabase
-    .from("profiles")
-    .update({
-      last_refreshed_at: new Date().toISOString(),
-      updated_at: new Date().toISOString(),
-    })
-    .eq("username", username)
-    .or(`last_refreshed_at.is.null,last_refreshed_at.lt.${cutoff}`)
-    .select("username")
-    .single();
-
-  if (error && error.code === "PGRST116") {
-    const { data: exists } = await supabase
-      .from("profiles")
-      .select("username, last_refreshed_at")
-      .eq("username", username)
-      .single();
-
-    if (!exists) {
+  switch (result.status) {
+    case "refreshed":
+      return createApiResponse({
+        success: true,
+        message: `Profile ${username} refresh triggered`,
+        refreshedAt: new Date().toISOString(),
+      });
+    case "rate_limited":
+      return createErrorResponse("Rate limited. Try again later.", 429, {
+        retryAfterSeconds: result.retryAfterSeconds,
+      });
+    case "not_found":
       return createErrorResponse("Profile not found", 404);
-    }
-
-    const lastRefresh = exists.last_refreshed_at
-      ? new Date(exists.last_refreshed_at).getTime()
-      : 0;
-    const retryAfter = Math.ceil((RATE_LIMIT_MS - (Date.now() - lastRefresh)) / 1000);
-    return createErrorResponse("Rate limited. Try again later.", 429, {
-      retryAfterSeconds: Math.max(retryAfter, 1),
-    });
+    case "error":
+      return createErrorResponse("Failed to refresh profile", 500);
   }
-
-  if (error) {
-    return createErrorResponse("Failed to refresh profile", 500);
-  }
-
-  revalidatePath(`/${username}`);
-
-  return createApiResponse({
-    success: true,
-    message: `Profile ${username} refresh triggered`,
-    refreshedAt: new Date().toISOString(),
-  });
 }

--- a/src/app/api/webhooks/github/route.ts
+++ b/src/app/api/webhooks/github/route.ts
@@ -84,8 +84,10 @@ export async function POST(request: NextRequest) {
   after(async () => {
     try {
       await refreshProfile(username);
-    } catch {
-      // Best-effort: GitHub already received its 2xx.
+    } catch (err) {
+      // Best-effort: GitHub already received its 2xx. Log so failed
+      // webhook-triggered refreshes are visible in production.
+      console.error("GitHub webhook: background refresh failed", { username, err });
     }
   });
 

--- a/src/app/api/webhooks/github/route.ts
+++ b/src/app/api/webhooks/github/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest, after } from "next/server";
+import { sanitizeUsername, createApiResponse, createErrorResponse } from "@/lib/api-validation";
+import { refreshProfile } from "@/lib/refresh-profile";
+
+// Receives GitHub `push` webhooks and triggers a (rate-limited) refresh of the
+// affected profile in the background. Signature verification uses Web Crypto so
+// it works on both the edge and Node runtimes.
+
+/** Constant-time comparison of two equal-length hex strings. */
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let mismatch = 0;
+  for (let i = 0; i < a.length; i++) {
+    mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return mismatch === 0;
+}
+
+/** Verify GitHub's `X-Hub-Signature-256` (HMAC-SHA256 of the raw body). */
+async function verifySignature(
+  secret: string,
+  body: string,
+  header: string | null
+): Promise<boolean> {
+  if (!header || !header.startsWith("sha256=")) return false;
+
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const signed = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(body));
+  const digest = Array.from(new Uint8Array(signed))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+
+  return timingSafeEqual(`sha256=${digest}`, header);
+}
+
+interface PushPayload {
+  repository?: { owner?: { login?: string; name?: string } };
+}
+
+export async function POST(request: NextRequest) {
+  const secret = process.env.GITHUB_WEBHOOK_SECRET;
+  if (!secret) {
+    // Fail closed: without a configured secret nothing can be verified.
+    return createErrorResponse("Webhook not configured", 503);
+  }
+
+  // The raw body is required — re-serializing parsed JSON would change bytes and
+  // break the HMAC.
+  const body = await request.text();
+  const signature = request.headers.get("x-hub-signature-256");
+  if (!(await verifySignature(secret, body, signature))) {
+    return createErrorResponse("Invalid signature", 401);
+  }
+
+  const event = request.headers.get("x-github-event");
+  if (event === "ping") {
+    return createApiResponse({ ok: true, message: "pong" });
+  }
+  if (event !== "push") {
+    // Acknowledge other events so GitHub doesn't retry them.
+    return createApiResponse({ ok: true, ignored: event ?? "unknown" });
+  }
+
+  let owner: string | undefined;
+  try {
+    const payload = JSON.parse(body) as PushPayload;
+    owner = payload.repository?.owner?.login ?? payload.repository?.owner?.name;
+  } catch {
+    return createErrorResponse("Invalid JSON payload", 400);
+  }
+
+  const username = sanitizeUsername(owner);
+  if (!username) {
+    return createApiResponse({ ok: true, ignored: "no repository owner" });
+  }
+
+  // Respond fast; run the rate-limited refresh after the response is sent.
+  after(async () => {
+    try {
+      await refreshProfile(username);
+    } catch {
+      // Best-effort: GitHub already received its 2xx.
+    }
+  });
+
+  return createApiResponse({ ok: true, accepted: username });
+}

--- a/src/lib/refresh-profile.ts
+++ b/src/lib/refresh-profile.ts
@@ -37,12 +37,17 @@ export async function refreshProfile(username: string): Promise<RefreshResult> {
   // PGRST116 = no row matched the update (either the profile doesn't exist, or
   // it exists but is still within the rate-limit window).
   if (error && error.code === "PGRST116") {
-    const { data: exists } = await supabase
+    const { data: exists, error: existsError } = await supabase
       .from("profiles")
       .select("username, last_refreshed_at")
       .eq("username", username)
       .single();
 
+    // A PGRST116 here means the row genuinely doesn't exist; any other error is
+    // an operational failure and must not be reported as "not found".
+    if (existsError && existsError.code !== "PGRST116") {
+      return { status: "error" };
+    }
     if (!exists) {
       return { status: "not_found" };
     }

--- a/src/lib/refresh-profile.ts
+++ b/src/lib/refresh-profile.ts
@@ -1,0 +1,63 @@
+import { revalidatePath } from "next/cache";
+import { createClient } from "@supabase/supabase-js";
+
+// A refresh bumps `last_refreshed_at` (which the profile page reads to re-fetch
+// from GitHub on its next render) and revalidates that page's cache. It's
+// rate-limited so rapid triggers — e.g. a burst of webhook pushes — don't hammer
+// the profile. This mirrors the manual Refresh endpoint's original behaviour,
+// extracted here so both the route and the webhook share one implementation.
+
+const RATE_LIMIT_MS = 10 * 60 * 1000;
+
+export type RefreshResult =
+  | { status: "refreshed"; username: string }
+  | { status: "rate_limited"; retryAfterSeconds: number }
+  | { status: "not_found" }
+  | { status: "error" };
+
+export async function refreshProfile(username: string): Promise<RefreshResult> {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !supabaseServiceKey) {
+    return { status: "error" };
+  }
+
+  const supabase = createClient(supabaseUrl, supabaseServiceKey);
+  const now = new Date().toISOString();
+  const cutoff = new Date(Date.now() - RATE_LIMIT_MS).toISOString();
+
+  const { data, error } = await supabase
+    .from("profiles")
+    .update({ last_refreshed_at: now, updated_at: now })
+    .eq("username", username)
+    .or(`last_refreshed_at.is.null,last_refreshed_at.lt.${cutoff}`)
+    .select("username")
+    .single();
+
+  // PGRST116 = no row matched the update (either the profile doesn't exist, or
+  // it exists but is still within the rate-limit window).
+  if (error && error.code === "PGRST116") {
+    const { data: exists } = await supabase
+      .from("profiles")
+      .select("username, last_refreshed_at")
+      .eq("username", username)
+      .single();
+
+    if (!exists) {
+      return { status: "not_found" };
+    }
+
+    const lastRefresh = exists.last_refreshed_at
+      ? new Date(exists.last_refreshed_at).getTime()
+      : 0;
+    const retryAfter = Math.ceil((RATE_LIMIT_MS - (Date.now() - lastRefresh)) / 1000);
+    return { status: "rate_limited", retryAfterSeconds: Math.max(retryAfter, 1) };
+  }
+
+  if (error) {
+    return { status: "error" };
+  }
+
+  revalidatePath(`/${data.username}`);
+  return { status: "refreshed", username: data.username };
+}


### PR DESCRIPTION
Closes #305

## Summary
Adds a GitHub webhook receiver so profiles refresh automatically on `push`,
instead of relying on the manual "Refresh" button. Per the scoping discussion
on the issue, this is the **webhook + shared-secret** version (a full GitHub
App is a documented follow-up).

## How it works
`POST /api/webhooks/github`:
1. Verifies the `X-Hub-Signature-256` header — HMAC-SHA256 of the **raw**
   request body against `GITHUB_WEBHOOK_SECRET`, using a constant-time
   comparison. Missing/invalid signatures → `401`. No secret configured →
   `503` (fail closed).
2. Handles `ping` (returns pong) and acknowledges non-`push` events with a
   `2xx` so GitHub doesn't retry them.
3. On `push`, reads `repository.owner.login` and schedules a background refresh
   of that profile via `after()`, so GitHub gets a fast `2xx`.

### Reuse, not duplication
The manual Refresh endpoint's logic (bump `last_refreshed_at`, rate-limit,
`revalidatePath`) is **extracted into `src/lib/refresh-profile.ts`**, and both
the existing `POST /api/[username]/refresh` route and the new webhook call it.
The existing route is refactored to delegate to it — same responses, same
status codes (verified), just no duplicated logic. The 10-minute rate limit
carries over, so a burst of pushes won't hammer a profile.

### Runtime / crypto
Signature verification uses **Web Crypto** (`crypto.subtle`), which works on
both the edge and Node runtimes — so it's robust regardless of how the route is
bundled for Cloudflare Pages. The background work uses Next's `after()`
(mapped to the platform's `waitUntil`), which keeps the webhook ack fast
without a detached task.

## Configuring the webhook (for maintainers)
1. Set `GITHUB_WEBHOOK_SECRET` in the deployment env (a strong random string).
2. In the repo/org **Settings → Webhooks → Add webhook**:
   - Payload URL: `https://ossfolio.qzz.io/api/webhooks/github`
   - Content type: `application/json`
   - Secret: the same value as `GITHUB_WEBHOOK_SECRET`
   - Events: **Just the push event**
`.env.example` documents the new variable.

## Verification
- `npm run type-check` — clean.
- `npm run lint` — clean.
- `npm run build` — succeeds; `ƒ /api/webhooks/github` registered, existing
  routes unaffected.
- **Signature verification tested against GitHub's official documented HMAC
  vector** (secret `It's a Secret to Everybody`, body `Hello, World!` →
  `sha256=757107ea…`): valid signature accepted; tampered, missing, wrong-
  prefix, and wrong-secret signatures all rejected.

## Notes
- New env var only: `GITHUB_WEBHOOK_SECRET`. No schema or dependency changes.
- The refresh reuses the existing `SUPABASE_SERVICE_ROLE_KEY` server-side path.
- Scheduling a refresh for an unknown owner is a safe no-op (the shared helper
  returns `not_found`).

## Follow-ups (out of scope here)
- Full GitHub App (installation flow, per-install secrets, permissions).
- Optionally handling more event types if other signals should trigger a
  refresh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub webhook support so profile data can refresh automatically after repository updates.
  * Added a configurable webhook secret example for secure setup.

* **Bug Fixes**
  * Improved profile refresh behavior with clearer outcomes for successful refreshes, rate limits, missing profiles, and server errors.
  * Made refreshes more reliable by updating cached profile data after changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->