### PR TITLE
fix: make dynamic per-user OG image win on shares + enrich card with stored stats (Closes #299)

### DIFF
--- a/src/app/[username]/opengraph-image.tsx
+++ b/src/app/[username]/opengraph-image.tsx
@@ -57,12 +57,12 @@ export default async function OGImage({ params }: OGImageProps) {
     ),
   ]);
 
-  // Fetch user data and score in parallel
+  // Fetch user data and the stored profile summary in parallel
   const [user, profileRow] = await Promise.all([
     fetchGitHubUser(username),
     supabase
       .from("profiles")
-      .select("score")
+      .select("score, total_commits, total_prs, total_issues, total_reviews")
       .eq("username", username)
       .maybeSingle()
       .then((r) => r.data),
@@ -74,6 +74,17 @@ export default async function OGImage({ params }: OGImageProps) {
     profileRow && typeof profileRow.score === "number"
       ? profileRow.score
       : 0;
+
+  // Stored contribution totals. Rendered only when the profile has been synced —
+  // an unsynced profile keeps the original avatar + score layout rather than
+  // showing a row of zeroes.
+  const statValue = (v: unknown) => (typeof v === "number" ? v : null);
+  const stats = [
+    { label: "Commits", value: statValue(profileRow?.total_commits) },
+    { label: "PRs", value: statValue(profileRow?.total_prs) },
+    { label: "Issues", value: statValue(profileRow?.total_issues) },
+    { label: "Reviews", value: statValue(profileRow?.total_reviews) },
+  ].filter((s): s is { label: string; value: number } => s.value !== null);
 
   return new ImageResponse(
     (
@@ -217,6 +228,53 @@ export default async function OGImage({ params }: OGImageProps) {
             </span>
           </div>
         </div>
+
+        {/* Stored contribution stats — only when the profile has been synced */}
+        {stats.length > 0 ? (
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "48px",
+              marginTop: "8px",
+            }}
+          >
+            {stats.map((stat) => (
+              <div
+                key={stat.label}
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: "2px",
+                }}
+              >
+                <span
+                  style={{
+                    fontSize: "30px",
+                    fontWeight: 500,
+                    color: "#171717",
+                    lineHeight: 1.15,
+                    letterSpacing: "-0.6px",
+                  }}
+                >
+                  {stat.value.toLocaleString("en-US")}
+                </span>
+                <span
+                  style={{
+                    fontSize: "12px",
+                    fontWeight: 500,
+                    color: "#707070",
+                    letterSpacing: "1.2px",
+                    textTransform: "uppercase" as const,
+                    lineHeight: 1.45,
+                  }}
+                >
+                  {stat.label}
+                </span>
+              </div>
+            ))}
+          </div>
+        ) : null}
 
         {/* Bottom bar — URL + tagline */}
         <div

--- a/src/app/[username]/page.tsx
+++ b/src/app/[username]/page.tsx
@@ -87,9 +87,27 @@ export async function generateMetadata({ params }: ProfilePageProps): Promise<Me
     // Rate limit or network error - fall back to minimal metadata
   }
   if (!user) {
+    const fallbackDescription = `Open-source profile for ${username}.`;
     return {
       title: `${username} - OSSfolio`,
-      description: `Open-source profile for ${username}.`,
+      description: fallbackDescription,
+      // Always emit openGraph/twitter blocks on a profile route — even when the
+      // GitHub lookup fails (rate limit / network). Returning without them let
+      // the root layout's static `/og-image.png` be inherited here, which is why
+      // shared profile links could fall back to the generic card. Neither block
+      // sets `images`, so the per-user `opengraph-image.tsx` / `twitter-image.tsx`
+      // file convention remains the single source of og:image and twitter:image.
+      openGraph: {
+        title: `${username} - OSSfolio`,
+        description: fallbackDescription,
+        type: "profile",
+        siteName: "OSSfolio",
+      },
+      twitter: {
+        card: "summary_large_image",
+        title: `${username} - OSSfolio`,
+        description: fallbackDescription,
+      },
     };
   }
   const displayName = user.name || user.login;


### PR DESCRIPTION
Closes #299

## Diagnosis

Before building anything, I dug into the existing OG setup (per my comment on the issue) and confirmed with PRODHOSH that the goal is to make the existing dynamic image take precedence, not add a duplicate endpoint.

The dynamic per-user OG image already exists at `src/app/[username]/opengraph-image.tsx`, using `next/og`'s `ImageResponse` (the App Router file-convention equivalent of `@vercel/og`) on the edge runtime, drawing a 1200×630 card with the user's avatar, name, and score. `twitter-image.tsx` re-exports the same generator for Twitter/X crawlers.

The actual bug was in `generateMetadata` (in `src/app/[username]/page.tsx`), specifically its **fallback path** — hit whenever the GitHub lookup rate-limits or errors, which is common. That path returned only `title`/`description`, with no `openGraph`/`twitter` block at all. Metadata without an explicit `openGraph.images` normally lets the file-convention image take over — but with *no* `openGraph` block whatsoever, Next.js falls back further up the tree to the root `layout.tsx`, which hardcodes a static image:

```ts
openGraph: { images: [{ url: "/og-image.png", width: 1200, height: 630 }] }
twitter: { images: ["/og-image.png"] }
```

That's exactly the reported symptom: shared profile links showing the generic static card. The success path (GitHub lookup succeeds) already omits `images` correctly, so this only manifested on the fallback path — which is why it wasn't 100% of shares, just some.

## What changed

**`src/app/[username]/page.tsx`**
- `generateMetadata`'s fallback branch now emits full `openGraph`/`twitter` blocks (title, description, type, siteName / card) — matching the shape of the success path — but still omits `images`. This means the per-user `opengraph-image.tsx` / `twitter-image.tsx` file convention is the *only* image source on every profile render, success or fallback.

**`src/app/[username]/opengraph-image.tsx`**
- Extended the `profiles` select to pull `total_commits`, `total_prs`, `total_issues`, `total_reviews` alongside `score` (all already stored via the `auth/callback` upsert — no new fetch or schema change).
- Added a stats row (Commits / PRs / Issues / Reviews) to the card, rendered **only when the profile has been synced** (each stat is filtered to only render if it's a real number) — an unsynced/never-logged-in profile keeps the original avatar + score layout rather than showing zeroes.
- Reused the file's existing hex design tokens (`#171717`, `#707070`, `#3ecf8e`) for the new elements — Satori (the renderer behind `ImageResponse`) doesn't support CSS custom properties, so the file was already using literal hex values; I kept that pattern rather than introducing `var(--...)` which would silently fail to render.

## Verification
- `npm run type-check` — clean
- `npm run lint` — clean (one pre-existing `<img>`-optimization warning in this file, unrelated to this change, present before and after)
- `npm run build` — compiles successfully; `/-/opengraph-image` and `/-/twitter-image` both present in the route output
- Manually verified: an existing synced profile now shows the enriched stats row; an unsynced profile (never logged in) renders the original avatar/score layout with no stat row; the fallback metadata path (simulated by forcing the GitHub fetch to fail) now emits `openGraph`/`twitter` without a static image reference

## Scope note
No new endpoint, no duplicate of the existing generator — per your comment, this fixes precedence on the existing implementation and enriches it, rather than adding a separate `/api/og` route.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Open Graph profile images now display stored contribution statistics, including commits, pull requests, issues, and reviews when available.
  * Added richer profile metadata for social previews, including tailored titles, descriptions, and profile-specific preview formats.

* **Bug Fixes**
  * Improved social preview information when profile lookups fail due to unavailable or limited external data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->