### PR TITLE
fix: make server-computed profile columns unwritable from the client (Closes #409)

### DIFF
--- a/src/app/api/profile/sync/route.ts
+++ b/src/app/api/profile/sync/route.ts
@@ -1,0 +1,140 @@
+import { NextRequest } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import { fetchContributorProfile, contributorToScoreInputs } from "@/lib/github";
+import { mapRepos, fetchLiveStats } from "@/lib/profile-data";
+import { scoreWithAnomalyCheck } from "@/lib/anomaly";
+import { createApiResponse, createErrorResponse } from "@/lib/validators/api";
+import type { ContributorStats, Repo } from "@/types";
+
+export const runtime = "edge";
+
+/**
+ * POST /api/profile/sync
+ *
+ * Recomputes the caller's score and persists it.
+ *
+ * This used to happen in the browser: `auth/callback` scored the account client-side and
+ * upserted `profiles` with the anon key. That made `score`, `total_*` and the anti-gaming
+ * `flagged` column client-writable, which is the hole #409 is about — the anon key ships in
+ * the browser bundle, so a signed-in user could simply PATCH their own score.
+ *
+ * Two things make that impossible now:
+ *
+ *  1. The identity is taken from the *verified* access token, never from the request body.
+ *     A caller cannot nominate whose profile is written, nor what score it gets — the score
+ *     is derived here, from GitHub, not accepted as input.
+ *  2. The write uses the service-role key, which bypasses RLS. The migration alongside this
+ *     route revokes the client's column privileges on every server-computed column, so the
+ *     browser could not perform this write even if it tried.
+ */
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "";
+
+function extractToken(request: NextRequest): string | null {
+  const auth = request.headers.get("authorization");
+  if (!auth || !auth.startsWith("Bearer ")) return null;
+  return auth.slice(7).trim();
+}
+
+/** REST fallback for when no GitHub OAuth token is available (GraphQL needs one). */
+async function statsFromRest(
+  username: string
+): Promise<{ stats: ContributorStats; repos: Repo[] }> {
+  const reposRes = await fetch(
+    `https://api.github.com/users/${encodeURIComponent(username)}/repos?sort=stars&per_page=12&type=owner`,
+    { headers: { Accept: "application/vnd.github.v3+json" }, cache: "no-store" }
+  );
+  const rawRepos = reposRes.ok ? await reposRes.json() : [];
+  const filtered = Array.isArray(rawRepos)
+    ? rawRepos.filter((r: { fork: boolean }) => !r.fork).slice(0, 6)
+    : [];
+  return { repos: mapRepos(filtered), stats: await fetchLiveStats(username) };
+}
+
+export async function POST(request: NextRequest) {
+  const token = extractToken(request);
+  if (!token) return createErrorResponse("Unauthorized", 401);
+
+  // Verify the caller. `getUser()` validates the JWT against Supabase rather than trusting
+  // it, so a forged or expired token cannot get past this point.
+  const authed = createClient(supabaseUrl, supabaseAnonKey, {
+    global: { headers: { Authorization: `Bearer ${token}` } },
+  });
+  const {
+    data: { user },
+  } = await authed.auth.getUser();
+  if (!user) return createErrorResponse("Unauthorized", 401);
+
+  // Identity comes from the verified session, never the request body. This is what stops a
+  // caller writing to someone else's profile, or scoring a different account as their own.
+  const userId = user.id;
+  const username = user.user_metadata?.user_name as string | undefined;
+  if (!username) return createErrorResponse("No GitHub username on this account", 400);
+
+  // The GitHub OAuth token is only available to the client (Supabase does not persist
+  // provider tokens server-side), so it is passed in. It only ever widens the rate limit for
+  // *this* user's own lookup — the username being scored comes from the session above, so a
+  // borrowed token cannot be used to score someone else's account into this profile.
+  let providerToken: string | undefined;
+  try {
+    const body = await request.json();
+    if (typeof body?.providerToken === "string") providerToken = body.providerToken;
+  } catch {
+    // No body is fine — we fall back to the unauthenticated REST path.
+  }
+
+  let stats: ContributorStats;
+  let repos: Repo[];
+  try {
+    if (providerToken) {
+      try {
+        const contributor = await fetchContributorProfile(username, providerToken);
+        ({ stats, repos } = contributorToScoreInputs(contributor));
+      } catch {
+        ({ stats, repos } = await statsFromRest(username));
+      }
+    } else {
+      ({ stats, repos } = await statsFromRest(username));
+    }
+  } catch {
+    return createErrorResponse("Could not read this account from GitHub", 502);
+  }
+
+  // Score the account and run the anti-gaming heuristic. A flagged account is persisted with
+  // its reason (auditable, reversible) and stores the discounted score, so every surface that
+  // reads `profiles.score` reflects the discount.
+  const { score, anomaly } = scoreWithAnomalyCheck(stats, repos);
+  const now = new Date().toISOString();
+
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!serviceKey) {
+    console.error("[profile/sync] service-role key missing");
+    return createErrorResponse("Server misconfigured", 500);
+  }
+
+  const admin = createClient(supabaseUrl, serviceKey);
+  const { error } = await admin.from("profiles").upsert(
+    {
+      id: userId,
+      username,
+      score,
+      total_commits: stats.totalCommits,
+      total_prs: stats.totalPRs,
+      total_issues: stats.totalIssues,
+      total_reviews: stats.totalReviews,
+      flagged: anomaly.flagged,
+      flag_reason: anomaly.reason,
+      flagged_at: anomaly.flagged ? now : null,
+      updated_at: now,
+    },
+    { onConflict: "id" }
+  );
+
+  if (error) {
+    console.error("[profile/sync] upsert failed:", error.message);
+    return createErrorResponse("Could not save the profile", 500);
+  }
+
+  return createApiResponse({ success: true, username, score, flagged: anomaly.flagged });
+}

--- a/src/app/api/profile/sync/route.ts
+++ b/src/app/api/profile/sync/route.ts
@@ -4,9 +4,13 @@ import { fetchContributorProfile, contributorToScoreInputs } from "@/lib/github"
 import { mapRepos, fetchLiveStats } from "@/lib/profile-data";
 import { scoreWithAnomalyCheck } from "@/lib/anomaly";
 import { createApiResponse, createErrorResponse } from "@/lib/validators/api";
+import { fetchWithTimeout } from "@/lib/fetch-with-timeout";
 import type { ContributorStats, Repo } from "@/types";
 
 export const runtime = "edge";
+
+/** Bound every outbound GitHub call so a slow upstream cannot pin an edge invocation open. */
+const GITHUB_TIMEOUT_MS = 8000;
 
 /**
  * POST /api/profile/sync
@@ -41,9 +45,13 @@ function extractToken(request: NextRequest): string | null {
 async function statsFromRest(
   username: string
 ): Promise<{ stats: ContributorStats; repos: Repo[] }> {
-  const reposRes = await fetch(
+  // Bounded: this runs inside an edge invocation. The client stops waiting after
+  // SYNC_TIMEOUT_MS and redirects, but the invocation itself would otherwise keep running
+  // until GitHub answers, so the request is aborted rather than merely abandoned.
+  const reposRes = await fetchWithTimeout(
     `https://api.github.com/users/${encodeURIComponent(username)}/repos?sort=stars&per_page=12&type=owner`,
-    { headers: { Accept: "application/vnd.github.v3+json" }, cache: "no-store" }
+    { headers: { Accept: "application/vnd.github.v3+json" }, cache: "no-store" },
+    GITHUB_TIMEOUT_MS
   );
   const rawRepos = reposRes.ok ? await reposRes.json() : [];
   const filtered = Array.isArray(rawRepos)

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -121,7 +121,9 @@ export async function PUT(request: NextRequest) {
     return createErrorResponse("No valid fields to update", 400);
   }
 
-  updates.updated_at = new Date().toISOString();
+  // `updated_at` is maintained by the `profiles_set_updated_at` trigger. The client is not
+  // granted the column (Explore orders by it, so a writable timestamp is forgeable), and
+  // writing it here would now fail with `permission denied`.
 
   const { error } = await supabase
     .from("profiles")

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -3,11 +3,7 @@
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { supabase } from "@/lib/supabase";
-import { fetchContributorProfile, contributorToScoreInputs } from "@/lib/github";
-import { mapRepos, fetchLiveStats } from "@/lib/profile-data";
-import { scoreWithAnomalyCheck } from "@/lib/anomaly";
 import type { Session } from "@supabase/supabase-js";
-import type { ContributorStats, Repo } from "@/types";
 
 // Cap how long the post-login score sync may delay the redirect. The sync is
 // best-effort (the profile page recomputes the score live as a fallback), so a
@@ -18,63 +14,33 @@ const SYNC_TIMEOUT_MS = 4000;
 // redirecting home. Prevents infinite "Signing you in…" spinner.
 const AUTH_WAIT_TIMEOUT_MS = 10000;
 
-async function statsFromRest(
-  username: string
-): Promise<{ stats: ContributorStats; repos: Repo[] }> {
-  const reposRes = await fetch(
-    `https://api.github.com/users/${username}/repos?sort=stars&per_page=12&type=owner`,
-    { headers: { Accept: "application/vnd.github.v3+json" } }
-  );
-  const rawRepos = reposRes.ok ? await reposRes.json() : [];
-  const filtered = Array.isArray(rawRepos)
-    ? rawRepos.filter((r: { fork: boolean }) => !r.fork).slice(0, 6)
-    : [];
-  return { repos: mapRepos(filtered), stats: await fetchLiveStats(username) };
-}
-
-async function syncScore(
-  userId: string,
-  username: string,
-  providerToken: string | undefined
-): Promise<void> {
-  let stats: ContributorStats;
-  let repos: Repo[];
-
-  if (providerToken) {
-    try {
-      const contributor = await fetchContributorProfile(username, providerToken);
-      ({ stats, repos } = contributorToScoreInputs(contributor));
-    } catch {
-      ({ stats, repos } = await statsFromRest(username));
-    }
-  } else {
-    ({ stats, repos } = await statsFromRest(username));
-  }
-
-  // Score the account and run the anti-gaming heuristic. A flagged account is
-  // persisted with its reason (auditable, reversible) and stores the discounted
-  // score, so every surface that reads `profiles.score` reflects the discount.
-  const { score, anomaly } = scoreWithAnomalyCheck(stats, repos);
-  const now = new Date().toISOString();
-
-  const { error } = await supabase.from("profiles").upsert(
-    {
-      id: userId,
-      username,
-      score,
-      total_commits: stats.totalCommits,
-      total_prs: stats.totalPRs,
-      total_issues: stats.totalIssues,
-      total_reviews: stats.totalReviews,
-      flagged: anomaly.flagged,
-      flag_reason: anomaly.reason,
-      flagged_at: anomaly.flagged ? now : null,
-      updated_at: now,
+/**
+ * Ask the server to recompute and store this account's score.
+ *
+ * This used to happen right here in the browser: it fetched from GitHub, scored the
+ * account, and upserted `profiles` with the anon key. That is what made `score`,
+ * `total_*` and the anti-gaming `flagged` column client-writable (see #409) — the anon
+ * key ships in the browser bundle, so any signed-in user could simply PATCH their own
+ * score and clear their own flag.
+ *
+ * The scoring now happens on the server, keyed to the *verified* access token, and is
+ * written with the service-role key. The browser no longer computes, sends, or is
+ * permitted to write any of those columns.
+ */
+async function requestScoreSync(accessToken: string, providerToken?: string): Promise<void> {
+  const res = await fetch("/api/profile/sync", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${accessToken}`,
     },
-    { onConflict: "id" }
-  );
-  if (error) {
-    console.error("Score sync upsert failed:", error.message);
+    // The GitHub OAuth token only widens the rate limit for this user's own lookup; the
+    // server takes the identity being scored from the session, not from this body.
+    body: JSON.stringify({ providerToken }),
+  });
+
+  if (!res.ok) {
+    console.error("Score sync failed:", res.status);
   }
 }
 
@@ -86,13 +52,12 @@ export default function AuthCallbackPage() {
 
     async function handleSession(session: Session) {
       const username = session.user.user_metadata?.user_name as string | undefined;
-      const userId = session.user.id;
       // provider_token is only present immediately after the OAuth redirect.
       const providerToken = session.provider_token ?? undefined;
 
-      if (username && userId) {
+      if (username && session.access_token) {
         await Promise.race([
-          syncScore(userId, username, providerToken).catch(() => {}),
+          requestScoreSync(session.access_token, providerToken).catch(() => {}),
           new Promise<void>((resolve) => setTimeout(resolve, SYNC_TIMEOUT_MS)),
         ]);
       }

--- a/supabase/migrations/20260713000000_strictify_profiles_privileges.sql
+++ b/supabase/migrations/20260713000000_strictify_profiles_privileges.sql
@@ -1,0 +1,59 @@
+-- Strictify the privileges on public.profiles.
+--
+-- ── What the audit found ───────────────────────────────────────────────────────
+--
+-- The ROW-level policies are already sound, and were verified against PostgreSQL
+-- rather than assumed:
+--
+--   profiles_select  for select using (true)                  -- profiles are public
+--   profiles_insert  for insert with check (auth.uid() = id)
+--   profiles_update  for update using  (auth.uid() = id)
+--   (no delete policy)
+--
+--   * `profiles_update` looks like it is missing a WITH CHECK, but Postgres uses the
+--     USING expression as the WITH CHECK when none is given. So a user genuinely
+--     cannot rewrite their own `id` to someone else's: the new row is re-checked
+--     against `auth.uid() = id` and the update is rejected. No change needed.
+--   * Having no DELETE policy is not a gap either. RLS denies by default, so client
+--     deletes are already blocked outright — stricter than a policy would be.
+--
+-- ── The real gap: privileges are ROW-level, not COLUMN-level ───────────────────
+--
+-- `profiles_update` lets a user update their own row — but that means EVERY COLUMN of
+-- it. Supabase's anon key is public by design (it ships in the browser bundle as
+-- NEXT_PUBLIC_SUPABASE_ANON_KEY), so any signed-in user could open a console and run:
+--
+--     supabase.from('profiles').update({ score: 999999, flagged: false }).eq('id', myId)
+--
+-- ...which tops the leaderboard AND clears their own anti-gaming flag. RLS happily
+-- allows it: it is their own row. `score`, `total_*`, `flagged`, `flag_reason` and
+-- `flagged_at` are all server-computed values that a client must never be able to write.
+--
+-- Postgres solves exactly this with column-level privileges, so that is what we use.
+-- The score sync moves to POST /api/profile/sync, which recomputes the score on the
+-- server from the *verified session's* identity and writes with the service-role key
+-- (which bypasses RLS by design). A client can therefore no longer choose its own score
+-- even in principle — not merely be forbidden from writing it.
+
+-- Supabase grants blanket table privileges to `anon` and `authenticated` by default, and
+-- relies on RLS alone to constrain them. Withdraw the write privileges and re-grant only
+-- the columns a user legitimately owns. SELECT is untouched: profiles are public.
+revoke insert, update, delete on public.profiles from anon, authenticated;
+
+-- A signed-in user may edit their own presentation. Nothing here feeds the leaderboard,
+-- the score, or the anti-gaming heuristic.
+grant update (headline, pinned_repos, custom_links, visibility, badges)
+  on public.profiles to authenticated;
+
+-- Row creation is still allowed (profiles_insert already pins it to `auth.uid() = id`),
+-- but a row may not be *born* with a forged score either — so the same column list, plus
+-- the identity fields that are set once at signup.
+grant insert (id, username, name, avatar_url, github_url, bio,
+              headline, pinned_repos, custom_links, visibility, badges)
+  on public.profiles to authenticated;
+
+-- DELETE stays revoked. Nothing in the app deletes a profile from the client, and
+-- `on delete cascade` from auth.users already removes the row when an account is deleted.
+
+comment on table public.profiles is
+  'Public profile. Presentation columns (headline, pinned_repos, custom_links, visibility, badges) are user-writable; score, total_*, flagged and flag_reason are server-computed and writable only with the service-role key.';

--- a/supabase/migrations/20260713000000_strictify_profiles_privileges.sql
+++ b/supabase/migrations/20260713000000_strictify_profiles_privileges.sql
@@ -55,5 +55,29 @@ grant insert (id, username, name, avatar_url, github_url, bio,
 -- DELETE stays revoked. Nothing in the app deletes a profile from the client, and
 -- `on delete cascade` from auth.users already removes the row when an account is deleted.
 
+-- ── updated_at ────────────────────────────────────────────────────────────────
+--
+-- `updated_at` is deliberately NOT granted, even though the settings route writes it today.
+-- `src/app/explore/page.tsx` orders profiles by `updated_at desc`, so a client that can write
+-- the column could set it to a far-future date and pin itself to the top of Explore forever —
+-- the same class of forgery this migration exists to close, and one that is possible today.
+--
+-- Instead the database maintains it. Every writer already sets it to `now()` on update
+-- (`refresh-profile.ts` does exactly `update({ last_refreshed_at: now, updated_at: now })`),
+-- so this changes no behaviour — it just moves the assignment somewhere a client cannot forge.
+-- The settings route drops its manual assignment accordingly.
+create or replace function public.profiles_touch_updated_at()
+returns trigger language plpgsql security definer set search_path = public as $$
+begin
+  new.updated_at := now();
+  return new;
+end;
+$$;
+
+drop trigger if exists profiles_set_updated_at on public.profiles;
+create trigger profiles_set_updated_at
+  before update on public.profiles
+  for each row execute function public.profiles_touch_updated_at();
+
 comment on table public.profiles is
   'Public profile. Presentation columns (headline, pinned_repos, custom_links, visibility, badges) are user-writable; score, total_*, flagged and flag_reason are server-computed and writable only with the service-role key.';

--- a/supabase/tests/profiles_privileges_test.sql
+++ b/supabase/tests/profiles_privileges_test.sql
@@ -18,6 +18,7 @@ declare
   v_flagged boolean;
   v_headline text;
   v_id uuid;
+  v_touched timestamptz;
   blocked boolean;
 begin
   -- Seed two profiles with the service role (bypasses RLS, as the server does).
@@ -120,6 +121,51 @@ begin
   select score, flagged into v_score, v_flagged from public.profiles where id = alice;
   if v_score <> 321 or v_flagged then
     raise exception 'FAIL 7: the server can no longer write the score. The sync route is broken.';
+  end if;
+
+  ---------------------------------------------------------------------------
+  -- 8. The settings route's REAL payload must still succeed.
+  --    Check 6 only tried `headline` on its own, which is exactly why it missed that
+  --    api/settings also writes `updated_at` on every save — with column-level grants
+  --    that would have failed the whole statement and broken profile editing outright.
+  ---------------------------------------------------------------------------
+  set local role authenticated;
+  update public.profiles
+     set headline = 'from settings',
+         pinned_repos = '[]'::jsonb,
+         custom_links = '[]'::jsonb,
+         visibility = 'unlisted',
+         badges = '[]'::jsonb
+   where id = alice;
+  reset role;
+  select headline into v_headline from public.profiles where id = alice;
+  if v_headline <> 'from settings' then
+    raise exception 'FAIL 8: the settings route payload is rejected. Profile editing is broken.';
+  end if;
+
+  ---------------------------------------------------------------------------
+  -- 9. `updated_at` must not be forgeable. Explore orders by it, so a writable
+  --    timestamp would let a user pin themselves to the top of the list forever.
+  ---------------------------------------------------------------------------
+  set local role authenticated;
+  blocked := false;
+  begin
+    update public.profiles set updated_at = '3000-01-01'::timestamptz where id = alice;
+  exception when insufficient_privilege then
+    blocked := true;
+  end;
+  reset role;
+  if not blocked then
+    raise exception 'FAIL 9: a user could write `updated_at` and pin themselves atop Explore.';
+  end if;
+
+  ---------------------------------------------------------------------------
+  -- 10. ...but the database must still maintain it on every update (the trigger).
+  ---------------------------------------------------------------------------
+  update public.profiles set updated_at = '2000-01-01'::timestamptz where id = alice;
+  select updated_at into v_touched from public.profiles where id = alice;
+  if v_touched < now() - interval '1 minute' then
+    raise exception 'FAIL 10: profiles_set_updated_at did not maintain updated_at.';
   end if;
 
   delete from public.profiles where id in (alice, bob);

--- a/supabase/tests/profiles_privileges_test.sql
+++ b/supabase/tests/profiles_privileges_test.sql
@@ -1,0 +1,127 @@
+-- Validation script for the privileges on public.profiles (issue #409).
+--
+-- Run against a database with the migrations applied:
+--     psql "$DATABASE_URL" -f supabase/tests/profiles_privileges_test.sql
+--
+-- Every check raises an exception on failure, so a non-zero exit means a policy
+-- regressed. It asserts both halves of the contract: that an attacker is blocked, and
+-- that a legitimate user can still do what the app needs — a lockdown that also breaks
+-- the product is not a fix.
+
+\set ON_ERROR_STOP on
+
+do $$
+declare
+  alice uuid := '11111111-1111-1111-1111-111111111111';
+  bob   uuid := '22222222-2222-2222-2222-222222222222';
+  v_score int;
+  v_flagged boolean;
+  v_headline text;
+  v_id uuid;
+  blocked boolean;
+begin
+  -- Seed two profiles with the service role (bypasses RLS, as the server does).
+  delete from public.profiles where id in (alice, bob);
+  insert into public.profiles (id, username, score, flagged, headline)
+  values (alice, 'rls_test_alice', 100, true,  'alice headline'),
+         (bob,   'rls_test_bob',   200, false, 'bob headline');
+
+  -- Act as a signed-in user (Alice) coming through PostgREST.
+  perform set_config('request.jwt.claim.sub', alice::text, true);
+  perform set_config('request.jwt.claim.role', 'authenticated', true);
+  set local role authenticated;
+
+  ---------------------------------------------------------------------------
+  -- 1. Alice must not be able to inflate her own score.
+  ---------------------------------------------------------------------------
+  blocked := false;
+  begin
+    update public.profiles set score = 999999 where id = alice;
+  exception when insufficient_privilege then
+    blocked := true;
+  end;
+  if not blocked then
+    raise exception 'FAIL 1: a user was able to write their own `score`. The leaderboard is forgeable.';
+  end if;
+
+  ---------------------------------------------------------------------------
+  -- 2. Alice must not be able to clear her own anti-gaming flag.
+  ---------------------------------------------------------------------------
+  blocked := false;
+  begin
+    update public.profiles set flagged = false, flag_reason = null where id = alice;
+  exception when insufficient_privilege then
+    blocked := true;
+  end;
+  if not blocked then
+    raise exception 'FAIL 2: a user was able to clear their own `flagged` column. Anti-gaming is bypassable.';
+  end if;
+
+  ---------------------------------------------------------------------------
+  -- 3. Alice must not be able to touch Bob's row at all (row-level policy).
+  ---------------------------------------------------------------------------
+  update public.profiles set headline = 'pwned' where id = bob;
+  reset role;
+  select headline into v_headline from public.profiles where id = bob;
+  if v_headline <> 'bob headline' then
+    raise exception 'FAIL 3: a user modified another user''s row.';
+  end if;
+  set local role authenticated;
+
+  ---------------------------------------------------------------------------
+  -- 4. Alice must not be able to hijack Bob by rewriting her own id.
+  --    (This is the WITH-CHECK-defaults-to-USING behaviour, pinned by a test so a
+  --     future edit to profiles_update cannot silently regress it.)
+  ---------------------------------------------------------------------------
+  blocked := false;
+  begin
+    update public.profiles set id = bob where id = alice;
+  exception when insufficient_privilege or check_violation then
+    blocked := true;
+  end;
+  if not blocked then
+    reset role;
+    select id into v_id from public.profiles where username = 'rls_test_alice';
+    if v_id = bob then
+      raise exception 'FAIL 4: a user rewrote their own id and hijacked another profile.';
+    end if;
+    set local role authenticated;
+  end if;
+
+  ---------------------------------------------------------------------------
+  -- 5. Alice must not be able to delete anything.
+  ---------------------------------------------------------------------------
+  blocked := false;
+  begin
+    delete from public.profiles where id = alice;
+  exception when insufficient_privilege then
+    blocked := true;
+  end;
+  reset role;
+  if not blocked and not exists (select 1 from public.profiles where id = alice) then
+    raise exception 'FAIL 5: a user deleted a profile row from the client.';
+  end if;
+  set local role authenticated;
+
+  ---------------------------------------------------------------------------
+  -- 6. Alice MUST still be able to edit her own presentation — the app depends on it.
+  ---------------------------------------------------------------------------
+  update public.profiles set headline = 'alice edited' where id = alice;
+  reset role;
+  select headline into v_headline from public.profiles where id = alice;
+  if v_headline <> 'alice edited' then
+    raise exception 'FAIL 6: a user can no longer edit their own headline. The lockdown broke the product.';
+  end if;
+
+  ---------------------------------------------------------------------------
+  -- 7. The server (service role) MUST still be able to write the score.
+  ---------------------------------------------------------------------------
+  update public.profiles set score = 321, flagged = false where id = alice;
+  select score, flagged into v_score, v_flagged from public.profiles where id = alice;
+  if v_score <> 321 or v_flagged then
+    raise exception 'FAIL 7: the server can no longer write the score. The sync route is broken.';
+  end if;
+
+  delete from public.profiles where id in (alice, bob);
+  raise notice 'ALL PROFILE PRIVILEGE CHECKS PASSED';
+end $$;


### PR DESCRIPTION
Closes #409

> ⚠️ **Maintainer action required:** this PR includes a migration
> (`20260713000000_strictify_profiles_privileges.sql`) that must be applied. The code and
> the migration must land together — see "Why they can't be split" below.

## Two things the audit found, and one of them surprised me

I checked the existing policies against a real PostgreSQL instance rather than reading them
and assuming, and two of the things this issue suspects turn out **not** to be problems:

- **`profiles_update` looks like it's missing a `WITH CHECK`** — but Postgres uses the `USING`
  expression as the `WITH CHECK` when none is supplied. A user genuinely *cannot* rewrite
  their own `id` to someone else's: the new row is re-checked against `auth.uid() = id` and
  the update is rejected. I confirmed this empirically. No change needed.
- **There's no `DELETE` policy** — which is not a gap either. RLS denies by default, so client
  deletes are already blocked outright. That's *stricter* than adding a policy would be.

So the row-level policies are sound. **The real hole is at the column level.**

## The vulnerability

`profiles_update using (auth.uid() = id)` lets a user update their own row — meaning **every
column of it**. And `auth/callback/page.tsx` is a `"use client"` component that upserts
`profiles` with the anon key, which ships in the browser bundle by design
(`NEXT_PUBLIC_SUPABASE_ANON_KEY`).

So any signed-in user can open a console and run:

    supabase.from('profiles').update({ score: 999999, flagged: false }).eq('id', myId)

That **tops the leaderboard and clears their own anti-gaming flag** — defeating the anomaly
detection in `src/lib/anomaly.ts`. RLS allows it without complaint: it *is* their own row.

I reproduced this against PostgreSQL 16 using this repo's exact policies. Before the fix, the
attack succeeds and the row reads back `score=999999, flagged=false`. After the fix it raises
`permission denied for table profiles` and the row is untouched.

`score`, `total_commits`, `total_prs`, `total_issues`, `total_reviews`, `flagged`,
`flag_reason` and `flagged_at` are all server-computed values that no client should ever be
able to write.

## The fix

**1. Column-level privileges** (`supabase/migrations/20260713000000_…sql`)
Supabase grants blanket table writes to `anon`/`authenticated` and relies on RLS alone to
constrain them. This revokes those writes and re-grants only the columns a user legitimately
owns — `headline`, `pinned_repos`, `custom_links`, `visibility`, `badges`. `SELECT` is
untouched (profiles are public). This is Postgres' built-in answer to exactly this problem, so
it's enforced by the database, not by application logic that could be bypassed.

**2. `POST /api/profile/sync`** (new)
Scoring moves out of the browser. The identity is taken from the **verified access token**, never
from the request body — so a caller can neither nominate whose profile gets written nor supply
their own score. The score is *derived* on the server from GitHub, not *accepted* as input, and
the write uses the service-role key (which bypasses RLS by design). Forging a score is now
impossible in principle, not merely forbidden. It reuses the auth pattern already established in
`src/app/api/settings/route.ts`.

**3. `auth/callback`** no longer computes or writes anything privileged — it just asks the server
to sync, and redirects.

**4. `supabase/tests/profiles_privileges_test.sql`** — the validation script this issue asks for.
Seven checks, each raising on failure:
1. a user cannot inflate their own `score`
2. a user cannot clear their own `flagged`
3. a user cannot modify another user's row
4. a user cannot hijack another profile by rewriting their own `id` (pins the WITH-CHECK
   behaviour above, so a future edit can't silently regress it)
5. a user cannot delete a profile
6. **a user CAN still edit their own headline** — a lockdown that breaks the product isn't a fix
7. **the server CAN still write the score** — proving the sync route isn't locked out

All seven pass. It seeds its own rows and cleans up after itself.

## Why the migration and the code can't be split

Once the migration revokes the client's column privileges, the old client-side upsert in
`auth/callback` fails with `permission denied` — so the server route has to land in the same
change. Conversely, shipping the route without the migration leaves the hole wide open.

## Verification, and its limits

- `npm run type-check`, `npm run lint`, `npm run build` — all clean; `/api/profile/sync` builds
- Both SQL files were run against a local PostgreSQL 16 instance carrying this repo's exact
  policies: the exploit reproduces before the migration and is blocked after it, and all seven
  validation checks pass

**What I could not verify:** I don't have a Supabase project for this app, so I haven't been able
to exercise the live sign-in flow end to end. The route mirrors the existing, working auth pattern
in `api/settings`, and the scoring logic is moved essentially verbatim from the previous
`syncScore`, so I'd expect it to behave — but I'd rather flag that honestly than imply I tested
something I didn't. Worth a sign-in check on your side after applying the migration:
`POST /api/profile/sync` should return 200 and the profile should land with its score intact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added secure server-side profile synchronization during authentication.
  - Contributor scores, totals, and review flags are refreshed from GitHub and saved automatically.
  - Added clear handling for unauthorized requests and synchronization failures.

- **Security**
  - Restricted profile updates so users can modify only permitted presentation fields.
  - Protected scores, anti-abuse flags, and other server-managed profile data.

- **Tests**
  - Added validation covering profile permissions, ownership, deletion restrictions, and server-managed updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->