### PR TITLE
feat:  toggle to Heatmap to show 365 days vs Calendar year

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@radix-ui/react-tabs": "^1.1.3",
         "@radix-ui/react-tooltip": "^1.2.0",
         "@supabase/supabase-js": "^2.49.4",
+        "@swc/helpers": "^0.5.23",
         "@upstash/redis": "^1.38.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -2617,10 +2618,11 @@
       "license": "Apache-2.0"
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
-      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -6769,6 +6771,15 @@
         "@swc/helpers": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next/node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,6 +85,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -300,6 +301,7 @@
       "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
@@ -311,6 +313,7 @@
       "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -2950,6 +2953,7 @@
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2960,6 +2964,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3009,6 +3014,7 @@
       "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.63.0",
         "@typescript-eslint/types": "8.63.0",
@@ -3621,6 +3627,7 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3976,6 +3983,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001800",
@@ -4591,6 +4599,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4776,6 +4785,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6761,17 +6771,6 @@
         }
       }
     },
-    "node_modules/next-intl/node_modules/@swc/helpers": {
-      "version": "0.5.23",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
-      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -7188,6 +7187,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7197,6 +7197,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7968,6 +7969,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8130,6 +8132,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8478,6 +8481,7 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-tabs": "^1.1.3",
     "@radix-ui/react-tooltip": "^1.2.0",
     "@supabase/supabase-js": "^2.49.4",
+    "@swc/helpers": "^0.5.23",
     "@upstash/redis": "^1.38.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/components/profile/HeatmapWithYearNav.tsx
+++ b/src/components/profile/HeatmapWithYearNav.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, memo } from "react";
+import { useState, useCallback, memo, useMemo } from "react";
 import type { HeatmapWeek } from "@/types";
 import { computeStreaks } from "@/lib/mock";
 
@@ -76,6 +76,47 @@ const StreakBadge = memo(function StreakBadge({
   );
 });
 
+interface DisplayedDay {
+  date: string;
+  count: number;
+  color: string;
+  isPlaceholder?: boolean;
+}
+
+interface DisplayedWeek {
+  days: DisplayedDay[];
+}
+
+function getFilteredWeeks(
+  weeks: HeatmapWeek[],
+  selectedYear: number,
+  viewMode: "365" | "calendar"
+): DisplayedWeek[] {
+  if (viewMode === "365" && selectedYear === currentYear) {
+    return weeks as DisplayedWeek[];
+  }
+
+  const yearStr = `${selectedYear}-`;
+
+  return weeks
+    .map((week) => {
+      const days: DisplayedDay[] = week.days.map((day) => {
+        if (day.date.startsWith(yearStr)) {
+          return day;
+        }
+        return {
+          ...day,
+          count: 0,
+          color: "transparent",
+          isPlaceholder: true,
+        };
+      });
+
+      return { ...week, days };
+    })
+    .filter((week) => week.days.some((day) => !day.isPlaceholder));
+}
+
 function HeatmapWithYearNavInner({
   username,
   initialWeeks,
@@ -84,8 +125,7 @@ function HeatmapWithYearNavInner({
 }: HeatmapWithYearNavProps) {
   const [selectedYear, setSelectedYear] = useState(currentYear);
   const [weeks, setWeeks] = useState(initialWeeks);
-  const [currentStreak, setCurrentStreak] = useState(initialCurrentStreak);
-  const [longestStreak, setLongestStreak] = useState(initialLongestStreak);
+  const [viewMode, setViewMode] = useState<"365" | "calendar">("365");
   const [loading, setLoading] = useState(false);
 
   const fetchYear = useCallback(
@@ -93,8 +133,6 @@ function HeatmapWithYearNavInner({
       if (year === selectedYear && weeks.length > 0) return;
       if (year === currentYear && initialWeeks.length > 0) {
         setWeeks(initialWeeks);
-        setCurrentStreak(initialCurrentStreak);
-        setLongestStreak(initialLongestStreak);
         setSelectedYear(year);
         return;
       }
@@ -106,19 +144,26 @@ function HeatmapWithYearNavInner({
         if (!res.ok) throw new Error("fetch failed");
         const data = await res.json();
         setWeeks(data.weeks);
-        const streaks = computeStreaks(data.weeks);
-        setCurrentStreak(streaks.current);
-        setLongestStreak(streaks.longest);
       } catch {
         setWeeks([]);
-        setCurrentStreak(0);
-        setLongestStreak(0);
       } finally {
         setLoading(false);
       }
     },
-    [username, selectedYear, weeks.length, initialWeeks, initialCurrentStreak, initialLongestStreak]
+    [username, selectedYear, weeks.length, initialWeeks]
   );
+
+  const displayedWeeks = useMemo(() => {
+    return getFilteredWeeks(weeks, selectedYear, selectedYear === currentYear ? viewMode : "calendar");
+  }, [weeks, selectedYear, viewMode]);
+
+  const { currentStreak, longestStreak } = useMemo(() => {
+    const streaks = computeStreaks(displayedWeeks);
+    return {
+      currentStreak: streaks.current,
+      longestStreak: streaks.longest,
+    };
+  }, [displayedWeeks]);
 
   if (initialWeeks.length === 0 && weeks.length === 0) return null;
 
@@ -141,9 +186,69 @@ function HeatmapWithYearNavInner({
         </div>
       </div>
 
-      <div style={{ display: "flex", flexWrap: "wrap", gap: "8px", margin: "0 0 12px 0" }}>
-        <StreakBadge label="Current streak" value={currentStreak} />
-        <StreakBadge label="Longest streak" value={longestStreak} />
+      <div
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          gap: "8px",
+          margin: "0 0 12px 0",
+          justifyContent: "space-between",
+          alignItems: "center",
+        }}
+      >
+        <div style={{ display: "flex", flexWrap: "wrap", gap: "8px" }}>
+          <StreakBadge label="Current streak" value={currentStreak} />
+          <StreakBadge label="Longest streak" value={longestStreak} />
+        </div>
+
+        {/* Toggle switch for Last 365 Days vs Calendar Year */}
+        {selectedYear === currentYear && (
+          <div
+            style={{
+              display: "inline-flex",
+              backgroundColor: "var(--color-canvas-soft)",
+              border: "1px solid var(--color-hairline)",
+              borderRadius: "20px",
+              padding: "2px",
+              gap: "2px",
+            }}
+          >
+            <button
+              type="button"
+              onClick={() => setViewMode("365")}
+              style={{
+                padding: "4px 12px",
+                fontSize: "12px",
+                fontWeight: viewMode === "365" ? 600 : 400,
+                color: viewMode === "365" ? "#171717" : "var(--color-ink-mute)",
+                backgroundColor: viewMode === "365" ? "#3ecf8e" : "transparent",
+                border: "none",
+                borderRadius: "9999px",
+                cursor: "pointer",
+                transition: "background-color 0.15s, color 0.15s",
+              }}
+            >
+              Last 365 Days
+            </button>
+            <button
+              type="button"
+              onClick={() => setViewMode("calendar")}
+              style={{
+                padding: "4px 12px",
+                fontSize: "12px",
+                fontWeight: viewMode === "calendar" ? 600 : 400,
+                color: viewMode === "calendar" ? "#171717" : "var(--color-ink-mute)",
+                backgroundColor: viewMode === "calendar" ? "#3ecf8e" : "transparent",
+                border: "none",
+                borderRadius: "9999px",
+                cursor: "pointer",
+                transition: "background-color 0.15s, color 0.15s",
+              }}
+            >
+              {currentYear} Year
+            </button>
+          </div>
+        )}
       </div>
 
       <div
@@ -159,18 +264,25 @@ function HeatmapWithYearNavInner({
           transition: "opacity 0.2s",
         }}
       >
-        {weeks.map((week, wi) => (
+        {displayedWeeks.map((week, wi) => (
           <div key={wi} style={{ display: "flex", flexDirection: "column", gap: "3px" }}>
             {week.days.map((day, di) => (
               <div
                 key={di}
-                title={`${day.count} contributions on ${day.date}`}
-                style={{ width: "11px", height: "11px", borderRadius: "2px", backgroundColor: day.color, flexShrink: 0 }}
+                title={day.isPlaceholder ? undefined : `${day.count} contributions on ${day.date}`}
+                style={{
+                  width: "11px",
+                  height: "11px",
+                  borderRadius: "2px",
+                  backgroundColor: day.isPlaceholder ? "transparent" : day.color,
+                  flexShrink: 0,
+                  pointerEvents: day.isPlaceholder ? "none" : "auto",
+                }}
               />
             ))}
           </div>
         ))}
-        {weeks.length === 0 && !loading && (
+        {displayedWeeks.length === 0 && !loading && (
           <p style={{ fontSize: "13px", color: "var(--color-ink-mute)", margin: "12px auto" }}>
             No contribution data available for {selectedYear}.
           </p>


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. Write this in your own words. Do not paste an AI-generated summary here. -->

I have added a toggle switch above the profile contribution heatmap to dynamically slice the contributions grid between a rolling "Last 365 Days" view (matching GitHub's default layout) and the selected "Calendar Year" view.

## Related Issue

Closes #293

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Chore / dependency update

## Changes Made

<!-- Bullet points of what changed and why you made each change -->
- View Mode State: Added a viewMode state ("365" | "calendar") defaulting to "365".
- Dynamic Streak Calculation: Recalculates both the "Current streak" and "Longest streak" dynamically via useMemo based on the currently filtered view.
- Segmented Control Toggle UI: Rendered a premium, responsive button group next to the streak badges when the current year is selected, allowing the user to seamlessly toggle between the rolling 365 days view and the calendar year view.

## AI Usage

- [x] I did not use AI for any part of the code in this PR
- [ ] I used AI for coding (specify which tool below) and I fully understand every change I made, including which functions I changed, why I changed them, and what side effects they could create

<!-- If you used AI, write the tool name here, e.g. "Used Claude Code for coding" -->



## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with `main`
- [x] Code works locally and I have tested it
- [x] No `console.log` left in `src/`
- [x] If schema changed — both `schema.sql` and a new migration file are included
- [x] If this is a UI change — I read `DESIGN.md` and followed the design system (colors, spacing, typography, components)
- [x] Docs updated if needed
- [x] PR title follows Conventional Commits format (`feat:`, `fix:`, `docs:`, etc.)
- [x] This PR description is written in my own words


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a year-view toggle for the activity heatmap, letting users switch between “Last 365 Days” and “calendar year.”
  * Dates outside the selected year now render as non-interactive, placeholder cells in the heatmap.

* **Bug Fixes**
  * Streak badges now stay in sync automatically with the currently displayed heatmap range.
  * Improved year-data loading/error behavior, including more consistent resets after failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->