### PR TITLE
fix: fall back to initials when the navbar avatar image fails to load (Closes #288)

### DIFF
--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -43,13 +43,21 @@ const tokens = {
 
 /** Circular GitHub avatar with a graceful initial-letter fallback. */
 function Avatar({ src, name, size }: { src?: string; name?: string; size: number }) {
-  if (src) {
+  // A `src` can be present but still fail to load (e.g. the GitHub avatar URL
+  // 404s), which previously rendered a broken-image icon. Remember *which* src
+  // failed rather than a bare boolean: that way a new avatar URL is retried
+  // automatically (failedSrc no longer matches), with no reset effect needed.
+  const [failedSrc, setFailedSrc] = useState<string | null>(null);
+  const failed = src !== undefined && failedSrc === src;
+
+  if (src && !failed) {
     return (
       <Image
         src={src}
         alt={name ?? "Profile"}
         width={size}
         height={size}
+        onError={() => setFailedSrc(src)}
         style={{ 
           borderRadius: "50%", 
           border: "1px solid var(--color-hairline-strong)", 

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -70,7 +70,8 @@ function Avatar({ src, name, size }: { src?: string; name?: string; size: number
   const initial = (name?.charAt(0) ?? "U").toUpperCase();
   return (
     <span
-      aria-hidden="true"
+      role="img"
+      aria-label={name ?? "Profile"}
       style={{
         width: size,
         height: size,


### PR DESCRIPTION
Closes #288

## Root cause
`Avatar` in `Navbar.tsx` only fell back to the initial when `src` was **absent** (`if (src)`).
A `src` that is *present but fails to load* — exactly the 404 case in this issue — rendered
`<Image>` with no `onError` handler, so the browser showed its broken-image icon instead.

## Fix
Track **which** `src` failed rather than a plain boolean:

```ts
const [failedSrc, setFailedSrc] = useState<string | null>(null);
const failed = src !== undefined && failedSrc === src;
```

`onError` records the failing URL; the initials fallback renders whenever `src` is missing
*or* has failed. Because the failure is keyed to the URL itself, a new avatar (e.g. after
sign-out/sign-in with a different account) is retried automatically — no reset effect needed,
and no stale failure state can leak across users.

## Note on the suggested approach
The issue suggested `@radix-ui/react-avatar`'s `AvatarFallback`. I kept `next/image` instead
of switching to Radix's plain `<img>`, since that swap would lose Next's image optimization
just to fix a bug that a single `onError` handler resolves cleanly. Happy to migrate to Radix
here if you'd rather standardize on it — let me know.

*(For transparency: my first pass used a `useEffect` to reset the flag whenever `src` changed.
ESLint's `react-hooks/set-state-in-effect` rule correctly flagged that as an error — calling
`setState` synchronously inside an effect risks cascading renders. The derived-state version
above removes the effect entirely and lints clean.)*

## Verification
- `npm run type-check` — clean
- `npm run lint` — clean (no new warnings; the one pre-existing warning in this file's
  neighborhood is unrelated to this change)
- `npm run build` — `✓ Compiled successfully`
- Manually verified: pointing the avatar at a URL that 404s now renders the initials
  fallback instead of a broken image icon; a valid avatar URL still renders normally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved avatar handling when profile images fail to load.
  - Automatically displays an initial-letter fallback instead of a broken image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->