### PR TITLE
feat(profile): add formatCount utility for compact number display

### DIFF
--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -111,6 +111,13 @@ interface ProfileExtras {
   mergedPRs: MergedPR[];
 }
 
+function formatCount(n: number): string {
+  if (n >= 1000) {
+    return `${(n / 1000).toFixed(1).replace(/\.0$/, "")}k`;
+  }
+  return n.toLocaleString("en-US");
+}
+
 function formatUpdatedAt(iso: string): string {
   const diffMs = Date.now() - new Date(iso).getTime();
   const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
@@ -716,13 +723,13 @@ export function ProfileView({
 
           <div style={{ display: "flex", gap: "20px", marginTop: "14px" }}>
             <span style={{ fontSize: "13px", color: "var(--color-ink-mute)" }}>
-              <strong style={{ color: "var(--color-ink)", fontWeight: 600 }}>{user.followers.toLocaleString("en-US")}</strong> followers
+              <strong style={{ color: "var(--color-ink)", fontWeight: 600 }}>{formatCount(user.followers)}</strong> followers
             </span>
             <span style={{ fontSize: "13px", color: "var(--color-ink-mute)" }}>
-              <strong style={{ color: "var(--color-ink)", fontWeight: 600 }}>{user.following.toLocaleString("en-US")}</strong> following
+              <strong style={{ color: "var(--color-ink)", fontWeight: 600 }}>{formatCount(user.following)}</strong> following
             </span>
             <span style={{ fontSize: "13px", color: "var(--color-ink-mute)" }}>
-              <strong style={{ color: "var(--color-ink)", fontWeight: 600 }}>{user.public_repos}</strong> repos
+              <strong style={{ color: "var(--color-ink)", fontWeight: 600 }}>{formatCount(user.public_repos)}</strong> repos
             </span>
           </div>
 


### PR DESCRIPTION
## Problem
Followers, following, and repos counts display as full integers (e.g. `1200`), which clutters the profile header at scale.

## Fix
Added a `formatCount(n)` utility function that formats numbers ≥1000 as k-suffix (e.g. `1200 → 1.2k`). Applied it to the followers, following, and repos display in `ProfileView.tsx`. Numbers below 1000 are left as-is with standard locale formatting.

## Test Plan
- [ ] Verify 1200 displays as `1.2k`
- [ ] Verify 999 displays as `999`
- [ ] Verify 50000 displays as `50k`
- [ ] Verify 1500 displays as `1.5k`

Closes #324


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profile statistics now display large numbers in a compact format, making follower, following, and public repository counts easier to read.
* **Bug Fixes**
  * Count formatting is now consistent across all profile header metrics.
  * Values of 1,000 and above are shown with a shortened “k” style representation, while smaller numbers retain standard locale formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->