### PR TITLE
feat: add copy-email action to the footer (Closes #285)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -40,7 +40,10 @@
       "terms": "Terms",
       "license": "License (MIT)"
     },
-    "ariaLabel": "Site footer"
+    "ariaLabel": "Site footer",
+    "copyEmail": "Copy email",
+    "emailCopied": "Email copied",
+    "copyEmailAria": "Copy contact email {email} to clipboard"
   },
   "LanguageSwitcher": {
     "label": "Language",

--- a/messages/es.json
+++ b/messages/es.json
@@ -40,7 +40,10 @@
       "terms": "Términos",
       "license": "Licencia (MIT)"
     },
-    "ariaLabel": "Pie de página"
+    "ariaLabel": "Pie de página",
+    "copyEmail": "Copiar correo",
+    "emailCopied": "Correo copiado",
+    "copyEmailAria": "Copiar el correo de contacto {email} al portapapeles"
   },
   "LanguageSwitcher": {
     "label": "Idioma",

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,8 +1,15 @@
 "use client";
 
+import { useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
+
+/**
+ * Contact address surfaced in the footer. Defined as a constant so it lives in
+ * one place if it changes.
+ */
+const CONTACT_EMAIL = "support@ossfolio.com";
 
 const linkSections = [
   {
@@ -33,6 +40,7 @@ const linkSections = [
 ] as const;
 
 export function Footer() {
+  const [copied, setCopied] = useState(false);
   const t = useTranslations("Footer");
   const tSections = useTranslations("Footer.sections");
   const tLinks = useTranslations("Footer.links");
@@ -95,6 +103,41 @@ export function Footer() {
               </svg>
               {t("starOnGitHub")}
             </a>
+
+            {/* Copy the contact address. Mirrors the inline "copied" feedback used by
+                ProfileActions rather than introducing a toast dependency. */}
+            <button
+              type="button"
+              onClick={async () => {
+                try {
+                  await navigator.clipboard.writeText(CONTACT_EMAIL);
+                  setCopied(true);
+                  setTimeout(() => setCopied(false), 2000);
+                } catch (err) {
+                  console.error("Copy to clipboard failed:", err);
+                }
+              }}
+              aria-label={t("copyEmailAria", { email: CONTACT_EMAIL })}
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: "6px",
+                fontSize: "12px",
+                color: copied ? "var(--color-primary)" : "var(--color-ink-mute-2)",
+                background: "none",
+                border: "none",
+                padding: 0,
+                cursor: "pointer",
+                textAlign: "left",
+                transition: "color 0.2s ease",
+              }}
+            >
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <rect x="2" y="4" width="20" height="16" rx="2" />
+                <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
+              </svg>
+              {copied ? t("emailCopied") : t("copyEmail")}
+            </button>
           </div>
 
           {/* Link cols */}


### PR DESCRIPTION
Closes #285

## What changed
Added a "Copy email" action to the footer's brand column, just below "Star on GitHub" — an
icon button that copies the contact address to the clipboard and confirms it inline.

## Two deliberate deviations — flagging both for your call before merge

**1. No toast library used.** The issue calls for a toast notification, but there's no toast
dependency anywhere in the project (no `sonner`, no `react-hot-toast`, etc.). Rather than pull
in a new dependency for a 10-point issue, I reused the pattern the codebase already has for
exactly this kind of feedback — the inline `copied` state in `ProfileActions.tsx` (the button
label flips to "Email copied" for 2 seconds, then reverts). Happy to add a real toast library
if you'd rather standardize on one, but that felt like a decision bigger than this issue.

**2. The email address needs your confirmation.** `support@ossfolio.com` doesn't appear
anywhere in the current codebase, so I have no way to confirm it's a real, monitored mailbox.
I've defined it as a single `CONTACT_EMAIL` constant at the top of `Footer.tsx`, so it's a
one-line change if you'd rather use a different address — **please confirm before merging**,
since shipping a dead support address to every visitor is worse than not having one.

## i18n
The footer is fully translated via `next-intl`, so I added three new keys — `copyEmail`,
`emailCopied`, `copyEmailAria` — to **both** `messages/en.json` and `messages/es.json`, rather
than hardcoding English strings into the component.

## Verification
- `npm run type-check` — clean; `npm run lint` — clean; `npm run build` — `✓ Compiled successfully`
- Manually verified the clipboard write and the inline "Email copied" confirmation.