### PR TITLE
feat(api): public v1 REST endpoint for third-party consumers (#303)

### DIFF
--- a/src/app/api/v1/users/[username]/route.ts
+++ b/src/app/api/v1/users/[username]/route.ts
@@ -6,8 +6,10 @@ export const runtime = "edge";
 
 // Public, cross-origin REST endpoint for third-party consumers of a profile's
 // aggregated score/stats. Reads are open because profiles are already publicly
-// viewable; responses are cached at the edge to absorb load. API-key generation
-// and per-key rate limiting are a planned follow-up (see the PR description).
+// viewable; responses are cached at the edge to absorb load. A coarse per-IP
+// rate limit (below) guards the read path so cache misses can't drive unbounded
+// Supabase reads; globally-shared per-key limiting comes with the API-key
+// follow-up (see the PR description).
 
 const CORS_HEADERS: Record<string, string> = {
   "Access-Control-Allow-Origin": "*",
@@ -21,6 +23,44 @@ function withCors(res: NextResponse): NextResponse {
     res.headers.set(key, value);
   }
   return res;
+}
+
+// Coarse, best-effort per-IP rate limit for the public read path. This lives in
+// the edge isolate's memory (not a globally-shared store), so it's a first line
+// against naive floods and high-cardinality scraping that would otherwise hit
+// Supabase on every cache miss — not a hard global guarantee. Proper globally-
+// shared, per-key limits arrive with the API-key follow-up.
+const RATE_LIMIT_MAX = 60; // requests per window, per IP, per isolate
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const rateHits = new Map<string, { count: number; resetAt: number }>();
+
+function getClientIp(request: NextRequest): string {
+  const forwarded = request.headers.get("x-forwarded-for");
+  if (forwarded) return forwarded.split(",")[0].trim();
+  return request.headers.get("cf-connecting-ip") ?? "unknown";
+}
+
+function checkRateLimit(ip: string): { limited: boolean; retryAfter: number } {
+  const now = Date.now();
+
+  // Opportunistically drop expired entries so the map can't grow unbounded.
+  if (rateHits.size > 10_000) {
+    for (const [key, value] of rateHits) {
+      if (now >= value.resetAt) rateHits.delete(key);
+    }
+  }
+
+  const entry = rateHits.get(ip);
+  if (!entry || now >= entry.resetAt) {
+    rateHits.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    return { limited: false, retryAfter: 0 };
+  }
+
+  entry.count += 1;
+  if (entry.count > RATE_LIMIT_MAX) {
+    return { limited: true, retryAfter: Math.ceil((entry.resetAt - now) / 1000) };
+  }
+  return { limited: false, retryAfter: 0 };
 }
 
 // Columns exposed publicly. Internal fields (id, visibility, view_count,
@@ -38,6 +78,17 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ username: string }> }
 ) {
+  const { limited, retryAfter } = checkRateLimit(getClientIp(request));
+  if (limited) {
+    const res = withCors(
+      createErrorResponse("Rate limit exceeded. Please slow down.", 429, {
+        retryAfterSeconds: retryAfter,
+      })
+    );
+    res.headers.set("Retry-After", String(retryAfter));
+    return res;
+  }
+
   const { username: rawUsername } = await params;
   const username = sanitizeUsername(rawUsername);
 

--- a/src/app/api/v1/users/[username]/route.ts
+++ b/src/app/api/v1/users/[username]/route.ts
@@ -1,0 +1,109 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+import { sanitizeUsername, createApiResponse, createErrorResponse } from "@/lib/api-validation";
+
+export const runtime = "edge";
+
+// Public, cross-origin REST endpoint for third-party consumers of a profile's
+// aggregated score/stats. Reads are open because profiles are already publicly
+// viewable; responses are cached at the edge to absorb load. API-key generation
+// and per-key rate limiting are a planned follow-up (see the PR description).
+
+const CORS_HEADERS: Record<string, string> = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type",
+  "Access-Control-Max-Age": "86400",
+};
+
+function withCors(res: NextResponse): NextResponse {
+  for (const [key, value] of Object.entries(CORS_HEADERS)) {
+    res.headers.set(key, value);
+  }
+  return res;
+}
+
+// Columns exposed publicly. Internal fields (id, visibility, view_count,
+// search_text, timestamps) are deliberately excluded.
+const PUBLIC_COLUMNS =
+  "username, name, avatar_url, github_url, bio, headline, score, followers, " +
+  "top_languages, total_commits, total_prs, total_issues, total_reviews, " +
+  "badges, last_refreshed_at";
+
+export async function OPTIONS() {
+  return new NextResponse(null, { status: 204, headers: CORS_HEADERS });
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ username: string }> }
+) {
+  const { username: rawUsername } = await params;
+  const username = sanitizeUsername(rawUsername);
+
+  if (!username) {
+    return withCors(createErrorResponse("Invalid username format", 400));
+  }
+
+  const { data, error } = await supabase
+    .from("profiles")
+    .select(PUBLIC_COLUMNS)
+    .eq("username", username)
+    .eq("visibility", "public")
+    .maybeSingle();
+
+  if (error) {
+    return withCors(createErrorResponse("Failed to fetch profile", 502));
+  }
+
+  // No row means either the username doesn't exist or the profile is unlisted.
+  // We return the same 404 for both so the API never reveals that an unlisted
+  // profile exists.
+  if (!data) {
+    return withCors(createErrorResponse("Profile not found", 404));
+  }
+
+  const profile = data as unknown as {
+    username: string;
+    name: string | null;
+    avatar_url: string | null;
+    github_url: string | null;
+    bio: string | null;
+    headline: string | null;
+    score: number;
+    followers: number;
+    top_languages: string[];
+    total_commits: number;
+    total_prs: number;
+    total_issues: number;
+    total_reviews: number;
+    badges: unknown;
+    last_refreshed_at: string | null;
+  };
+
+  const body = {
+    username: profile.username,
+    name: profile.name,
+    avatar_url: profile.avatar_url,
+    github_url: profile.github_url,
+    bio: profile.bio,
+    headline: profile.headline,
+    score: profile.score,
+    followers: profile.followers,
+    top_languages: profile.top_languages,
+    stats: {
+      commits: profile.total_commits,
+      prs: profile.total_prs,
+      issues: profile.total_issues,
+      reviews: profile.total_reviews,
+    },
+    badges: profile.badges,
+    last_refreshed_at: profile.last_refreshed_at,
+  };
+
+  return withCors(
+    createApiResponse(body, 200, {
+      "Cache-Control": "public, s-maxage=300, stale-while-revalidate=600",
+    })
+  );
+}

--- a/src/app/api/v1/users/[username]/route.ts
+++ b/src/app/api/v1/users/[username]/route.ts
@@ -14,7 +14,7 @@ export const runtime = "edge";
 const CORS_HEADERS: Record<string, string> = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Methods": "GET, OPTIONS",
-  "Access-Control-Allow-Headers": "Content-Type",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization, If-None-Match, Cache-Control",
   "Access-Control-Max-Age": "86400",
 };
 
@@ -32,21 +32,33 @@ function withCors(res: NextResponse): NextResponse {
 // shared, per-key limits arrive with the API-key follow-up.
 const RATE_LIMIT_MAX = 60; // requests per window, per IP, per isolate
 const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX_KEYS = 10_000; // hard cap on tracked IPs to bound memory
 const rateHits = new Map<string, { count: number; resetAt: number }>();
 
 function getClientIp(request: NextRequest): string {
+  // Prefer the platform-set header (unspoofable on Cloudflare) so a client can't
+  // forge x-forwarded-for to bypass the limiter or inflate key cardinality.
+  const cfIp = request.headers.get("cf-connecting-ip");
+  if (cfIp) return cfIp;
+  const realIp = request.headers.get("x-real-ip");
+  if (realIp) return realIp;
   const forwarded = request.headers.get("x-forwarded-for");
   if (forwarded) return forwarded.split(",")[0].trim();
-  return request.headers.get("cf-connecting-ip") ?? "unknown";
+  return "unknown";
 }
 
 function checkRateLimit(ip: string): { limited: boolean; retryAfter: number } {
   const now = Date.now();
 
-  // Opportunistically drop expired entries so the map can't grow unbounded.
-  if (rateHits.size > 10_000) {
+  // Opportunistically drop expired entries, then enforce a hard cap so a flood
+  // of many unique IPs can't grow the map without bound and OOM the isolate.
+  if (rateHits.size > RATE_LIMIT_MAX_KEYS) {
     for (const [key, value] of rateHits) {
       if (now >= value.resetAt) rateHits.delete(key);
+    }
+    // Still at capacity after pruning: stop tracking new keys rather than grow.
+    if (rateHits.size > RATE_LIMIT_MAX_KEYS && !rateHits.has(ip)) {
+      return { limited: true, retryAfter: Math.ceil(RATE_LIMIT_WINDOW_MS / 1000) };
     }
   }
 


### PR DESCRIPTION
Closes #303

## Summary
Adds a public, cross-origin REST endpoint for third-party consumers of a
profile's aggregated score/stats:

    GET /api/v1/users/:username

Returns public JSON, respects profile visibility, and sets CORS headers for
cross-origin use.

## Scope (first PR of two)
The issue covers a lot — endpoint + CORS + API-key generation + rate limiting.
As discussed on the issue, this PR is the **public read endpoint + CORS**, with
**API-key generation and per-key rate limiting as a focused follow-up**.
Reasoning:
- Profiles are already publicly viewable (`profiles` RLS: "publicly viewable"),
  so the read endpoint doesn't need a key to expose anything that isn't already
  public.
- **Globally-shared, per-key rate limiting belongs with the API-key system** —
  that's the follow-up, not this PR.
- For public, cacheable data, the main first-line protection is edge caching +
  the platform's built-in DDoS controls. Responses here are cached
  (`Cache-Control: public, s-maxage=300, stale-while-revalidate=600`).

This PR does include a **coarse, best-effort per-IP rate limit** on the read
path (60 req/min/IP, checked before the Supabase query, 429 + `Retry-After` on
excess). It's in-memory per edge isolate — not a globally-shared store — so it's
a first line against naive floods and high-cardinality scraping that would
otherwise hit Supabase on every cache miss, not a hard global guarantee. Proper
globally-shared, per-key limits still arrive with the API-key follow-up.
## What it does
- **Reuses the existing patterns**: `runtime = "edge"`, `sanitizeUsername`,
  `createApiResponse` / `createErrorResponse` from `api-validation`, and the
  `supabase` anon client — same as the other `/api/*` routes.
- **Respects visibility**: the query filters `visibility = 'public'`, so
  `unlisted` profiles are never exposed. A missing or unlisted profile both
  return the same `404`, so the API never reveals that an unlisted profile
  exists.
- **CORS**: `Access-Control-Allow-Origin: *` (+ methods/headers/max-age) on every
  response, plus an `OPTIONS` preflight handler returning `204`.
- **Curated public shape**: internal columns (`id`, `visibility`, `view_count`,
  `search_text`, timestamps) are excluded.

### Response shape
```json
{
  "username": "octocat",
  "name": "The Octocat",
  "avatar_url": "https://...",
  "github_url": "https://github.com/octocat",
  "bio": "...",
  "headline": "...",
  "score": 1234,
  "followers": 50,
  "top_languages": ["TypeScript", "Python"],
  "stats": { "commits": 900, "prs": 120, "issues": 40, "reviews": 30 },
  "badges": [...],
  "last_refreshed_at": "2026-07-07T..."
}
```
Returns the **stored** aggregated data (not a live GitHub re-fetch), with
`last_refreshed_at` so consumers can see freshness.

## Verification
- `npm run type-check` — clean.
- `npm run lint` — clean (0 errors).
- `npm run build` — succeeds; `ƒ /api/v1/users/[username]` registers as an edge
  route.
- No new dependencies; no schema changes (read-only, uses existing `profiles`).
- Hardened per Copilot review: client IP resolution now trusts platform-set
  headers (`cf-connecting-ip`/`x-real-ip`) before `x-forwarded-for` (unspoofable
  first), the rate-limit map has a hard cap so a high-cardinality flood can't
  grow it unbounded, and CORS `Allow-Headers` was broadened for conditional
  GETs.

## Follow-up (next PR)
- `api_keys` table (hashed keys, RLS) + authenticated key generation in settings.
- Per-key rate limiting (Supabase counter or Cloudflare KV).
- Optional: keyed requests get higher limits / attribution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public user profile API endpoint that supports fetching profile details by username.
  * Enabled browser-friendly CORS handling, including preflight requests.

* **Bug Fixes**
  * Returns clear error responses for invalid usernames, missing profiles, and backend lookup failures.
  * Limits returned profile data to public information only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->