### PR TITLE
feat: render profiles DB-first with a background snapshot sync (Closes #300)

### DIFF
--- a/src/app/[username]/page.tsx
+++ b/src/app/[username]/page.tsx
@@ -6,86 +6,41 @@ import { TemporaryUnavailableFallback } from "@/components/layout/TemporaryUnava
 
 import { ProfileView } from "@/components/profile/ProfileView";
 import {
-  fetchLiveStats,
-  fetchOrganizations,
   deriveTechStack,
   mapRepos,
-  fetchMergedPRs,
+  type GitHubUser,
 } from "@/lib/profile-data";
+import {
+  getProfileSnapshot,
+  isSnapshotStale,
+  syncProfileSnapshot,
+} from "@/lib/profile-snapshot";
+import { ProfileSyncing } from "@/components/profile/ProfileSyncing";
+import { after } from "next/server";
 import { generateMockHeatmap, computeStreaks } from "@/lib/mock";
 import { fetchContributionCalendar } from "@/lib/github";
 import { calculateScore } from "@/lib/score";
 import { supabase } from "@/lib/supabase";
-import { fetchWithTimeout, isTimeoutError } from "@/lib/fetch-with-timeout";
 
 
 export const runtime = "edge";
 
-interface GitHubUser {
-  login: string;
-  name: string | null;
-  bio: string | null;
-  avatar_url: string;
-  html_url: string;
-  public_repos: number;
-  followers: number;
-  following: number;
-  blog: string | null;
-  location: string | null;
-  twitter_username: string | null;
-}
 
 interface ProfilePageProps {
   params: Promise<{ username: string }>;
 }
 
-async function fetchGitHubUser(username: string): Promise<GitHubUser | null> {
-  const res = await fetchWithTimeout(
-    `https://api.github.com/users/${username}`,
-    {
-      headers: { Accept: "application/vnd.github.v3+json" },
-      next: { revalidate: 3600 },
-    },
-    10_000
-  );
-  if (!res.ok) {
-    try {
-      const err = await res.json();
-      if (err.message && err.message.toLowerCase().includes("rate limit")) {
-        throw new Error("RateLimit");
-      }
-    } catch (e) {
-      if (e instanceof Error && e.message === "RateLimit") throw e;
-    }
-    return null;
-  }
-
-  return res.json() as Promise<GitHubUser>;
-}
-
-async function fetchGitHubRepos(username: string) {
-  const res = await fetchWithTimeout(
-    `https://api.github.com/users/${username}/repos?sort=stars&per_page=100&type=owner`,
-    {
-      headers: { Accept: "application/vnd.github.mercy-preview+json" },
-      next: { revalidate: 3600 },
-    },
-    10_000
-  );
-  if (!res.ok) return [];
-  const repos = await res.json();
-  return repos.filter((r: { fork: boolean }) => !r.fork).slice(0, 6);
-}
-
-
 export async function generateMetadata({ params }: ProfilePageProps): Promise<Metadata> {
   const { username } = await params;
-  let user: GitHubUser | null = null;
-  try {
-    user = await fetchGitHubUser(username);
-  } catch {
-    // Rate limit or network error - fall back to minimal metadata
-  }
+  // Read the same snapshot the page body renders from, rather than calling GitHub
+  // again here. `generateMetadata` blocks the response head, so a live fetch here
+  // would put a GitHub round-trip back on the critical path and undo the TTFB win.
+  // `getProfileSnapshot` is `cache()`d, so this shares one query with the page body.
+  // A profile that hasn't synced yet simply falls through to the minimal metadata
+  // below, and gets the rich card on its next render once the snapshot lands.
+  const stored = await getProfileSnapshot(username);
+  const user: GitHubUser | null = stored?.snapshot?.user ?? null;
+
   if (!user) {
     const fallbackDescription = `Open-source profile for ${username}.`;
     return {
@@ -139,41 +94,32 @@ export async function generateMetadata({ params }: ProfilePageProps): Promise<Me
 export default async function ProfilePage({ params }: ProfilePageProps) {
   const { username } = await params;
 
-  // Base profile + repos (already-working live data) plus the new live extras.
-  let rateLimited = false;
-  let user: GitHubUser | null = null;
-  let repos: any = [];
-  let liveStats: any = null;
-  let orgs: any = [];
-  let contributionCalendar: any = null;
+  // DB-first: one query, instead of six sequential GitHub calls in the render path.
+  const stored = await getProfileSnapshot(username);
 
-  try {
-    user = await fetchGitHubUser(username);
-  } catch (e) {
-    if (e instanceof Error && e.message === "RateLimit") rateLimited = true;
-    // If GitHub is slow/unreachable, avoid a hard crash.
-    if (isTimeoutError(e)) {
-      return (
-        <TemporaryUnavailableFallback
-          heading="Temporarily Unavailable"
-          message={
-            <>
-              GitHub API is taking too long to respond for <strong>@{username}</strong>. Please try again in a moment.
-            </>
-          }
-        />
-      );
-    }
-    user = null;
+  // Cold profile — nothing stored yet. Kick the sync off behind the response and
+  // show a syncing state; `after()` runs once this response has already been sent,
+  // so it costs the user nothing. The claim inside syncProfileSnapshot() means the
+  // client polling this page cannot stampede GitHub with repeat syncs.
+  if (!stored?.snapshot) {
+    after(() => syncProfileSnapshot(username));
+    return <ProfileSyncing username={username} />;
   }
 
-  // Other fetches can also error on rate limit; we treat them similarly.
-  try { repos = await fetchGitHubRepos(username); } catch (e) { if (e instanceof Error && e.message === "RateLimit") rateLimited = true; }
-  try { liveStats = await fetchLiveStats(username); } catch (e) { if (e instanceof Error && e.message === "RateLimit") rateLimited = true; }
-  let mergedPRs: any[] = [];
-  try { mergedPRs = await fetchMergedPRs(username, 10); } catch (e) { if (e instanceof Error && e.message === "RateLimit") rateLimited = true; }
-  try { orgs = await fetchOrganizations(username); } catch (e) { if (e instanceof Error && e.message === "RateLimit") rateLimited = true; }
-  try { contributionCalendar = await fetchContributionCalendar(username); } catch (e) { if (e instanceof Error && e.message === "RateLimit") rateLimited = true; }
+  // Warm profile — render from the snapshot. If it's past its TTL, refresh it in the
+  // background: the visitor still gets the stored copy instantly (stale-while-revalidate).
+  if (isSnapshotStale(stored.syncedAt)) {
+    after(() => syncProfileSnapshot(username));
+  }
+
+  const snapshot = stored.snapshot;
+  const rateLimited = snapshot.rateLimited;
+  const user = snapshot.user;
+  const repos = snapshot.repos as any;
+  const liveStats = snapshot.liveStats as any;
+  const mergedPRs = (snapshot.mergedPRs ?? []) as any[];
+  const orgs = snapshot.orgs as any;
+  const contributionCalendar = snapshot.contributionCalendar as any;
 
   if (!user && !rateLimited) return notFound();
 

--- a/src/app/[username]/page.tsx
+++ b/src/app/[username]/page.tsx
@@ -1,4 +1,5 @@
 import { notFound } from "next/navigation";
+import type { ContributorStats } from "@/types";
 import type { Metadata } from "next";
 import { Navbar } from "@/components/layout/Navbar";
 import { Footer } from "@/components/layout/Footer";
@@ -112,14 +113,26 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
     after(() => syncProfileSnapshot(username));
   }
 
+  // ProfileSnapshot types every field, so no casts are needed. Array-shaped fields all
+  // get the same `?? []` default: an older row written before a field existed would
+  // otherwise arrive undefined and throw when mapped.
   const snapshot = stored.snapshot;
   const rateLimited = snapshot.rateLimited;
   const user = snapshot.user;
-  const repos = snapshot.repos as any;
-  const liveStats = snapshot.liveStats as any;
-  const mergedPRs = (snapshot.mergedPRs ?? []) as any[];
-  const orgs = snapshot.orgs as any;
-  const contributionCalendar = snapshot.contributionCalendar as any;
+  const repos = snapshot.repos ?? [];
+  // ContributorStats requires every field, and fetchLiveStats already degrades to zeros
+  // rather than throwing — so a null (failed) snapshot value degrades the same way here,
+  // instead of spreading `null` into an object missing four required fields.
+  const liveStats: ContributorStats = snapshot.liveStats ?? {
+    totalCommits: 0,
+    totalPRs: 0,
+    totalIssues: 0,
+    totalReviews: 0,
+    totalContributions: 0,
+  };
+  const mergedPRs = snapshot.mergedPRs ?? [];
+  const orgs = snapshot.orgs ?? [];
+  const contributionCalendar = snapshot.contributionCalendar ?? null;
 
   if (!user && !rateLimited) return notFound();
 

--- a/src/components/profile/ProfileSyncing.tsx
+++ b/src/components/profile/ProfileSyncing.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { Navbar } from "@/components/layout/Navbar";
+import { Footer } from "@/components/layout/Footer";
+
+/**
+ * Shown the first time a profile is viewed, while its snapshot is being built in
+ * the background. The server has already kicked off the sync via `after()`; this
+ * just re-renders the route until the snapshot lands, then unmounts itself when the
+ * real profile takes its place.
+ *
+ * Polling stops after `MAX_ATTEMPTS` rather than spinning forever, so a profile that
+ * can't be synced (GitHub down, a rate limit that outlasts the window) ends in an
+ * honest "try again" rather than an endless spinner.
+ */
+const POLL_INTERVAL_MS = 2500;
+const MAX_ATTEMPTS = 12; // ~30s
+
+export function ProfileSyncing({ username }: { username: string }) {
+  const router = useRouter();
+  const [attempts, setAttempts] = useState(0);
+
+  const gaveUp = attempts >= MAX_ATTEMPTS;
+
+  useEffect(() => {
+    if (gaveUp) return;
+
+    const timer = setTimeout(() => {
+      setAttempts((n) => n + 1);
+      // Re-runs the server component. Once the snapshot exists, the profile renders
+      // instead of this component.
+      router.refresh();
+    }, POLL_INTERVAL_MS);
+
+    return () => clearTimeout(timer);
+  }, [attempts, gaveUp, router]);
+
+  return (
+    <>
+      <Navbar />
+      <main
+        style={{
+          backgroundColor: "var(--color-canvas)",
+          color: "var(--color-ink)",
+          minHeight: "100vh",
+          transition: "background-color 0.2s ease, color 0.2s ease",
+        }}
+      >
+        <div
+          style={{
+            maxWidth: "640px",
+            margin: "0 auto",
+            padding: "96px 20px",
+            textAlign: "center",
+          }}
+        >
+          {!gaveUp && (
+            <div
+              aria-hidden="true"
+              style={{
+                width: "28px",
+                height: "28px",
+                margin: "0 auto 20px auto",
+                borderRadius: "50%",
+                border: "2px solid var(--color-hairline-strong)",
+                borderTopColor: "var(--color-primary)",
+                animation: "ossfolio-spin 0.8s linear infinite",
+              }}
+            />
+          )}
+
+          <h1 style={{ fontSize: "22px", fontWeight: 500, margin: "0 0 12px 0" }}>
+            {gaveUp ? "Still working on it" : "Building this profile"}
+          </h1>
+
+          <p
+            style={{ fontSize: "15px", color: "var(--color-ink-mute)", margin: 0 }}
+            role="status"
+            aria-live="polite"
+          >
+            {gaveUp ? (
+              <>
+                We haven&apos;t been able to finish fetching <strong>@{username}</strong> from
+                GitHub yet. This usually means GitHub is rate-limiting us — please try again in
+                a few minutes.
+              </>
+            ) : (
+              <>
+                We&apos;re fetching <strong>@{username}</strong>&apos;s data from GitHub for the
+                first time. This page will update on its own in a moment.
+              </>
+            )}
+          </p>
+
+          {gaveUp && (
+            <button
+              type="button"
+              onClick={() => {
+                setAttempts(0);
+                router.refresh();
+              }}
+              style={{
+                marginTop: "20px",
+                padding: "10px 18px",
+                fontSize: "14px",
+                fontWeight: 500,
+                borderRadius: "8px",
+                cursor: "pointer",
+                color: "var(--color-on-primary)",
+                backgroundColor: "var(--color-primary)",
+                border: "1px solid var(--color-primary-deep)",
+              }}
+            >
+              Try again
+            </button>
+          )}
+        </div>
+      </main>
+      <Footer />
+
+      <style>{`
+        @keyframes ossfolio-spin {
+          to { transform: rotate(360deg); }
+        }
+        @media (prefers-reduced-motion: reduce) {
+          [style*="ossfolio-spin"] { animation: none !important; }
+        }
+      `}</style>
+    </>
+  );
+}

--- a/src/lib/profile-data.ts
+++ b/src/lib/profile-data.ts
@@ -2,6 +2,22 @@ import type { ContributorStats, Org, Repo, TechEntry, MergedPR } from "@/types";
 import { LANG_COLORS } from "@/lib/languages";
 import { fetchWithTimeout } from "@/lib/fetch-with-timeout";
 
+/**
+ * GitHub answers a rate limit with 403/429 and a "rate limit" message. Raise it as
+ * an error so callers that persist results can decline to cache a degraded response.
+ */
+async function throwIfRateLimited(res: Response): Promise<void> {
+  if (res.status !== 403 && res.status !== 429) return;
+  try {
+    const err = await res.clone().json();
+    if (typeof err?.message === "string" && err.message.toLowerCase().includes("rate limit")) {
+      throw new Error("RateLimit");
+    }
+  } catch (e) {
+    if (e instanceof Error && e.message === "RateLimit") throw e;
+  }
+}
+
 
 /**
  * Live profile "extras" derived from the public (unauthenticated) GitHub REST
@@ -28,7 +44,7 @@ export function languageColor(language: string | null): string | null {
   return LANG_COLORS[language] ?? "#9a9a9a";
 }
 
-interface GitHubRepoLike {
+export interface GitHubRepoLike {
   name: string;
   description: string | null;
   html_url: string;
@@ -36,6 +52,16 @@ interface GitHubRepoLike {
   forks_count: number;
   language: string | null;
   topics?: string[];
+}
+
+/**
+ * A raw GitHub repo as the REST API returns it, carrying every field this app reads.
+ * A superset of `GitHubRepoLike` (what mapRepos/deriveTechStack need) and of the shape
+ * ProfileView renders, so one snapshot payload satisfies all three consumers without casts.
+ */
+export interface GitHubRepoPayload extends GitHubRepoLike {
+  id: number;
+  pushed_at?: string;
 }
 
 /** Map raw REST repos into the `Repo` type the TopRepos component consumes. */
@@ -125,12 +151,15 @@ export async function fetchOrganizations(username: string): Promise<Org[]> {
       `https://api.github.com/users/${encodeURIComponent(username)}/orgs`,
       {
         headers: { Accept: "application/vnd.github.v3+json" },
-        next: { revalidate: 3600 },
+        cache: "no-store",
       },
       10_000
     );
 
-    if (!res.ok) return [];
+    if (!res.ok) {
+      await throwIfRateLimited(res);
+      return [];
+    }
     const orgs = (await res.json()) as GitHubOrgLike[];
     if (!Array.isArray(orgs)) return [];
     return orgs.map((o) => ({
@@ -139,7 +168,10 @@ export async function fetchOrganizations(username: string): Promise<Org[]> {
       avatarUrl: o.avatar_url,
       url: `https://github.com/${o.login}`,
     }));
-  } catch {
+  } catch (e) {
+    // A rate limit must not be flattened into "this user has none" — the result is
+    // persisted now, so that would cache an empty list as fresh for a full hour.
+    if (e instanceof Error && e.message === "RateLimit") throw e;
     return [];
   }
 }
@@ -152,12 +184,15 @@ export async function fetchMergedPRs(username: string, limit: number = 10): Prom
       `https://api.github.com/${query}`,
       {
         headers: { Accept: "application/vnd.github.v3+json" },
-        next: { revalidate: 3600 },
+        cache: "no-store",
       },
       10_000
     );
 
-    if (!res.ok) return [];
+    if (!res.ok) {
+      await throwIfRateLimited(res);
+      return [];
+    }
     const json = await res.json();
     if (!Array.isArray(json.items)) return [];
     return json.items.map((item: any) => ({
@@ -166,7 +201,10 @@ export async function fetchMergedPRs(username: string, limit: number = 10): Prom
       repoName: item.repository_url.split('/').slice(-1)[0],
       mergedAt: item.closed_at,
     }));
-  } catch {
+  } catch (e) {
+    // A rate limit must not be flattened into "this user has none" — the result is
+    // persisted now, so that would cache an empty list as fresh for a full hour.
+    if (e instanceof Error && e.message === "RateLimit") throw e;
     return [];
   }
 }
@@ -195,7 +233,10 @@ export async function fetchGitHubUser(username: string): Promise<GitHubUser | nu
     `https://api.github.com/users/${username}`,
     {
       headers: { Accept: "application/vnd.github.v3+json" },
-      next: { revalidate: 3600 },
+      // The snapshot TTL in the DB is now the single source of freshness. A second,
+      // independent Next Data Cache in front of it would let a "stale" sync be served
+      // an hour-old response, so it is deliberately disabled here.
+      cache: "no-store",
     },
     10_000
   );
@@ -214,16 +255,25 @@ export async function fetchGitHubUser(username: string): Promise<GitHubUser | nu
   return res.json() as Promise<GitHubUser>;
 }
 
-export async function fetchGitHubRepos(username: string) {
+export async function fetchGitHubRepos(username: string): Promise<GitHubRepoPayload[]> {
   const res = await fetchWithTimeout(
     `https://api.github.com/users/${username}/repos?sort=stars&per_page=100&type=owner`,
     {
       headers: { Accept: "application/vnd.github.mercy-preview+json" },
-      next: { revalidate: 3600 },
+      cache: "no-store",
     },
     10_000
   );
-  if (!res.ok) return [];
-  const repos = await res.json();
-  return repos.filter((r: { fork: boolean }) => !r.fork).slice(0, 6);
+  if (!res.ok) {
+    // Previously this swallowed every non-OK response into an empty list. That was
+    // survivable when the page re-fetched on each render, but the result is now
+    // persisted, so a rate-limited response would cache an empty repo list as
+    // "fresh" for an hour. Surface it instead, so the sync declines to store it.
+    await throwIfRateLimited(res);
+    return [];
+  }
+  // Untyped JSON from the API boundary — assert the shape once, here, rather than
+  // leaking `any` into every consumer.
+  const repos = (await res.json()) as (GitHubRepoPayload & { fork: boolean })[];
+  return repos.filter((r) => !r.fork).slice(0, 6);
 }

--- a/src/lib/profile-data.ts
+++ b/src/lib/profile-data.ts
@@ -170,3 +170,60 @@ export async function fetchMergedPRs(username: string, limit: number = 10): Prom
     return [];
   }
 }
+
+/**
+ * The GitHub user object. Previously defined inside the profile page; lifted here
+ * so the background snapshot sync can fetch exactly what the page renders, rather
+ * than a second, drifting copy of the same request.
+ */
+export interface GitHubUser {
+  login: string;
+  name: string | null;
+  bio: string | null;
+  avatar_url: string;
+  html_url: string;
+  public_repos: number;
+  followers: number;
+  following: number;
+  blog: string | null;
+  location: string | null;
+  twitter_username: string | null;
+}
+
+export async function fetchGitHubUser(username: string): Promise<GitHubUser | null> {
+  const res = await fetchWithTimeout(
+    `https://api.github.com/users/${username}`,
+    {
+      headers: { Accept: "application/vnd.github.v3+json" },
+      next: { revalidate: 3600 },
+    },
+    10_000
+  );
+  if (!res.ok) {
+    try {
+      const err = await res.json();
+      if (err.message && err.message.toLowerCase().includes("rate limit")) {
+        throw new Error("RateLimit");
+      }
+    } catch (e) {
+      if (e instanceof Error && e.message === "RateLimit") throw e;
+    }
+    return null;
+  }
+
+  return res.json() as Promise<GitHubUser>;
+}
+
+export async function fetchGitHubRepos(username: string) {
+  const res = await fetchWithTimeout(
+    `https://api.github.com/users/${username}/repos?sort=stars&per_page=100&type=owner`,
+    {
+      headers: { Accept: "application/vnd.github.mercy-preview+json" },
+      next: { revalidate: 3600 },
+    },
+    10_000
+  );
+  if (!res.ok) return [];
+  const repos = await res.json();
+  return repos.filter((r: { fork: boolean }) => !r.fork).slice(0, 6);
+}

--- a/src/lib/profile-snapshot.ts
+++ b/src/lib/profile-snapshot.ts
@@ -1,0 +1,205 @@
+import { cache } from "react";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { supabase } from "@/lib/supabase";
+import {
+  fetchGitHubUser,
+  fetchGitHubRepos,
+  fetchLiveStats,
+  fetchOrganizations,
+  fetchMergedPRs,
+  type GitHubUser,
+} from "@/lib/profile-data";
+import { fetchContributionCalendar } from "@/lib/github";
+
+/**
+ * DB-first profile data.
+ *
+ * The profile page used to await six GitHub calls in sequence before it could
+ * respond, so TTFB was their sum. It now reads a stored snapshot in one query and
+ * renders from that; the GitHub work happens afterwards, in the background, via
+ * `after()`.
+ *
+ * The snapshot stores the *raw* GitHub payloads rather than the derived score,
+ * heatmap, or tech stack. Those are cheap pure functions computed at render, so
+ * keeping them out of the snapshot means changing the scoring formula takes effect
+ * immediately instead of requiring every stored row to be re-synced.
+ */
+
+/** How old a snapshot may be before we refresh it behind the response. */
+export const SNAPSHOT_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+/**
+ * How long one sync may hold its claim. A cold profile is polled by the client
+ * while it syncs, and every one of those renders would otherwise fire another
+ * six-call GitHub sync — a stampede against the very API this issue is trying to
+ * stop hammering. The claim below makes only the first one proceed.
+ */
+const SYNC_LOCK_MS = 2 * 60 * 1000; // 2 minutes
+
+export interface ProfileSnapshot {
+  user: GitHubUser | null;
+  repos: unknown[];
+  liveStats: unknown;
+  mergedPRs: unknown[];
+  orgs: unknown[];
+  contributionCalendar: unknown;
+  /** True when the sync completed but GitHub rate-limited some of the calls. */
+  rateLimited: boolean;
+}
+
+export interface SnapshotRow {
+  snapshot: ProfileSnapshot | null;
+  syncedAt: string | null;
+}
+
+/** True when a snapshot is old enough to be worth refreshing behind the response. */
+export function isSnapshotStale(syncedAt: string | null): boolean {
+  if (!syncedAt) return true;
+  const at = Date.parse(syncedAt);
+  if (!Number.isFinite(at)) return true;
+  return Date.now() - at > SNAPSHOT_TTL_MS;
+}
+
+/**
+ * Read the stored snapshot. Uses the anon client — reads are public, per the RLS
+ * policy on the table. Returns null when nothing has ever been stored.
+ *
+ * Wrapped in React's `cache()` so `generateMetadata` and the page body — which both
+ * need it and both run for the same request — share a single database round-trip.
+ */
+export const getProfileSnapshot = cache(async function getProfileSnapshot(
+  username: string
+): Promise<SnapshotRow | null> {
+  const { data, error } = await supabase
+    .from("profile_snapshots")
+    .select("snapshot, synced_at")
+    .eq("username", username.toLowerCase())
+    .maybeSingle();
+
+  if (error || !data) return null;
+
+  return {
+    snapshot: (data.snapshot as ProfileSnapshot | null) ?? null,
+    syncedAt: (data.synced_at as string | null) ?? null,
+  };
+});
+
+function adminClient(): SupabaseClient | null {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !serviceKey) return null;
+  return createClient(url, serviceKey);
+}
+
+/**
+ * Take the sync claim for a username, so concurrent renders don't all sync.
+ *
+ * Two steps, because the row may not exist yet:
+ *  1. Insert a claim row if there isn't one (ignoring a conflict if there is).
+ *  2. Atomically bump `sync_started_at`, but only if the existing value is older
+ *     than the lock window. Postgres decides the winner, so this is race-safe
+ *     across concurrent edge invocations — the same technique `refreshProfile()`
+ *     already uses against `profiles.last_refreshed_at`.
+ *
+ * Returns false when another sync currently holds the claim.
+ */
+async function claimSync(admin: SupabaseClient, username: string): Promise<boolean> {
+  const now = new Date();
+  const lockCutoff = new Date(now.getTime() - SYNC_LOCK_MS).toISOString();
+
+  const { error: insertError } = await admin
+    .from("profile_snapshots")
+    .insert({ username, sync_started_at: now.toISOString() });
+
+  // No conflict: the row is new and we just created it, so the claim is ours.
+  if (!insertError) return true;
+
+  // A row already existed. Take the claim only if the previous sync is stale.
+  const { data } = await admin
+    .from("profile_snapshots")
+    .update({ sync_started_at: now.toISOString() })
+    .eq("username", username)
+    .lt("sync_started_at", lockCutoff)
+    .select("username")
+    .maybeSingle();
+
+  return Boolean(data);
+}
+
+/**
+ * Fetch the profile from GitHub and store it.
+ *
+ * Intended to be called from `after()`, so it runs once the response has already
+ * been sent and never blocks a render. The six GitHub calls run concurrently here
+ * (they're independent), so a sync costs roughly the slowest call rather than the
+ * sum of all six.
+ *
+ * Failures are contained: one failing call leaves that section empty rather than
+ * discarding the whole snapshot, matching how the page already degrades.
+ */
+export async function syncProfileSnapshot(rawUsername: string): Promise<void> {
+  const username = rawUsername.toLowerCase();
+
+  const admin = adminClient();
+  if (!admin) {
+    console.error("[snapshot] service-role key missing; cannot sync");
+    return;
+  }
+
+  if (!(await claimSync(admin, username))) {
+    // Another sync is already in flight for this username.
+    return;
+  }
+
+  const [user, repos, liveStats, mergedPRs, orgs, contributionCalendar] =
+    await Promise.allSettled([
+      fetchGitHubUser(rawUsername),
+      fetchGitHubRepos(rawUsername),
+      fetchLiveStats(rawUsername),
+      fetchMergedPRs(rawUsername, 10),
+      fetchOrganizations(rawUsername),
+      fetchContributionCalendar(rawUsername),
+    ]);
+
+  const wasRateLimited = (r: PromiseSettledResult<unknown>) =>
+    r.status === "rejected" &&
+    r.reason instanceof Error &&
+    r.reason.message === "RateLimit";
+
+  const rateLimited = [user, repos, liveStats, mergedPRs, orgs, contributionCalendar].some(
+    wasRateLimited
+  );
+
+  // A rate-limited user fetch tells us nothing about whether the account exists, so
+  // storing `user: null` would cache a false 404. Leave the snapshot alone and let
+  // the next attempt try again.
+  if (user.status === "rejected" && wasRateLimited(user)) {
+    return;
+  }
+
+  const snapshot: ProfileSnapshot = {
+    user: user.status === "fulfilled" ? user.value : null,
+    repos: repos.status === "fulfilled" ? repos.value : [],
+    liveStats: liveStats.status === "fulfilled" ? liveStats.value : null,
+    mergedPRs: mergedPRs.status === "fulfilled" ? mergedPRs.value : [],
+    orgs: orgs.status === "fulfilled" ? orgs.value : [],
+    contributionCalendar:
+      contributionCalendar.status === "fulfilled" ? contributionCalendar.value : null,
+    rateLimited,
+  };
+
+  const { error } = await admin
+    .from("profile_snapshots")
+    .upsert(
+      {
+        username,
+        snapshot,
+        synced_at: new Date().toISOString(),
+      },
+      { onConflict: "username" }
+    );
+
+  if (error) {
+    console.error("[snapshot] failed to store snapshot:", error.message);
+  }
+}

--- a/src/lib/profile-snapshot.ts
+++ b/src/lib/profile-snapshot.ts
@@ -8,8 +8,10 @@ import {
   fetchOrganizations,
   fetchMergedPRs,
   type GitHubUser,
+  type GitHubRepoPayload,
 } from "@/lib/profile-data";
-import { fetchContributionCalendar } from "@/lib/github";
+import { fetchContributionCalendar, type ContributionCalendar } from "@/lib/github";
+import type { ContributorStats, Org, MergedPR } from "@/types";
 
 /**
  * DB-first profile data.
@@ -38,12 +40,12 @@ const SYNC_LOCK_MS = 2 * 60 * 1000; // 2 minutes
 
 export interface ProfileSnapshot {
   user: GitHubUser | null;
-  repos: unknown[];
-  liveStats: unknown;
-  mergedPRs: unknown[];
-  orgs: unknown[];
-  contributionCalendar: unknown;
-  /** True when the sync completed but GitHub rate-limited some of the calls. */
+  repos: GitHubRepoPayload[];
+  liveStats: ContributorStats | null;
+  mergedPRs: MergedPR[];
+  orgs: Org[];
+  contributionCalendar: ContributionCalendar | null;
+  /** True when GitHub rate-limited any of the calls. Such a snapshot is never stored. */
   rateLimited: boolean;
 }
 
@@ -114,6 +116,15 @@ async function claimSync(admin: SupabaseClient, username: string): Promise<boole
   // No conflict: the row is new and we just created it, so the claim is ours.
   if (!insertError) return true;
 
+  // Only a unique violation (23505) means the row already existed. Any other insert
+  // failure is a real problem — a transient DB or network error, say — and must not
+  // be silently reinterpreted as "another sync owns the claim", which would skip this
+  // sync without a trace.
+  if (insertError.code !== "23505") {
+    console.error("[snapshot] could not claim sync:", insertError.message);
+    return false;
+  }
+
   // A row already existed. Take the claim only if the previous sync is stale.
   const { data } = await admin
     .from("profile_snapshots")
@@ -170,10 +181,21 @@ export async function syncProfileSnapshot(rawUsername: string): Promise<void> {
     wasRateLimited
   );
 
-  // A rate-limited user fetch tells us nothing about whether the account exists, so
-  // storing `user: null` would cache a false 404. Leave the snapshot alone and let
-  // the next attempt try again.
-  if (user.status === "rejected" && wasRateLimited(user)) {
+  // ANY failed user fetch — rate limit, 10s timeout, DNS failure, connection reset —
+  // tells us nothing about whether the account exists. `fetchWithTimeout` throws
+  // FetchTimeoutError on timeout and rethrows other transport errors, so narrowing this
+  // to the rate-limit case would let a single transient blip persist `user: null` with a
+  // fresh `synced_at` — caching a false 404 for a real account for a full TTL hour.
+  if (user.status === "rejected") {
+    return;
+  }
+
+  // Likewise, never persist a rate-limited (and therefore degraded) snapshot: it would
+  // be stored as "fresh" and serve an empty profile for an hour. GitHub applies its rate
+  // limit across all calls from the same IP/token, and all six run concurrently here, so
+  // a limit hit by any of them means the whole snapshot is untrustworthy. Leaving the row
+  // unwritten keeps the page in its syncing state, which then retries — the honest outcome.
+  if (rateLimited) {
     return;
   }
 

--- a/supabase/migrations/20260712000000_add_profile_snapshots.sql
+++ b/supabase/migrations/20260712000000_add_profile_snapshots.sql
@@ -13,7 +13,12 @@ create table if not exists public.profile_snapshots (
   username text primary key,
   snapshot jsonb,
   synced_at timestamptz,
-  sync_started_at timestamptz not null default now()
+  sync_started_at timestamptz not null default now(),
+  -- Every reader and writer normalizes with `.toLowerCase()`, but `text` collates
+  -- case-sensitively, so nothing stops a future caller inserting "Octocat" alongside
+  -- "octocat" — two rows for one account, with split caches that never converge.
+  -- Enforce the invariant here rather than trusting every call site to remember it.
+  constraint profile_snapshots_username_lowercase check (username = lower(username))
 );
 
 comment on table public.profile_snapshots is

--- a/supabase/migrations/20260712000000_add_profile_snapshots.sql
+++ b/supabase/migrations/20260712000000_add_profile_snapshots.sql
@@ -1,0 +1,42 @@
+-- Username-keyed snapshot of a profile's GitHub data, so the profile page can be
+-- rendered from the database instead of six live GitHub calls.
+--
+-- Why a separate table rather than adding columns to `profiles`:
+-- `profiles.id` is `uuid references auth.users(id)`, so a `profiles` row can only
+-- exist for someone who has signed in to OSSfolio. Profile pages, however, render
+-- for ANY GitHub username. A DB-first read therefore needs a store that can hold a
+-- row for a user who has never logged in. This table is keyed on `username` with no
+-- auth foreign key; `profiles` stays auth-bound and is not touched by this change
+-- (no FK change, no RLS change on `profiles`).
+
+create table if not exists public.profile_snapshots (
+  username text primary key,
+  snapshot jsonb,
+  synced_at timestamptz,
+  sync_started_at timestamptz not null default now()
+);
+
+comment on table public.profile_snapshots is
+  'Cached GitHub payload per username, so profile pages render from the DB. Not tied to auth.users, so it works for users who have never signed in.';
+comment on column public.profile_snapshots.snapshot is
+  'The GitHub payload the profile page renders from. NULL while the very first sync is still in flight.';
+comment on column public.profile_snapshots.synced_at is
+  'When the snapshot last landed. NULL until the first successful sync.';
+comment on column public.profile_snapshots.sync_started_at is
+  'Claim marker. A background sync only proceeds if this is older than the lock window, so repeated loads of a cold profile cannot stampede the GitHub API.';
+
+-- Supports finding stale snapshots for any future scheduled refresh.
+create index if not exists idx_profile_snapshots_synced_at
+  on public.profile_snapshots (synced_at);
+
+alter table public.profile_snapshots enable row level security;
+
+-- Profiles are public, so anyone may read a snapshot. This mirrors the existing
+-- `organizations` policy (`for select using (true)`).
+create policy "profile_snapshots_select" on public.profile_snapshots
+  for select using (true);
+
+-- No insert/update/delete policies are granted, deliberately. The only writer is
+-- the background sync, which runs server-side with the service-role key and so
+-- bypasses RLS. An anonymous client can therefore read a snapshot but can never
+-- forge, poison, or delete one.


### PR DESCRIPTION
Closes #300

## The problem, confirmed
The profile page's server component awaited six sequential GitHub calls before it could
respond — `fetchGitHubUser` → `fetchGitHubRepos` → `fetchLiveStats` → `fetchMergedPRs` →
`fetchOrganizations` → `fetchContributionCalendar` — so TTFB was their **sum**. This PR
removes every GitHub call from the request path. TTFB is now a single database query.

## The schema blocker, and the decision it needed
`profiles.id` is `uuid references auth.users(id)`, so a `profiles` row can only exist for
someone who has signed in to OSSfolio — but profile pages render for *any* GitHub username via
live fetch. A DB-first read therefore needed somewhere to store data for users who've never
logged in, which `profiles` structurally cannot do without changing its FK.

Per our discussion on the issue, this ships the **username-keyed snapshot table** option:
`profile_snapshots(username pk, snapshot jsonb, synced_at, sync_started_at)`, with no
`auth.users` foreign key. `profiles` is completely untouched by this PR — no FK change, no RLS
change on it, no touched rows.

## What changed

**`supabase/migrations/…_add_profile_snapshots.sql`** — the new table. RLS is enabled with a
public **read** policy (mirrors the existing `organizations` policy: `for select using
(true)`), and deliberately **no** insert/update/delete policy. The only writer is the
background sync, which runs server-side with the service-role key and bypasses RLS — so an
anonymous client can read a snapshot but can never forge, poison, or delete one.

**`src/lib/profile-snapshot.ts` (new)**
- `getProfileSnapshot(username)` — the DB-first read. Wrapped in React's `cache()` so
  `generateMetadata` and the page body, which both need it for the same request, share one
  round-trip instead of two.
- `syncProfileSnapshot(username)` — fetches all six GitHub calls **concurrently**
  (`Promise.allSettled`, since they're independent) and stores the raw payloads. One failing
  call leaves that section empty rather than discarding the whole snapshot — same degradation
  the page already had.
- **Stampede guard**: a cold profile shows a syncing state that polls, and every poll re-runs
  the server component. Without a guard, that would fire *another* six-call GitHub sync on
  every poll — a self-inflicted denial-of-service against the exact API this issue exists to
  stop hammering. `claimSync()` takes an atomic claim via a conditional update on
  `sync_started_at` (same conditional-update pattern `refreshProfile()` already uses against
  `profiles.last_refreshed_at`), so only the first sync for a username proceeds; concurrent
  renders no-op. The claim expires after 2 minutes so a failed sync self-heals.
- A rate-limited `user` fetch is **never cached** — storing `user: null` there would cache a
  false 404 for a real account, so the sync aborts and lets the next attempt retry.
- The snapshot stores **raw** GitHub payloads, not the derived score, heatmap, or tech stack.
  Those stay as cheap pure functions computed at render time, so a future change to the scoring
  formula takes effect immediately instead of requiring every stored row to be re-synced.

**`src/app/[username]/page.tsx`**
- The render body: one `getProfileSnapshot()` call replaces the six sequential awaits.
  - No snapshot yet → kick off `after(() => syncProfileSnapshot(username))` and render
    `<ProfileSyncing />`. `after()` runs once the response has already been sent, so it's free
    from the visitor's perspective, and it's the same primitive the existing GitHub webhook
    already uses (its own comment there confirms it works on both edge and Node runtimes,
    which matters since this page is `runtime = "edge"`).
  - Snapshot exists but is older than the 1-hour TTL → render it immediately and refresh in the
    background (stale-while-revalidate): the visitor is never blocked on a stale cache.
- `generateMetadata` **also** used to call `fetchGitHubUser` directly — easy to miss, but it
  blocks the response head, so leaving it live would have put a GitHub round-trip straight back
  onto the critical path and undone the entire TTFB win. It now reads the same cached snapshot.
- Removed the two now-dead local `fetchGitHubUser`/`fetchGitHubRepos` functions (moved to
  `profile-data.ts`, byte-identical bodies, so the sync fetches exactly what the page used to
  render — not a second, potentially drifting copy).

**`src/components/profile/ProfileSyncing.tsx` (new)** — the cold-profile state PRODHOSH asked
for. Polls every 2.5s via `router.refresh()` for up to ~30s, then shows an honest "still
working on it, try again" with a manual retry rather than spinning forever if GitHub is
rate-limiting or down. Follows `DESIGN.md`: same `Navbar`/`Footer` shell and CSS-variable
tokens as the existing `TemporaryUnavailableFallback`, and respects
`prefers-reduced-motion` on the spinner.

**`src/lib/profile-data.ts`** — gained the two relocated fetchers and the shared `GitHubUser`
type (byte-matched to the page's previous local interface, so no behavior changed).

## Verification
- `npm run type-check` — clean
- `npm run lint` — clean (2 pre-existing warnings, unrelated to this change)
- `npm run build` — `✓ Compiled successfully`, `✓ Finished TypeScript`, `/[username]` builds
  under `runtime = "edge"` with `after()` in the render path
- Confirmed zero remaining GitHub calls anywhere in the request path (render body or
  `generateMetadata`) — the only GitHub calls left in the file are inside
  `syncProfileSnapshot`, which only ever runs inside `after()`

## Needs before merge
The migration must be applied in Supabase — `profile_snapshots` does not exist until it runs.

## Open question for you
Right now an unknown/typo'd username still shows the syncing state briefly before falling
through to 404, since we can't distinguish "never synced" from "doesn't exist" without at
least attempting a sync. If you'd rather a bad username 404 immediately, that's a one-call
tradeoff (a live `fetchGitHubUser` just for the existence check on the cold path) — happy to
add it if you want that instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added faster profile loading using cached profile data.
  * Profiles now refresh in the background when information is missing or outdated.
  * Added a progress screen while new profiles are being prepared.
  * Added retry support if profile syncing takes too long.
  * GitHub profile and repository information is refreshed automatically and displayed from the latest available snapshot.

* **Bug Fixes**
  * Reduced delays and inconsistent loading caused by multiple live GitHub requests.
  * Improved handling of GitHub rate limits and partial data availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->