### PR TITLE
feat: add ratio-based anomaly detection for scoring spikes (Closes #302)

### DIFF
--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import { supabase } from "@/lib/supabase";
 import { fetchContributorProfile, contributorToScoreInputs } from "@/lib/github";
 import { mapRepos, fetchLiveStats } from "@/lib/profile-data";
-import { calculateScore } from "@/lib/score";
+import { scoreWithAnomalyCheck } from "@/lib/anomaly";
 import type { Session } from "@supabase/supabase-js";
 import type { ContributorStats, Repo } from "@/types";
 
@@ -51,7 +51,11 @@ async function syncScore(
     ({ stats, repos } = await statsFromRest(username));
   }
 
-  const score = calculateScore(stats, repos);
+  // Score the account and run the anti-gaming heuristic. A flagged account is
+  // persisted with its reason (auditable, reversible) and stores the discounted
+  // score, so every surface that reads `profiles.score` reflects the discount.
+  const { score, anomaly } = scoreWithAnomalyCheck(stats, repos);
+  const now = new Date().toISOString();
 
   const { error } = await supabase.from("profiles").upsert(
     {
@@ -62,7 +66,10 @@ async function syncScore(
       total_prs: stats.totalPRs,
       total_issues: stats.totalIssues,
       total_reviews: stats.totalReviews,
-      updated_at: new Date().toISOString(),
+      flagged: anomaly.flagged,
+      flag_reason: anomaly.reason,
+      flagged_at: anomaly.flagged ? now : null,
+      updated_at: now,
     },
     { onConflict: "id" }
   );

--- a/src/lib/anomaly.ts
+++ b/src/lib/anomaly.ts
@@ -1,0 +1,102 @@
+import type { ContributorStats, Repo } from "@/types";
+import { calculateScore } from "@/lib/score";
+
+/**
+ * Heuristic anti-gaming check for the contributor score.
+ *
+ * The exploit this targets: commits are weighted directly in `calculateScore`
+ * (SCORE_WEIGHTS.COMMIT), so an account that spams empty commits gains score
+ * with no real contribution. Empty-commit spam has a distinctive shape — a very
+ * large commit count paired with almost no collaborative activity (PRs, issues,
+ * reviews) and no community validation (stars). Legitimate high-volume
+ * contributors essentially always have proportional PRs/reviews, stars, or both.
+ *
+ * v1 is deliberately conservative: an account must clear *all* of the guards
+ * below before it is flagged, so false positives stay rare. Thresholds are
+ * exported constants so they can be tuned without touching the logic.
+ *
+ * Note: `ContributorStats` carries only aggregate totals (no time dimension), so
+ * a literal commits-per-day velocity isn't computable here. This ratio signal
+ * uses only data already fetched — no extra GitHub calls.
+ */
+export const ANOMALY_THRESHOLDS = {
+  /** Accounts below this many commits are never flagged (protects small/new accounts). */
+  MIN_COMMITS: 1000,
+  /** Commits per collaborative contribution (PRs + issues + reviews) above which activity looks synthetic. */
+  MAX_COMMIT_RATIO: 50,
+  /** An account with at least this many total stars is treated as community-validated and never flagged. */
+  CREDIBLE_STARS: 50,
+} as const;
+
+/** A flagged account's score is multiplied by this (a discount, not a zeroing — reversible and tunable). */
+export const ANOMALY_SCORE_MULTIPLIER = 0.25;
+
+export interface AnomalyResult {
+  flagged: boolean;
+  /** Human-readable justification, persisted to `profiles.flag_reason` for auditability. */
+  reason: string | null;
+  /** commits ÷ (PRs + issues + reviews); equals the commit count when there is no collaborative activity. */
+  commitRatio: number;
+}
+
+/**
+ * Applies the ratio heuristic to a contributor's aggregate stats.
+ * Pure — no side effects, no network.
+ */
+export function detectAnomaly(
+  stats: ContributorStats,
+  totalStars: number
+): AnomalyResult {
+  const collaborative =
+    stats.totalPRs + stats.totalIssues + stats.totalReviews;
+  const commitRatio =
+    collaborative > 0 ? stats.totalCommits / collaborative : stats.totalCommits;
+
+  const notFlagged: AnomalyResult = { flagged: false, reason: null, commitRatio };
+
+  // Guard 1 — too little volume to be worth flagging.
+  if (stats.totalCommits < ANOMALY_THRESHOLDS.MIN_COMMITS) return notFlagged;
+
+  // Guard 2 — community validation. Stars mean real projects people use.
+  if (totalStars >= ANOMALY_THRESHOLDS.CREDIBLE_STARS) return notFlagged;
+
+  // Guard 3 — the ratio itself must be implausible.
+  if (commitRatio < ANOMALY_THRESHOLDS.MAX_COMMIT_RATIO) return notFlagged;
+
+  return {
+    flagged: true,
+    reason:
+      `Unusual commit ratio: ${stats.totalCommits.toLocaleString("en-US")} commits ` +
+      `vs ${collaborative.toLocaleString("en-US")} PRs/issues/reviews ` +
+      `(${Math.round(commitRatio)}:1) with ${totalStars} stars`,
+    commitRatio,
+  };
+}
+
+/** Returns the score after applying the flagged-account discount. */
+export function applyAnomalyDiscount(
+  score: number,
+  anomaly: AnomalyResult
+): number {
+  if (!anomaly.flagged) return score;
+  return Math.round(score * ANOMALY_SCORE_MULTIPLIER);
+}
+
+/**
+ * Convenience wrapper for the sync path: computes the score, runs the heuristic,
+ * and returns the (possibly discounted) score alongside the anomaly result so the
+ * caller can persist both the score and the flag columns in one upsert.
+ */
+export function scoreWithAnomalyCheck(
+  stats: ContributorStats,
+  repos: Repo[]
+): { score: number; rawScore: number; anomaly: AnomalyResult } {
+  const totalStars = repos.reduce((sum, r) => sum + r.stars, 0);
+  const rawScore = calculateScore(stats, repos);
+  const anomaly = detectAnomaly(stats, totalStars);
+  return {
+    score: applyAnomalyDiscount(rawScore, anomaly),
+    rawScore,
+    anomaly,
+  };
+}

--- a/supabase/migrations/20260711000000_add_profile_anomaly_flags.sql
+++ b/supabase/migrations/20260711000000_add_profile_anomaly_flags.sql
@@ -1,0 +1,16 @@
+-- Anomaly detection flags for scoring abuse (see src/lib/anomaly.ts).
+-- flagged      : set when the ratio heuristic detects likely score gaming (e.g. empty-commit spam).
+-- flag_reason  : human-readable justification, so a flag is auditable and reversible.
+-- flagged_at   : when the flag was last applied.
+-- A flagged account keeps its profile; its stored score is discounted at sync time.
+
+alter table public.profiles
+  add column if not exists flagged boolean not null default false,
+  add column if not exists flag_reason text,
+  add column if not exists flagged_at timestamptz;
+
+-- Partial index: only flagged rows are indexed, since that is the set moderation
+-- (and a future "hide flagged profiles" pass) will need to look up.
+create index if not exists idx_profiles_flagged
+  on public.profiles (flagged)
+  where flagged;


### PR DESCRIPTION
Closes #302

Per our discussion on the issue: **v1 scope** is the ratio-based heuristic, conservative thresholds, a persisted flag (not a hard ban), and a score discount. Hiding flagged profiles from discover/leaderboard is an explicit follow-up, not in this PR.

## Approach

`calculateScore` (`src/lib/score.ts`) weights commits directly (`SCORE_WEIGHTS.COMMIT = 1`), so an account that spams empty commits gains score with zero real contribution — that's the exploit in the issue.

`calculateScore` only receives aggregate totals (`ContributorStats`), with no time dimension, so a literal "commits per day" velocity isn't computable from what's available at that point without fetching more data (e.g. the contribution heatmap or account-creation date). Per our exchange, v1 uses the **ratio signal** instead — no extra GitHub calls, and it directly targets the empty-commit pattern:

Empty-commit spam has a distinctive shape: a large commit count paired with almost no collaborative activity (PRs, issues, reviews) and no community validation (stars). Legitimate high-volume contributors almost always have proportional PRs/reviews, stars, or both — so the ratio cleanly separates the two without touching genuine power users.

An account is flagged only when **all three** guards pass, which keeps false positives rare:
1. `totalCommits >= 1000` — small/new accounts are never flagged regardless of ratio
2. `totalStars < 50` — any real community validation exempts the account entirely
3. `commits / (PRs + issues + reviews) >= 50` — the ratio itself must be implausible

All three thresholds are exported constants (`ANOMALY_THRESHOLDS`) at the top of the module, so they can be tuned without touching the logic.

## What changed

**`src/lib/anomaly.ts` (new)**
- `detectAnomaly(stats, totalStars)` — pure function, applies the three guards, returns `{ flagged, reason, commitRatio }`. `reason` is a human-readable string (e.g. `"Unusual commit ratio: 5,000 commits vs 0 PRs/issues/reviews (5000:1) with 0 stars"`), persisted for auditability.
- `applyAnomalyDiscount(score, anomaly)` — multiplies a flagged score by `ANOMALY_SCORE_MULTIPLIER = 0.25` (a discount, not a zeroing — reversible if the flag is later cleared).
- `scoreWithAnomalyCheck(stats, repos)` — convenience wrapper combining `calculateScore` + `detectAnomaly` + the discount, for use at the persistence boundary.

**`supabase/migrations/20260711000000_add_profile_anomaly_flags.sql` (new)**
- Adds `flagged boolean not null default false`, `flag_reason text`, `flagged_at timestamptz` to `profiles`.
- Adds a partial index `idx_profiles_flagged` (`where flagged`) — sized for the future "hide from discover" follow-up, which will need to look up exactly this set.
- **This migration must be applied in Supabase before/alongside merging** — `auth/callback`'s upsert (below) writes these three columns, and will error until they exist.

**`src/app/auth/callback/page.tsx`**
- This is the persistence boundary for `profiles.score` — the one place that writes a user's score after sign-in (which `[username]/page.tsx`, `discover`, and the OG generator all read downstream). Swapped its `calculateScore` call for `scoreWithAnomalyCheck`, and the upsert now also writes `flagged`, `flag_reason`, `flagged_at`.
- `calculateScore` itself, and its two other call sites (`[username]/page.tsx`'s live-render score and `compare/page.tsx`), are untouched — those compute a display-time score for a page that's already rendering an existing profile and aren't the write path, so v1 doesn't touch them. Happy to revisit if you'd like the live-render paths to reflect a flag too.

## Verification
- `npm run type-check` — clean; `npm run lint` — clean; `npm run build` — compiles.
- No test suite in this repo, so I ran the heuristic directly against 8 synthetic profiles covering the cases that matter most:

| Profile | Commits | Collab | Stars | Ratio | Flagged? |
|---|---|---|---|---|---|
| Empty-commit spammer | 5,000 | 0 | 0 | 5000:1 | ✅ yes |
| Spammer w/ token collab | 3,000 | 3 | 3 | 1000:1 | ✅ yes |
| Legit power user | 5,000 | 900 | 2,000 | 5.6:1 | ❌ no |
| Legit low-star maintainer | 2,000 | 230 | 10 | 8.7:1 | ❌ no |
| **Popular solo dev** (high ratio, real stars) | 3,000 | 5 | 500 | 600:1 | ❌ **no — star guard protects this account** |
| New/small account | 50 | 0 | 0 | 50:1 | ❌ no (below commit floor) |
| Boundary: just under commit floor | 999 | 0 | 0 | 999:1 | ❌ no |
| Boundary: just under ratio threshold | 1,500 | 40 | 0 | 37.5:1 | ❌ no |

All 8 classified as expected. Also confirmed the discount math: the spammer's raw score of 5,000 is stored as 1,250; the legit power user's 7,200 is stored unchanged.

## Follow-up (explicitly out of scope here)
Hiding flagged profiles from `discover`/leaderboard while keeping the profile visible to its own owner — noted in the issue as a separate pass, tracked there.