### PR TITLE
fix: make heatmap year navigation horizontally scrollable on mobile (Closes #280)

### DIFF
--- a/src/components/profile/HeatmapWithYearNav.tsx
+++ b/src/components/profile/HeatmapWithYearNav.tsx
@@ -40,6 +40,8 @@ const YearButton = memo(function YearButton({
         borderRadius: "9999px",
         cursor: loading ? "wait" : "pointer",
         transition: "background-color 0.15s, color 0.15s",
+        // Hold the pill's natural width so the strip scrolls instead of squashing.
+        flexShrink: 0,
       }}
     >
       {year}
@@ -173,7 +175,22 @@ function HeatmapWithYearNavInner({
         <h2 style={{ fontSize: "16px", fontWeight: 600, color: "var(--color-ink)", margin: 0, letterSpacing: "-0.2px" }}>
           Contribution activity
         </h2>
-        <div style={{ display: "flex", gap: "6px" }}>
+        <div
+          style={{
+            display: "flex",
+            gap: "6px",
+            // Keep the years on one row and let the strip scroll horizontally on
+            // narrow screens rather than squashing the buttons. `minWidth: 0` is
+            // required because this div is itself a flex item — without it the
+            // default `min-width: auto` prevents it from shrinking below its
+            // content, so `overflowX` would never engage.
+            flexWrap: "nowrap",
+            overflowX: "auto",
+            minWidth: 0,
+            WebkitOverflowScrolling: "touch",
+            scrollbarWidth: "none",
+          }}
+        >
           {years.map((year) => (
             <YearButton
               key={year}


### PR DESCRIPTION
Closes #280

## What I found
The reported behavior is real, but the stated root cause isn't quite accurate. The year-nav
container is:

```tsx
<div style={{ display: "flex", gap: "6px" }}>
```

There's no `flexWrap: "wrap"` set — CSS defaults to `nowrap` — so the buttons don't actually
wrap to multiple lines. What happens instead is they **squish**: the nav sits inside a
`justifyContent: "space-between"` header alongside the "Contribution activity" heading, and on
narrow viewports the flex item shrinks, compressing the year pills.

## Fix
- **Year-nav container:** `flexWrap: "nowrap"`, `overflowX: "auto"`, and **`minWidth: 0`**.
  The `minWidth: 0` is the detail that actually makes this work — the container is itself a
  flex item, and the default `min-width: auto` prevents it from shrinking below its content
  width, which would otherwise stop `overflowX` from ever engaging. Also added
  `WebkitOverflowScrolling: "touch"` for momentum scrolling on iOS and `scrollbarWidth: "none"`
  to keep the scrollbar visually out of the way.
- **`YearButton`:** added `flexShrink: 0`, so each pill holds its natural width and the whole
  strip scrolls horizontally instead of compressing individual buttons.

Note: this component uses inline `style={{}}` objects throughout, not Tailwind utility
classes, so I matched the file's existing convention rather than introducing
`flex-nowrap`/`overflow-x-auto` classes as originally suggested.

## Verification
- `npm run type-check` — clean; `npm run lint` — clean; `npm run build` — `✓ Compiled successfully`
- Manually checked at a 320px viewport width (iPhone SE): the year pills keep their full size
  and the strip scrolls horizontally in a single row instead of squishing.