### PR TITLE
feat: rate limit the refresh endpoint per IP (Closes #408)

### DIFF
--- a/src/app/api/[username]/refresh/route.ts
+++ b/src/app/api/[username]/refresh/route.ts
@@ -1,11 +1,32 @@
 import { NextRequest } from "next/server";
 import { sanitizeUsername, createApiResponse, createErrorResponse } from "@/lib/validators/api";
 import { refreshProfile } from "@/lib/refresh-profile";
+import { checkRefreshRateLimit } from "@/lib/rate-limit";
 
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ username: string }> }
 ) {
+  // Limit the caller before doing anything else — before the username is even looked at.
+  //
+  // This has to come first, because the existing per-username limit inside refreshProfile()
+  // cannot see the two attacks that matter here. A caller can rotate the username to get a
+  // fresh bucket each time, and a username that doesn't exist gets no limit recorded at all
+  // (there's no row to record it on), so `/api/{random}/refresh` is unbounded today at two
+  // database queries a go. Both are anonymous — this endpoint takes no auth.
+  //
+  // Limiting per IP up here closes both, and it means a rejected request costs us a single
+  // Redis round-trip instead of two database queries.
+  const rateLimit = await checkRefreshRateLimit(request);
+  if (!rateLimit.allowed) {
+    return createErrorResponse(
+      "Too many refresh requests. Please try again shortly.",
+      429,
+      { retryAfterSeconds: rateLimit.retryAfterSeconds },
+      { "Retry-After": String(rateLimit.retryAfterSeconds) }
+    );
+  }
+
   const { username: rawUsername } = await params;
   const username = sanitizeUsername(rawUsername);
 

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,154 @@
+import { redis } from "@/lib/redis";
+import type { NextRequest } from "next/server";
+
+/**
+ * Per-IP rate limiting for the manual refresh endpoint.
+ *
+ * ── Why the existing limit isn't enough ───────────────────────────────────────
+ *
+ * `refreshProfile()` already rate-limits, but it does so **per username**, by way of an
+ * atomic conditional update on `profiles.last_refreshed_at`. That protects a single
+ * profile from being hammered — and nothing else. Two holes fall straight out of it:
+ *
+ *   1. **Username rotation.** Hit `/api/alice/refresh`, then `/api/bob/refresh`, then
+ *      `/api/carol/refresh`. Every username gets its own independent bucket, so a caller
+ *      can drive as much work as it likes just by moving the target.
+ *
+ *   2. **Usernames that don't exist.** For an unknown username, `refreshProfile()` runs an
+ *      UPDATE that matches no rows, then a SELECT to distinguish "rate limited" from
+ *      "not found", and returns `not_found` — *without recording a limit anywhere*, since
+ *      there is no row to record it on. So `/api/{random}/refresh` can be called without
+ *      bound, costing two database queries every single time, and the existing limiter
+ *      never once fires.
+ *
+ * The endpoint is unauthenticated, so both are reachable by anyone. This module closes
+ * them by limiting the *caller* rather than the target, before any of that work is done.
+ *
+ * ── Why `SET NX EX` and not a counter ────────────────────────────────────────
+ *
+ * `src/lib/redis.ts` falls back to a stub with only `get` and `set` when Upstash isn't
+ * configured (CI builds, local dev). A limiter built on `incr`/`expire`/`eval` would throw
+ * "not a function" in exactly those environments. `SET key value NX EX <window>` is a
+ * single atomic Redis operation that needs neither — it either takes the slot or reports
+ * that someone already holds it, with no read-then-write race.
+ *
+ * With no Upstash configured the stub's `set` returns "OK", so every request is allowed and
+ * the limiter is simply inert — the same way the GitHub response cache in `lib/github.ts`
+ * already degrades. Local development and CI keep working; production gets the limit.
+ */
+
+/** One refresh per IP per window, as the issue specifies. */
+const WINDOW_SECONDS = 5 * 60;
+
+export interface RateLimitResult {
+  allowed: boolean;
+  /** Only meaningful when `allowed` is false. */
+  retryAfterSeconds: number;
+}
+
+/**
+ * Work out who is calling.
+ *
+ * This is the part that decides whether the limit is real or theatre. `x-forwarded-for` is
+ * just a header — a client can send whatever it likes in it. Trusting its **first** entry
+ * (the usual mistake) means an attacker sets a fresh fake IP on every request, lands in a
+ * fresh bucket every time, and the rate limit does nothing at all while looking like it
+ * works.
+ *
+ * So: prefer the headers the edge itself writes, which overwrite anything the client sent
+ * and therefore cannot be forged. Only if none are present do we fall back to
+ * `x-forwarded-for`, and then we take the **last** entry — because each proxy *appends* the
+ * address it saw, so the rightmost value is the one written by the proxy closest to us,
+ * and everything to its left is unverified client input.
+ */
+function clientIp(request: NextRequest): string | null {
+  // Cloudflare (this app deploys via @opennextjs/cloudflare) — set by the edge, not forgeable.
+  const cf = request.headers.get("cf-connecting-ip");
+  if (cf) return cf.trim();
+
+  // Vercel and most reverse proxies — also set by the edge.
+  const real = request.headers.get("x-real-ip");
+  if (real) return real.trim();
+
+  const forwarded = request.headers.get("x-forwarded-for");
+  if (forwarded) {
+    const hops = forwarded
+      .split(",")
+      .map((hop) => hop.trim())
+      .filter(Boolean);
+    return hops.length > 0 ? hops[hops.length - 1] : null;
+  }
+
+  return null;
+}
+
+/**
+ * Hash the identifier before it becomes a Redis key.
+ *
+ * A raw IP address is personal data, and there's no reason to hold one: the limiter only
+ * ever needs to know whether it has seen *this* caller before, which a digest answers just
+ * as well. Web Crypto is available in the edge runtime, so this costs nothing.
+ */
+async function keyFor(identifier: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(identifier)
+  );
+  const hex = Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  // 16 bytes is far beyond enough to avoid collisions here, and keeps the key short.
+  return `ratelimit:refresh:${hex.slice(0, 32)}`;
+}
+
+/**
+ * Consume one unit of the caller's allowance.
+ *
+ * Returns `allowed: false` with the seconds remaining when the caller is over the limit.
+ * Never throws: if Redis is unreachable, the request is allowed through. A rate limiter
+ * that takes the whole endpoint down when its backing store hiccups is a worse outage than
+ * the one it was added to prevent, and the per-username limit is still underneath it.
+ */
+export async function checkRefreshRateLimit(
+  request: NextRequest
+): Promise<RateLimitResult> {
+  // No usable address (local dev, an odd proxy) — everything unidentifiable shares one
+  // bucket rather than being waved through, so the absence of a header can't become a way
+  // around the limit.
+  const identifier = clientIp(request) ?? "unidentified";
+
+  try {
+    const key = await keyFor(identifier);
+    const now = Date.now();
+    const resetAt = now + WINDOW_SECONDS * 1000;
+
+    // Atomic: takes the slot only if nobody holds it, and expires on its own.
+    const acquired = await redis.set(key, resetAt, {
+      nx: true,
+      ex: WINDOW_SECONDS,
+    });
+
+    if (acquired === "OK") {
+      return { allowed: true, retryAfterSeconds: 0 };
+    }
+
+    // Someone already holds the slot. Read back when it frees up so the caller gets a real
+    // number rather than a guess.
+    const storedResetAt = await redis.get<number>(key);
+    const remainingMs =
+      typeof storedResetAt === "number" ? storedResetAt - now : WINDOW_SECONDS * 1000;
+
+    return {
+      allowed: false,
+      // At least 1: "try again in 0 seconds" reads like a bug, and a client that trusts it
+      // would retry straight into another rejection.
+      retryAfterSeconds: Math.max(1, Math.ceil(remainingMs / 1000)),
+    };
+  } catch (error) {
+    console.error(
+      "[rate-limit] refresh limiter unavailable, allowing request:",
+      error instanceof Error ? error.message : error
+    );
+    return { allowed: true, retryAfterSeconds: 0 };
+  }
+}

--- a/src/lib/validators/api.ts
+++ b/src/lib/validators/api.ts
@@ -106,7 +106,15 @@ export function createApiResponse<T>(data: T, status = 200, extraHeaders?: Recor
   });
 }
 
-export function createErrorResponse(error: string, status = 400, extra?: Record<string, unknown>): NextResponse {
+export function createErrorResponse(
+  error: string,
+  status = 400,
+  extra?: Record<string, unknown>,
+  // Optional extra response headers. Added so a 429 can carry the standard `Retry-After`
+  // header, which well-behaved clients, crawlers and proxies honour without needing to
+  // parse the body. Existing callers are unaffected.
+  headers?: Record<string, string>
+): NextResponse {
   return NextResponse.json(
     { error, ...extra },
     {
@@ -114,6 +122,7 @@ export function createErrorResponse(error: string, status = 400, extra?: Record<
       headers: {
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "DENY",
+        ...headers,
       },
     }
   );


### PR DESCRIPTION
Closes #408

## The threat model has moved, and the hole is worse than the issue describes

The issue says a spammer would "burn through our GitHub API quota". That was true when it was
written, but since the DB-first refactor (#300) landed, `refreshProfile()` doesn't call GitHub
at all — it does a Supabase `UPDATE` and a `revalidatePath`.

What I found instead is worse, so it's worth being precise about it.

**A username that doesn't exist is completely unlimited.** For an unknown username,
`refreshProfile()` runs an UPDATE that matches no rows, then a SELECT to tell "rate limited"
apart from "not found", returns `not_found` — and **records no limit anywhere**, because there
is no row to record one on. The existing limiter is keyed on `profiles.last_refreshed_at`; no
row, no limit.

So `/api/{anything}/refresh` can be hit without bound, forever, at two database queries a call,
and the current rate limiting never fires once. The endpoint takes no auth, so this is open to
anyone. Rotating the username across *real* profiles has the same effect for a different reason:
every username gets its own independent bucket.

Both are the same underlying mistake — the limit is on the **target**, not the **caller**.

## The fix

`src/lib/rate-limit.ts` limits per IP, and the route applies it **before the username is even
parsed**. A rejected request now costs one Redis round-trip instead of two database queries, and
neither attack above has anywhere to go.

The per-username limit stays exactly where it is. The two do different jobs: per-username stops
one profile being hammered, per-IP stops one caller hammering everything.

## Two things constrained the design

**`src/lib/redis.ts` falls back to a stub with only `get` and `set`.**

    : ({ get: async () => null, set: async () => "OK" } as unknown as Redis)

So a limiter built on `incr` / `expire` / `eval` would throw "not a function" in exactly the
environments where that stub is used — CI builds and local dev, since neither has Upstash
configured. `SET key value NX EX 300` is a single atomic Redis operation that needs neither, and
has no read-then-write race.

With no Upstash configured, the stub's `set` returns `"OK"`, so every request is allowed and the
limiter is simply inert — the same way the GitHub response cache in `lib/github.ts` already
degrades. Local dev and CI keep working untouched.

**`X-Forwarded-For` is a header the client writes, and getting this wrong makes the whole thing
theatre.**

The usual approach is to take the *first* entry of `x-forwarded-for`. That's the bug: an attacker
sets a fresh fake address on every request, lands in a fresh bucket every time, and the rate limit
does precisely nothing while looking like it works.

So the limiter prefers the headers the edge itself writes — `cf-connecting-ip` (this app deploys
via `@opennextjs/cloudflare`) and `x-real-ip` — which overwrite whatever the client sent and
therefore can't be forged. Only if neither is present does it fall back to `x-forwarded-for`, and
then it takes the **last** hop, because each proxy *appends* the address it saw: the rightmost
value is the one written by the proxy closest to us, and everything to its left is unverified
client input.

## Verification

There's no test runner in this repo, so rather than assert the limiter works I attacked it and
watched what happened. **14/14 pass**, including:

- **spoofing:** three requests with a rotating fake `X-Forwarded-For` behind a real proxy →
  the 2nd and 3rd are still **blocked**, and the attacker creates **one** bucket, not three.
  Pinned with an assertion that taking the first entry would have created three — i.e. would
  have defeated the limiter entirely.
- `cf-connecting-ip` outranks a spoofed `x-forwarded-for`
- a request with **no** identifying headers doesn't get waved through — everything unidentifiable
  shares one bucket, so a missing header can't be a way around the limit
- **Redis unreachable → fails open.** A rate limiter that 500s the endpoint when its backing
  store hiccups is a worse outage than the one it was added to prevent, and the per-username
  limit is still underneath it.
- different IPs don't block each other
- `retryAfterSeconds` is never 0 ("try again in 0 seconds" reads like a bug, and a client that
  believes it retries straight into another rejection)

Plus `npm run type-check`, `npm run lint`, `npm run build` — all clean.

## The UI feedback already works

The issue asks for clear feedback when a user is rate-limited. `ProfileView` already handles it:

    if (res.status === 429 && payload.retryAfterSeconds) {
      setErrorMsg(`Try again in ${Math.ceil(payload.retryAfterSeconds / 60)} min`);

So the new limit returns exactly that contract — 429 with `retryAfterSeconds` in the body — and
the existing message and disabled button work unchanged, with no frontend edit at all. I also
added the standard `Retry-After` header, which well-behaved clients and proxies honour without
parsing the body. (`createErrorResponse` gained an optional headers argument for that; existing
callers are unaffected.)

A live *ticking* countdown, rather than "try again in 5 min", would mean editing `ProfileView.tsx`
— which is currently locked by open PR #396. Happy to add it as a follow-up once that lands, if
you'd like it.

## Privacy

The Redis key is a SHA-256 digest of the address, not the address itself. A raw IP is personal
data, and there's no reason to hold one — the limiter only ever needs to know whether it has seen
*this* caller before, which a digest answers just as well.

## A tradeoff to flag

One refresh per IP per five minutes is what the issue asks for, and it's what's implemented
(`WINDOW_SECONDS`, one constant). Worth being aware that visitors sharing an IP — an office, a
university, a mobile carrier's NAT — share the bucket, so a second person clicking Refresh within
five minutes will see the "try again" message. That's the accepted cost of an unauthenticated
endpoint, but it's a one-line change if you'd rather allow a small burst.