### PR TITLE
feat: add an achievements grid with earned and in-progress milestones (Closes #396)

### DIFF
--- a/src/components/profile/AchievementsGrid.tsx
+++ b/src/components/profile/AchievementsGrid.tsx
@@ -1,0 +1,186 @@
+import type { Achievement } from "@/lib/achievements";
+
+/**
+ * The achievements grid.
+ *
+ * Locked achievements are rendered too, dimmed, with a progress bar — that's the point of
+ * the feature. The issue asks for "milestones to strive for", and a milestone you can't
+ * see isn't one you can strive for, so this shows the whole set rather than only the
+ * trophies already won.
+ *
+ * Styling follows DESIGN.md and the surrounding profile sections: CSS-variable tokens
+ * (so it themes light/dark for free) and the 6px `--radius-sm` card corner.
+ */
+
+function CheckIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <path
+        d="M3.5 8.5L6.5 11.5L12.5 5"
+        stroke="var(--color-on-primary)"
+        strokeWidth="2.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function AchievementCard({ achievement }: { achievement: Achievement }) {
+  const { name, tagline, unlocked, current, target, progress } = achievement;
+  const pct = Math.round(progress * 100);
+
+  return (
+    <li
+      style={{
+        listStyle: "none",
+        padding: "16px",
+        borderRadius: "var(--radius-sm)",
+        border: `1px solid ${unlocked ? "var(--color-primary)" : "var(--color-hairline)"}`,
+        backgroundColor: unlocked ? "var(--color-canvas-soft)" : "var(--color-canvas)",
+        transition: "background-color 0.2s ease, border-color 0.2s ease",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: "8px", marginBottom: "6px" }}>
+        <span
+          aria-hidden="true"
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
+            width: "20px",
+            height: "20px",
+            flexShrink: 0,
+            borderRadius: "var(--radius-full)",
+            backgroundColor: unlocked ? "var(--color-primary)" : "transparent",
+            border: unlocked ? "none" : "1px dashed var(--color-hairline-strong)",
+          }}
+        >
+          {unlocked && <CheckIcon />}
+        </span>
+
+        <h3
+          style={{
+            fontSize: "14px",
+            fontWeight: 600,
+            margin: 0,
+            letterSpacing: "-0.1px",
+            color: unlocked ? "var(--color-ink)" : "var(--color-ink-mute)",
+          }}
+        >
+          {name}
+        </h3>
+      </div>
+
+      <p
+        style={{
+          fontSize: "13px",
+          margin: "0 0 12px 0",
+          color: "var(--color-ink-mute)",
+          lineHeight: 1.4,
+        }}
+      >
+        {tagline}
+      </p>
+
+      {/* The bar is decorative; the accessible value lives on the row below, so a screen
+          reader hears "Century: 42 of 100" once rather than twice. */}
+      <div
+        aria-hidden="true"
+        style={{
+          height: "4px",
+          width: "100%",
+          borderRadius: "var(--radius-full)",
+          backgroundColor: "var(--color-hairline)",
+          overflow: "hidden",
+        }}
+      >
+        <div
+          style={{
+            height: "100%",
+            width: `${pct}%`,
+            borderRadius: "var(--radius-full)",
+            backgroundColor: unlocked ? "var(--color-primary)" : "var(--color-ink-mute-2)",
+            transition: "width 0.3s ease",
+          }}
+        />
+      </div>
+
+      <div
+        style={{
+          marginTop: "8px",
+          fontSize: "12px",
+          fontWeight: 500,
+          color: unlocked ? "var(--color-primary-deep)" : "var(--color-ink-mute)",
+        }}
+      >
+        <span aria-hidden="true">
+          {unlocked ? "Earned" : `${current} / ${target}`}
+        </span>
+        <span className="sr-only">
+          {unlocked
+            ? `${name} earned: ${tagline}.`
+            : `${name} locked. ${current} of ${target}. ${tagline}.`}
+        </span>
+      </div>
+    </li>
+  );
+}
+
+export function AchievementsGrid({
+  achievements,
+  unlockedCount,
+}: {
+  achievements: Achievement[];
+  unlockedCount: number;
+}) {
+  if (achievements.length === 0) return null;
+
+  return (
+    <div
+      style={{
+        marginTop: "32px",
+        borderBottom: "1px solid var(--color-hairline)",
+        paddingBottom: "32px",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: "16px",
+        }}
+      >
+        <h2
+          style={{
+            fontSize: "16px",
+            fontWeight: 600,
+            color: "var(--color-ink)",
+            margin: 0,
+            letterSpacing: "-0.2px",
+          }}
+        >
+          Achievements
+        </h2>
+        <span style={{ fontSize: "13px", color: "var(--color-ink-mute)" }}>
+          {unlockedCount} of {achievements.length} earned
+        </span>
+      </div>
+
+      <ul
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))",
+          gap: "12px",
+          margin: 0,
+          padding: 0,
+        }}
+      >
+        {achievements.map((a) => (
+          <AchievementCard key={a.id} achievement={a} />
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -11,6 +11,8 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { SkeletonCard } from "@/components/ui/skeleton-card";
+import { evaluateAchievements, countUnlocked } from "@/lib/achievements";
+import { AchievementsGrid } from "@/components/profile/AchievementsGrid";
 import type { ContributorStats, Org, TechEntry, HeatmapWeek, BadgeItem } from "@/types";
 import { toPng } from "html-to-image";
 import { supabase } from "@/lib/supabase";
@@ -466,6 +468,16 @@ export function ProfileView({
     customLinks?: Array<{ label: string; url: string }>;
     customizationLoaded?: boolean;
   }) {
+  // Derived from stats the page already fetched and passed down, so the whole feature
+  // costs no extra GitHub calls and no extra database queries. `useMemo` keeps the array
+  // referentially stable across the many re-renders this component does (tab switches,
+  // repo filtering, sorting), so the cards don't rebuild on every keystroke.
+  const achievements = useMemo(
+    () => evaluateAchievements({ stats, longestStreak }),
+    [stats, longestStreak]
+  );
+  const unlockedCount = useMemo(() => countUnlocked(achievements), [achievements]);
+
   const [copied, setCopied] = useState(false);
   const [repoSort, setRepoSort] = useState<"stars" | "forks" | "updated">("stars");
   const [isDownloading, setIsDownloading] = useState(false);
@@ -1014,6 +1026,9 @@ export function ProfileView({
           )}
         </div>
       )}
+
+      {/* Achievements — auto-earned milestones, distinct from the self-declared badges above */}
+      <AchievementsGrid achievements={achievements} unlockedCount={unlockedCount} />
 
       {/* Tab navigation */}
       <div

--- a/src/lib/achievements.ts
+++ b/src/lib/achievements.ts
@@ -1,0 +1,123 @@
+import type { ContributorStats } from "@/types";
+
+/**
+ * Achievements — automatically earned milestones, derived from a profile's GitHub stats.
+ *
+ * Distinct from the existing `badges` on a profile, which are self-declared programme
+ * badges (GSoC, GSSoC, …) that a user picks in the badge modal. These are computed, not
+ * chosen: you either hit the number or you haven't.
+ *
+ * Two decisions worth spelling out.
+ *
+ * 1. **Locked achievements are returned too, with their progress.** The issue asks for
+ *    "milestones to strive for" — a milestone you cannot see is not something you can
+ *    strive for. Filtering to only the unlocked ones would turn this into a trophy
+ *    cabinet rather than a goal list, so `evaluateAchievements` always returns every
+ *    definition and lets the UI dim the ones that aren't earned yet.
+ *
+ * 2. **Every metric here is exact, and free.** Each reads a value the profile page has
+ *    already fetched and passed down, so the whole system costs zero additional GitHub
+ *    calls and zero additional database queries.
+ *
+ * On the issue's "Night Owl" example (late-night commits): that one is not currently
+ * computable. GitHub's contributions calendar is per-day (`date` + `count`) and
+ * `ContributorStats` carries no timestamps, so nothing in the data model knows what
+ * *hour* a commit landed. Getting that would mean walking every commit in every repo for
+ * its author date — hundreds of API calls per profile view, which runs directly against
+ * the caching and rate-limit work elsewhere in the codebase. It's left out deliberately
+ * rather than faked; see the PR for the trade-off.
+ */
+
+export interface Achievement {
+  id: string;
+  name: string;
+  /** What earning it actually means, in plain words. */
+  tagline: string;
+  unlocked: boolean;
+  /** How far along the user is — already clamped to `target`. */
+  current: number;
+  target: number;
+  /** 0–1, for the progress bar. */
+  progress: number;
+}
+
+/** Everything an achievement can be measured against. All of it is already on the page. */
+export interface AchievementInput {
+  stats: ContributorStats;
+  longestStreak: number;
+}
+
+interface AchievementDefinition {
+  id: string;
+  name: string;
+  tagline: string;
+  target: number;
+  measure: (input: AchievementInput) => number;
+}
+
+/**
+ * The registry. Starting with three, as the issue asks.
+ *
+ * They're deliberately spread across three different kinds of contribution rather than
+ * three sizes of the same one — volume, consistency, and helping other people — so the
+ * set rewards more than just shipping a lot of code.
+ *
+ * Adding a fourth is a five-line entry here; nothing else needs to change.
+ */
+const DEFINITIONS: readonly AchievementDefinition[] = [
+  {
+    id: "century",
+    name: "Century",
+    tagline: "100 merged pull requests",
+    target: 100,
+    measure: ({ stats }) => stats.totalPRs,
+  },
+  {
+    id: "marathon",
+    name: "Marathon",
+    tagline: "A 30-day contribution streak",
+    target: 30,
+    measure: ({ longestStreak }) => longestStreak,
+  },
+  {
+    id: "reviewer",
+    name: "Reviewer",
+    tagline: "50 code reviews for other people",
+    target: 50,
+    measure: ({ stats }) => stats.totalReviews,
+  },
+];
+
+/**
+ * Evaluate every achievement against a profile's stats.
+ *
+ * Pure and deterministic: same stats in, same achievements out. Returns them in a stable
+ * order so cards never reshuffle between renders.
+ */
+export function evaluateAchievements(input: AchievementInput): Achievement[] {
+  return DEFINITIONS.map((def) => {
+    const raw = def.measure(input);
+
+    // A stat can arrive missing or malformed — a degraded snapshot, a GitHub hiccup. Fall
+    // back to 0 rather than rendering "NaN / 100" or a negative progress bar.
+    const measured = Number.isFinite(raw) ? Math.max(0, Math.floor(raw)) : 0;
+
+    // Clamp so an over-achiever reads "100 / 100", not "412 / 100".
+    const current = Math.min(measured, def.target);
+
+    return {
+      id: def.id,
+      name: def.name,
+      tagline: def.tagline,
+      target: def.target,
+      current,
+      unlocked: measured >= def.target,
+      progress: def.target > 0 ? current / def.target : 0,
+    };
+  });
+}
+
+/** How many of the achievements a profile has earned. */
+export function countUnlocked(achievements: Achievement[]): number {
+  return achievements.filter((a) => a.unlocked).length;
+}


### PR DESCRIPTION
Closes #396

## One thing up front: "Night Owl" isn't computable

The issue gives two examples — "Night Owl" for late-night commits, and "Century" for 100+ PRs.
I built Century. I did **not** build Night Owl, and I'd rather explain why than quietly ship
something that looks like it but isn't.

Nothing in the data model knows what *hour* a commit landed:

- `ContributorStats` is `{ totalCommits, totalPRs, totalIssues, totalReviews, totalContributions }`
  — no timestamps at all.
- GitHub's contributions calendar is **per-day** (`date` + `count`), not per-hour.

Getting hour-of-day would mean walking every commit in every repo for its author date —
hundreds of API calls per profile view. That runs directly against the caching and rate-limit
work elsewhere in the codebase, and it would be a strange thing to spend the quota on for a
badge. So it's left out on purpose, and the reasoning is written into `src/lib/achievements.ts`
so the next person doesn't have to rediscover it. Happy to revisit if you want to add a
commit-timestamp fetch later — it just needs to be a deliberate decision rather than a side
effect of a badge.

## The three badges

Per "start with just 3 basic badges":

| Badge | Unlocks at | Reads |
|---|---|---|
| **Century** | 100 merged pull requests | `stats.totalPRs` |
| **Marathon** | a 30-day contribution streak | `longestStreak` |
| **Reviewer** | 50 code reviews for other people | `stats.totalReviews` |

They're deliberately three *different kinds* of contribution rather than three sizes of the same
one — volume, consistency, and helping other people — so the set rewards more than just shipping
a lot of code. Reviewer in particular exists because reviewing is one of the most undervalued
things people do in open source.

**Every metric is exact, and every metric is free.** Each reads a value the profile page has
already fetched and passed into `ProfileView`, so the whole feature costs **zero additional
GitHub calls and zero additional database queries** — no migration, no new fetch, no new column.

I deliberately avoided star-count and language-count badges, tempting as they are:
`fetchGitHubRepos` slices to the top 6 repos, so any total computed from `repos` would be an
approximation. I'd rather ship three exact numbers than five plausible ones.

## Locked badges are shown too — that's the whole point

The issue asks for **"milestones to strive for"**, and a milestone you can't see isn't one you
can strive for. So `evaluateAchievements()` always returns every definition, with its progress,
and the grid dims the ones that aren't earned yet.

Filtering to only the unlocked ones would have turned this into a trophy cabinet rather than a
goal list. A brand-new user now sees all three at `0 / 100`, `0 / 30`, `0 / 50` and knows exactly
what to chase — which is the gamification the issue is actually after.

## What's in the PR

**`src/lib/achievements.ts` (new)** — the utility function the issue asks for. Pure and
deterministic: same stats in, same achievements out. The badges live in a declarative registry,
so adding a fourth is a five-line entry and nothing else changes ("we can add more later").

**`src/components/profile/AchievementsGrid.tsx` (new)** — the dedicated grid. Responsive
(`auto-fit`, `minmax(200px, 1fr)`), earned cards accented, locked cards dimmed with a progress
bar. Follows `DESIGN.md`: CSS-variable tokens throughout (so it themes light/dark for free) and
the 6px `--radius-sm` card corner. The progress bar is `aria-hidden` and the real value is
announced once via an `sr-only` string ("Century locked. 42 of 100. 100 merged pull requests."),
so a screen reader doesn't hear the number twice.

**`src/components/profile/ProfileView.tsx`** — computes the achievements from props it already
receives and renders the grid as its own section, between the existing Badges section and the
tabs. Purely additive: **15 insertions, 0 deletions.**

The achievements are `useMemo`'d. `ProfileView` re-renders on every keystroke in the repo filter,
every sort change and every tab switch, so without it the cards would rebuild constantly for no
reason.

## Note on the existing badges

These are **not** the same thing as the `badges` already on a profile. Those are self-declared
programme badges (GSoC, GSSoC, …) that a user picks in the badge modal. Achievements are
computed — you either hit the number or you haven't. That's why they get their own section
rather than being mixed into the existing one, and why the code and the copy keep them clearly
separate.

## Verification

There's no test runner in this repo, so rather than assert that the logic works I executed it
against the cases most likely to embarrass us in production. **18/18 pass:**

- a **`NaN`** stat (a degraded snapshot, a GitHub hiccup) → falls back to `0`, so a card can
  never render **"NaN / 100"**
- **412 PRs** → clamps to **`100 / 100`**, and progress clamps to `1` so the bar can't overflow
  its track — while still reading as unlocked
- **exactly 100** PRs → unlocked (`>=`, not `>`) — the classic off-by-one
- a **negative** stat → `0`, so no negative-width progress bar
- a **fractional** stat → floored
- brand-new user → all three still returned, none unlocked, progress `0` (the locked-visible
  requirement above, pinned by a test)
- deterministic, and a stable order so the cards never reshuffle between renders

Plus `npm run type-check`, `npm run lint` and `npm run build` — all clean. (`lint` reports one
pre-existing warning in `ProfileView` about a `profileTabs` dependency; it's on `main` already
and just shifts line number because of my imports.)