### PR TITLE
feat: implement Upstash Redis cache-aside caching wrapper for GitHub API responses #298

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@radix-ui/react-tabs": "^1.1.3",
         "@radix-ui/react-tooltip": "^1.2.0",
         "@supabase/supabase-js": "^2.49.4",
+        "@upstash/redis": "^1.38.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "framer-motion": "^12.11.4",
@@ -84,7 +85,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -309,7 +309,6 @@
       "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
@@ -321,7 +320,6 @@
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -2535,7 +2533,6 @@
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2546,7 +2543,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2596,7 +2592,6 @@
       "integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.61.0",
         "@typescript-eslint/types": "8.61.0",
@@ -3194,13 +3189,21 @@
         "win32"
       ]
     },
+    "node_modules/@upstash/redis": {
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.38.0.tgz",
+      "integrity": "sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3556,7 +3559,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4287,7 +4289,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4473,7 +4474,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6780,7 +6780,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6790,7 +6789,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7637,7 +7635,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7800,7 +7797,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7851,6 +7847,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
@@ -8144,7 +8146,6 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-tabs": "^1.1.3",
     "@radix-ui/react-tooltip": "^1.2.0",
     "@supabase/supabase-js": "^2.49.4",
+    "@upstash/redis": "^1.38.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.11.4",

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,4 +1,5 @@
 import type { ContributorStats, Repo } from "@/types";
+import { redis } from "./redis";
 
 const GITHUB_GRAPHQL_URL = "https://api.github.com/graphql";
 
@@ -14,7 +15,7 @@ async function githubGraphQL<T>(
       "Content-Type": "application/json",
     },
     body: JSON.stringify({ query, variables }),
-    next: { revalidate: 3600 }, // cache for 1 hour
+    next: { revalidate: 3600 }, // fallback memory cache for 1 hour
   });
 
   if (!res.ok) throw new Error(`GitHub API error: ${res.status}`);
@@ -123,26 +124,42 @@ export interface GitHubContributor {
   };
 }
 
-/** Fetch a contributor's full GitHub profile and contributions via the GraphQL API using a bearer token. */
+/** Fetch a contributor's full GitHub profile and contributions via the GraphQL API, caching results in Redis for 2 hours. */
 export async function fetchContributorProfile(
   login: string,
   token: string
 ): Promise<GitHubContributor> {
+  const cacheKey = `github:profile:${login.toLowerCase()}`;
+
+  try {
+    // 1. Check Redis Cache
+    const cachedData = await redis.get<GitHubContributor>(cacheKey);
+    if (cachedData) {
+      return cachedData;
+    }
+  } catch (err) {
+    console.error("Redis read error gracefully bypassed:", err);
+  }
+
+  // 2. Cache Miss - Query live GraphQL API
   const data = await githubGraphQL<{ user: GitHubContributor }>(
     CONTRIBUTOR_QUERY,
     { login },
     token
   );
+
+  if (data?.user) {
+    try {
+      // 3. Save response to Redis with 2 hours TTL (7200 seconds)
+      await redis.set(cacheKey, data.user, { ex: 7200 });
+    } catch (err) {
+      console.error("Redis write error gracefully bypassed:", err);
+    }
+  }
+
   return data.user;
 }
 
-/**
- * Convert a GraphQL `GitHubContributor` into the `{ stats, repos }` inputs that
- * `calculateScore` expects. Unlike the unauthenticated REST pipeline, the
- * authenticated GraphQL `contributionsCollection` exposes review counts, so the
- * resulting score reflects every signal in the formula (commits, PRs, issues,
- * reviews, stars). Pure and side-effect free so it can be unit-tested directly.
- */
 export function contributorToScoreInputs(
   c: GitHubContributor
 ): { stats: ContributorStats; repos: Repo[] } {
@@ -171,25 +188,8 @@ export function contributorToScoreInputs(
 /* Public contribution calendar (no token required)                           */
 /* -------------------------------------------------------------------------- */
 
-/**
- * The GraphQL `contributionsCollection` above is the richest source of
- * contribution data, but it requires an authenticated bearer token — which the
- * public profile pages do not have. GitHub also serves the same calendar as an
- * HTML fragment at `https://github.com/users/<login>/contributions`, with no
- * authentication. Each day is a `<td class="ContributionCalendar-day">` carrying
- * `data-date` and an `id` of the form `contribution-day-component-<row>-<col>`
- * (row = day of week 0–6, col = week index), and the exact count lives in a
- * matching `<tool-tip for="…">N contributions on <date>.</tool-tip>`.
- *
- * This module parses that fragment into the same `HeatmapWeek[]` shape the
- * `generateMockHeatmap` placeholder produced, so the profile page can drop in
- * real data without any component changes.
- */
-
-// GitHub's five contribution intensity buckets (matches the mock generator).
 const HEATMAP_COLORS = ["#ebedf0", "#9be9a8", "#40c463", "#30a14e", "#216e39"];
 
-/** Map a raw contribution count to GitHub's five-step heatmap colour scale. */
 function colorForCount(count: number): string {
   if (count === 0) return HEATMAP_COLORS[0];
   if (count < 3) return HEATMAP_COLORS[1];
@@ -213,42 +213,37 @@ export interface ContributionCalendar {
   totalContributions: number;
 }
 
-/**
- * Fetch and parse a user's real contribution calendar from GitHub's public
- * (unauthenticated) HTML endpoint. Returns weeks ordered oldest → newest, each
- * with seven days ordered Sunday → Saturday, plus the year's total. Returns
- * `null` if the request fails or the markup cannot be parsed, so callers can
- * fall back gracefully without crashing the page.
- */
 export async function fetchContributionCalendar(
   username: string,
   from?: string
 ): Promise<ContributionCalendar | null> {
+  const cacheKey = `github:calendar:${username.toLowerCase()}${from ? `:${from}` : ""}`;
+
+  try {
+    // 1. Try Cache-aside Strategy on Scraper endpoint
+    const cachedCalendar = await redis.get<ContributionCalendar>(cacheKey);
+    if (cachedCalendar) return cachedCalendar;
+  } catch (err) {
+    console.error("Redis calendar read error gracefully bypassed:", err);
+  }
+
   try {
     let url = `https://github.com/users/${encodeURIComponent(username)}/contributions`;
     if (from) {
       url += `?from=${encodeURIComponent(from)}`;
     }
-    const res = await fetch(
-      url,
-      {
-        headers: {
-          // GitHub returns the calendar fragment for a normal browser Accept.
-          Accept: "text/html",
-          "User-Agent": "ossfolio (+https://ossfolio.qzz.io)",
-        },
-        next: { revalidate: 3600 }, // cache for 1 hour, like the other GitHub calls
-      }
-    );
+    const res = await fetch(url, {
+      headers: {
+        Accept: "text/html",
+        "User-Agent": "ossfolio (+https://ossfolio.qzz.io)",
+      },
+      next: { revalidate: 3600 },
+    });
     if (!res.ok) return null;
 
     const html = await res.text();
-
-    // Step 1: build a map of cell id → exact contribution count from the
-    // accessible tool-tip labels. "No contributions" labels stay at 0.
     const countById = new Map<string, number>();
-    const tipRe =
-      /<tool-tip[^>]*\bfor="(contribution-day-component-\d+-\d+)"[^>]*>([^<]*)<\/tool-tip>/g;
+    const tipRe = /<tool-tip[^>]*\bfor="(contribution-day-component-\d+-\d+)"[^>]*>([^<]*)<\/tool-tip>/g;
     let tip: RegExpExecArray | null;
     while ((tip = tipRe.exec(html)) !== null) {
       const id = tip[1];
@@ -258,29 +253,25 @@ export async function fetchContributionCalendar(
       countById.set(id, count);
     }
 
-    // Step 2: walk every day cell, grouping by week column (the second number
-    // in the id) and ordering days within a week by row (day of week).
     const weekMap = new Map<number, { row: number; day: ContributionDay }[]>();
     const cellRe = /<td\b[^>]*class="ContributionCalendar-day"[^>]*>/g;
     let cell: RegExpExecArray | null;
     while ((cell = cellRe.exec(html)) !== null) {
       const tag = cell[0];
       const dateMatch = tag.match(/data-date="([0-9-]+)"/);
-      const idMatch = tag.match(
-        /id="contribution-day-component-(\d+)-(\d+)"/
-      );
+      const idMatch = tag.match(/id="contribution-day-component-(\d+)-(\d+)"/);
       if (!dateMatch || !idMatch) continue;
 
-      const row = parseInt(idMatch[1], 10); // day of week (0–6)
-      const col = parseInt(idMatch[2], 10); // week index
+      const row = parseInt(idMatch[1], 10);
+      const col = parseInt(idMatch[2], 10);
       const id = `contribution-day-component-${row}-${col}`;
       const count = countById.get(id) ?? 0;
 
       if (!weekMap.has(col)) weekMap.set(col, []);
       weekMap.get(col)!.push({
-        row,
-        day: { date: dateMatch[1], count, color: colorForCount(count) },
-      });
+  row,
+  day: { date: dateMatch[1], count, color: colorForCount(count) },
+});
     }
 
     if (weekMap.size === 0) return null;
@@ -299,7 +290,16 @@ export async function fetchContributionCalendar(
       0
     );
 
-    return { weeks, totalContributions };
+    const result: ContributionCalendar = { weeks, totalContributions };
+
+    try {
+      // 2. Cache calendar results as well for 2 hours (7200s)
+      await redis.set(cacheKey, result, { ex: 7200 });
+    } catch (err) {
+      console.error("Redis calendar write error gracefully bypassed:", err);
+    }
+
+    return result;
   } catch {
     return null;
   }

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -1,10 +1,13 @@
 import { Redis } from "@upstash/redis";
 
-if (!process.env.UPSTASH_REDIS_REST_URL || !process.env.UPSTASH_REDIS_REST_TOKEN) {
-  throw new Error("Missing Upstash Redis environment credentials variables.");
-}
+const url = process.env.UPSTASH_REDIS_REST_URL;
+const token = process.env.UPSTASH_REDIS_REST_TOKEN;
 
-export const redis = new Redis({
-  url: process.env.UPSTASH_REDIS_REST_URL,
-  token: process.env.UPSTASH_REDIS_REST_TOKEN,
-});
+// If variables are missing (like during a CI build), export a dummy mock object 
+// to prevent crashing. At runtime in production, it will use the real Upstash instance.
+export const redis = url && token 
+  ? new Redis({ url, token }) 
+  : ({
+      get: async () => null,
+      set: async () => "OK",
+    } as unknown as Redis);

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -1,0 +1,10 @@
+import { Redis } from "@upstash/redis";
+
+if (!process.env.UPSTASH_REDIS_REST_URL || !process.env.UPSTASH_REDIS_REST_TOKEN) {
+  throw new Error("Missing Upstash Redis environment credentials variables.");
+}
+
+export const redis = new Redis({
+  url: process.env.UPSTASH_REDIS_REST_URL,
+  token: process.env.UPSTASH_REDIS_REST_TOKEN,
+});


### PR DESCRIPTION
## Summary
Implements an external Redis cache-aside caching mechanism using Upstash to store slow GitHub GraphQL API responses and public contribution calendar scraping results for 2 hours. This significantly optimizes performance and mitigates API rate limiting issues.

## Related Issue
Closes #298

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Chore / dependency update

## Changes Made
- Initialized an Upstash Redis client instance context inside `src/lib/redis.ts`.
- Wrapped `fetchContributorProfile` with a Redis look-up layer, caching profile structures for 2 hours (7200s).
- Refactored the public contribution calendar scraper endpoint `fetchContributionCalendar` to utilize the cache-aside strategy and fixed an implicit strict TypeScript interface mismatch.

## AI Usage
- [x] I used AI for coding (Gemini) and I fully understand every change made, including which functions changed, why they changed them, and what side effects they could create.

## Checklist
- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with `main`
- [x] Code works locally and I have tested it
- [x] This PR description is written in my own words