### PR TITLE
test: add Playwright E2E for the critical paths (Closes #402)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,42 @@
+name: E2E
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  playwright:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Only Chromium. Installing all three engines roughly triples the download for
+      # coverage this suite doesn't currently use.
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      # No secrets are referenced anywhere in this job, and that is deliberate: GitHub does
+      # not expose secrets to pull requests from forks, so a suite that needed them would
+      # fail for every outside contributor. The database is stood in for by
+      # e2e/mock-supabase.mjs, which Playwright starts via `webServer`.
+      - name: Run E2E tests
+        run: npx playwright test
+
+      - name: Upload report
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,8 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Playwright
+/playwright-report/
+/test-results/
+/blob-report/

--- a/e2e/critical-paths.spec.ts
+++ b/e2e/critical-paths.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * The three critical paths from the issue: the homepage renders, a profile renders, and the
+ * leaderboard is reachable.
+ *
+ * One correction worth recording: the issue says "navigate to the leaderboard", but there is
+ * no `/leaderboard` route. The leaderboard is `/explore` — that's the page that ranks profiles
+ * by score. The test targets the page that exists.
+ *
+ * Assertions lean on roles and visible text rather than CSS classes or test ids, so a styling
+ * change (the Tailwind v4 refactor in #414, say) doesn't turn into a false failure. A test that
+ * breaks when the design changes teaches everyone to ignore it.
+ */
+
+test.describe("critical paths", () => {
+  test("the homepage renders and offers a way in", async ({ page }) => {
+    const response = await page.goto("/");
+
+    expect(response?.status()).toBe(200);
+    await expect(page).toHaveTitle(/ossfolio/i);
+
+    // A 200 that renders an empty page is still a broken homepage, and that's precisely the
+    // kind of failure this suite exists to catch. `#main-content` is the landmark the skip
+    // link targets, so it's the right thing to assert on — and it's a single element, unlike
+    // a `main, body` selector list, which matches both and trips Playwright's strict mode.
+    const main = page.locator("#main-content");
+    await expect(main).toBeVisible();
+    await expect(main).not.toBeEmpty();
+
+    // The primary journey out of the homepage must exist.
+    const explore = page.getByRole("link", { name: /explore|discover|leaderboard/i }).first();
+    await expect(explore).toBeVisible();
+  });
+
+  test("the leaderboard lists profiles by score", async ({ page }) => {
+    // `/explore` is the leaderboard; see the note above.
+    const response = await page.goto("/explore");
+    expect(response?.status()).toBe(200);
+
+    // Both fixture profiles come from the mock Supabase, so this asserts the whole
+    // server-component data path — query, render, hydrate — not merely that a route responds.
+    await expect(page.getByText("e2e-alice").first()).toBeVisible();
+    await expect(page.getByText("e2e-bob").first()).toBeVisible();
+  });
+
+  test("a profile page renders that user's data", async ({ page }) => {
+    const response = await page.goto("/e2e-alice");
+    expect(response?.status()).toBe(200);
+
+    // e2e-alice has a stored snapshot in the fixtures, so the DB-first path from #300 should
+    // render her straight from it — no GitHub call, and no syncing state.
+    await expect(page.getByText("E2E Alice").first()).toBeVisible();
+    await expect(page.getByText(/e2e-alice/).first()).toBeVisible();
+
+    await expect(page.getByText(/Building this profile/i)).toHaveCount(0);
+  });
+
+  test("a profile with no snapshot yet shows the syncing state", async ({ page }) => {
+    // e2e-bob deliberately has no snapshot row. This covers the other half of #300: a cold
+    // profile must respond immediately with the syncing state rather than blocking on GitHub.
+    // It's the branch most likely to rot unnoticed, since it only appears on a first-ever view.
+    const response = await page.goto("/e2e-bob");
+    expect(response?.status()).toBe(200);
+
+    await expect(page.getByText(/Building this profile/i)).toBeVisible();
+  });
+
+  test("an unknown route 404s rather than erroring", async ({ page }) => {
+    const response = await page.goto("/this-route-does-not-exist-e2e");
+    // Next serves the not-found page; what matters is that it isn't a 500.
+    expect(response?.status()).toBeLessThan(500);
+  });
+});

--- a/e2e/mock-supabase.mjs
+++ b/e2e/mock-supabase.mjs
@@ -1,0 +1,201 @@
+/**
+ * A stand-in for Supabase, for end-to-end tests.
+ *
+ * ── Why this exists ───────────────────────────────────────────────────────────
+ *
+ * The pages worth testing — the leaderboard on `/explore`, a profile on `/[username]` —
+ * are React Server Components. They query Supabase on the *server*, before any HTML
+ * reaches the browser, so Playwright's `page.route()` can't intercept them: by the time
+ * the browser sees anything, the query has already happened.
+ *
+ * The other obvious answer, pointing CI at a real Supabase project, doesn't work either —
+ * and not for the reason you'd guess. GitHub Actions **does not expose secrets to pull
+ * requests from forks**. This repository is built on fork contributions, so a suite that
+ * needed `SUPABASE_URL` would fail on every external contributor's PR while passing on
+ * the maintainer's. A test suite that only runs for some people is worse than none.
+ *
+ * So: supabase-js is just an HTTP client. It issues plain PostgREST requests to
+ * `${SUPABASE_URL}/rest/v1/<table>?<filters>`. Point it at this server instead and the
+ * server components get deterministic fixtures — no secrets, no network, no GitHub, and
+ * identical behaviour for maintainers and first-time contributors alike.
+ *
+ * This also satisfies the issue's "do not test real GitHub OAuth in CI; mock the
+ * authentication state": nothing here talks to GitHub or to a real auth provider.
+ */
+
+import { createServer } from "node:http";
+
+const PORT = Number(process.env.MOCK_SUPABASE_PORT ?? 54321);
+
+/** Two profiles, so the leaderboard has something to rank. */
+const PROFILES = [
+  {
+    id: "11111111-1111-1111-1111-111111111111",
+    username: "e2e-alice",
+    name: "E2E Alice",
+    avatar_url: "https://avatars.githubusercontent.com/u/1?v=4",
+    github_url: "https://github.com/e2e-alice",
+    score: 1240,
+    total_commits: 820,
+    total_prs: 143,
+    total_issues: 61,
+    total_reviews: 77,
+    followers: 210,
+    top_languages: ["TypeScript", "Go"],
+    badges: [],
+    headline: "Alice builds things",
+    pinned_repos: [],
+    custom_links: [],
+    visibility: "public",
+    flagged: false,
+    flag_reason: null,
+    score_delta_30_days: 40,
+    view_count: 12,
+    updated_at: "2026-07-01T00:00:00.000Z",
+    last_refreshed_at: "2026-07-01T00:00:00.000Z",
+    created_at: "2025-01-01T00:00:00.000Z",
+    bio: null,
+    search_text: "e2e-alice",
+  },
+  {
+    id: "22222222-2222-2222-2222-222222222222",
+    username: "e2e-bob",
+    name: "E2E Bob",
+    avatar_url: "https://avatars.githubusercontent.com/u/2?v=4",
+    github_url: "https://github.com/e2e-bob",
+    score: 610,
+    total_commits: 300,
+    total_prs: 44,
+    total_issues: 12,
+    total_reviews: 9,
+    followers: 30,
+    top_languages: ["Python"],
+    badges: [],
+    headline: null,
+    pinned_repos: [],
+    custom_links: [],
+    visibility: "public",
+    flagged: false,
+    flag_reason: null,
+    score_delta_30_days: 5,
+    view_count: 3,
+    updated_at: "2026-06-01T00:00:00.000Z",
+    last_refreshed_at: "2026-06-01T00:00:00.000Z",
+    created_at: "2025-03-01T00:00:00.000Z",
+    bio: null,
+    search_text: "e2e-bob",
+  },
+];
+
+/**
+ * A snapshot for `e2e-alice`, so her profile renders fully rather than falling into the
+ * "Building this profile" state. `e2e-bob` deliberately has none — that's how the syncing
+ * path gets covered too.
+ */
+const SNAPSHOTS = [
+  {
+    username: "e2e-alice",
+    synced_at: new Date().toISOString(),
+    sync_started_at: new Date().toISOString(),
+    snapshot: {
+      user: {
+        login: "e2e-alice",
+        name: "E2E Alice",
+        bio: "Alice builds things",
+        avatar_url: "https://avatars.githubusercontent.com/u/1?v=4",
+        html_url: "https://github.com/e2e-alice",
+        public_repos: 24,
+        followers: 210,
+        following: 12,
+        blog: null,
+        location: "Testville",
+        twitter_username: null,
+      },
+      repos: [
+        {
+          id: 1,
+          name: "alice-cli",
+          description: "A command line tool",
+          html_url: "https://github.com/e2e-alice/alice-cli",
+          stargazers_count: 412,
+          forks_count: 33,
+          language: "TypeScript",
+          topics: ["cli"],
+          pushed_at: "2026-06-20T00:00:00.000Z",
+        },
+      ],
+      liveStats: {
+        totalCommits: 820,
+        totalPRs: 143,
+        totalIssues: 61,
+        totalReviews: 77,
+        totalContributions: 1101,
+      },
+      mergedPRs: [],
+      orgs: [],
+      contributionCalendar: null,
+      rateLimited: false,
+    },
+  },
+];
+
+/** Pull the value out of a PostgREST filter such as `username=eq.e2e-alice`. */
+function eqValue(params, column) {
+  const raw = params.get(column);
+  if (!raw) return null;
+  return raw.startsWith("eq.") ? decodeURIComponent(raw.slice(3)) : null;
+}
+
+const server = createServer((req, res) => {
+  const url = new URL(req.url ?? "/", `http://localhost:${PORT}`);
+
+  res.setHeader("Content-Type", "application/json");
+  res.setHeader("Access-Control-Allow-Origin", "*");
+
+  // supabase-js asks for a single object (rather than an array) via this header.
+  const wantsSingle = (req.headers["accept"] ?? "").includes("vnd.pgrst.object");
+
+  const respond = (rows) => {
+    if (wantsSingle) {
+      // `.maybeSingle()` expects one object, or 406 when there's nothing.
+      if (rows.length === 0) {
+        res.statusCode = 406;
+        res.end(JSON.stringify({ message: "no rows" }));
+        return;
+      }
+      res.statusCode = 200;
+      res.end(JSON.stringify(rows[0]));
+      return;
+    }
+    res.statusCode = 200;
+    res.end(JSON.stringify(rows));
+  };
+
+  if (url.pathname.startsWith("/rest/v1/profiles")) {
+    const username = eqValue(url.searchParams, "username");
+    const id = eqValue(url.searchParams, "id");
+    let rows = PROFILES;
+    if (username) rows = rows.filter((p) => p.username === username);
+    if (id) rows = rows.filter((p) => p.id === id);
+    respond(rows);
+    return;
+  }
+
+  if (url.pathname.startsWith("/rest/v1/profile_snapshots")) {
+    const username = eqValue(url.searchParams, "username");
+    const rows = username
+      ? SNAPSHOTS.filter((s) => s.username === username)
+      : SNAPSHOTS;
+    respond(rows);
+    return;
+  }
+
+  // Anything we haven't taught it about answers with an empty set rather than a 404, so an
+  // unmocked query degrades to "no data" instead of failing the render outright.
+  respond([]);
+});
+
+server.listen(PORT, "127.0.0.1", () => {
+  // Playwright's `webServer` waits for this port, so the message is only for humans.
+  console.log(`[mock-supabase] listening on http://127.0.0.1:${PORT}`);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "@emnapi/core": "^1.11.1",
         "@emnapi/runtime": "^1.11.1",
         "@opennextjs/cloudflare": "^1",
+        "@playwright/test": "^1.61.1",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -3780,6 +3781,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@poppinss/colors": {
@@ -11322,6 +11339,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/po-parser": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "preview:cf": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
     "start": "next start",
     "lint": "eslint src/",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@radix-ui/react-avatar": "^1.1.3",
@@ -34,10 +36,10 @@
     "tailwind-merge": "^3.3.0"
   },
   "devDependencies": {
-    "@opennextjs/cloudflare": "^1",
-    "wrangler": "^4",
     "@emnapi/core": "^1.11.1",
     "@emnapi/runtime": "^1.11.1",
+    "@opennextjs/cloudflare": "^1",
+    "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
@@ -46,6 +48,7 @@
     "eslint-config-next": "^16.2.9",
     "postcss": "^8",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "wrangler": "^4"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,66 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * End-to-end tests.
+ *
+ * The suite deliberately runs with **no secrets at all**. That isn't a shortcut — it's the
+ * only way it can be useful here. GitHub Actions does not expose repository secrets to pull
+ * requests from forks, and this project is built almost entirely on fork contributions. A
+ * suite that needed a real Supabase URL would go green for the maintainer and red for every
+ * outside contributor, which is worse than having no suite at all.
+ *
+ * So `e2e/mock-supabase.mjs` stands in for the database. supabase-js is just an HTTP client
+ * against PostgREST, so pointing `NEXT_PUBLIC_SUPABASE_URL` at a local fixture server gives
+ * the server components deterministic data — no secrets, no network, and no GitHub, which is
+ * also what the issue asks for ("do not test real GitHub OAuth in CI; mock the
+ * authentication state").
+ *
+ * `NEXT_PUBLIC_*` values are inlined by Next at build time, not read at runtime, which is why
+ * the app is built here with the mock's URL already set rather than having it injected later.
+ */
+export default defineConfig({
+  testDir: "./e2e",
+  // Fail the build rather than quietly skip, if someone leaves a `test.only` behind.
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  // One worker on CI: the suite shares a single app server and a single fixture server, so
+  // parallel workers would be racing over the same state for no real gain at this size.
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : "list",
+
+  use: {
+    baseURL: "http://127.0.0.1:3000",
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+
+  webServer: [
+    {
+      command: "node e2e/mock-supabase.mjs",
+      port: 54321,
+      reuseExistingServer: !process.env.CI,
+      stdout: "pipe",
+    },
+    {
+      command: "npm run build && npm run start",
+      port: 3000,
+      // A cold Next build is slow; the default 60s is not enough on a CI runner.
+      timeout: 240_000,
+      reuseExistingServer: !process.env.CI,
+      env: {
+        NEXT_PUBLIC_SUPABASE_URL: "http://127.0.0.1:54321",
+        // Not real credentials, and not secret — the fixture server ignores them entirely.
+        // They exist only because the client refuses to construct without a key.
+        NEXT_PUBLIC_SUPABASE_ANON_KEY: "e2e-anon-key",
+        SUPABASE_SERVICE_ROLE_KEY: "e2e-service-role-key",
+      },
+    },
+  ],
+});


### PR DESCRIPTION
Closes #402

## The constraint that shaped the whole design

Before writing a line of this I had to answer one question: **can this suite run on a pull request
from a fork?**

GitHub Actions does not expose repository secrets to fork PRs. This project runs almost entirely on
fork contributions — every open PR right now is from one. So a suite that needed a real
`SUPABASE_URL` would go green on a maintainer's branch and red on every outside contributor's,
through no fault of theirs. That's worse than having no suite at all: it teaches everyone to ignore
a red check.

And the pages actually worth testing — the leaderboard, a profile — are React Server Components.
They query Supabase on the *server*, before any HTML reaches the browser, so Playwright's
`page.route()` can't intercept them. By the time the browser sees anything, the query has already
happened.

**So the database is stood in for.** `e2e/mock-supabase.mjs` is a small fixture server. supabase-js
is just an HTTP client against PostgREST, so pointing `NEXT_PUBLIC_SUPABASE_URL` at it hands the
server components deterministic data with **no secrets, no network, and no GitHub calls** — which is
also exactly what the issue asks for ("do not test real GitHub OAuth in CI; mock the authentication
state"). Nothing here touches a real auth provider.

It's plain `.mjs` and runs on bare Node, so CI needs no extra tooling to start it. Playwright brings
it up itself via `webServer`.

## Two corrections to the issue

**There is no `/leaderboard` route.** The leaderboard is `/explore` — that's the page that ranks
profiles by score. The test targets the page that exists.

**`NEXT_PUBLIC_*` values are inlined by Next at build time**, not read at runtime, so the app has to
be *built* with the mock's URL rather than having it injected afterwards. Handled in `webServer.env`.

## The tests

The issue's three, plus two more that I think earn their place:

1. **the homepage renders** — 200, correct title, a non-empty `#main-content`, and a working way in.
   A 200 that renders an empty page is still a broken homepage, and that's precisely the failure
   this suite exists to catch.
2. **the leaderboard lists profiles by score** — both fixture profiles appear, which exercises the
   whole server-component data path (query → render → hydrate), not merely that a route responds.
3. **a profile page renders that user's data** — `e2e-alice` has a stored snapshot, so this asserts
   the DB-first path from #300 renders her straight from it, with no GitHub call and no syncing
   state.
4. **a profile with no snapshot shows the syncing state** — `e2e-bob` deliberately has no snapshot
   row. This covers the *other* half of #300: a cold profile must respond immediately with the
   syncing state rather than blocking on GitHub. It's the branch most likely to rot unnoticed,
   because it only ever appears on a first-ever view.
5. **an unknown route doesn't 500** — cheap, and exactly the kind of regression that slips through.

Assertions use roles and visible text rather than CSS classes or test ids. A styling change — the
Tailwind v4 refactor in #414, say — shouldn't be able to turn a passing test red. A suite that
breaks when the design changes teaches everyone to ignore it.

## It already found a bug

On its first run the suite surfaced `Error: MISSING_MESSAGE: Navigation (en)` on **every route**,
and the homepage's body text coming back as
`"Navigation.skipToMainContent OSSfolio Features How it works Leaderboard …"`.

The skip-to-content link — the first thing a keyboard or screen-reader user hits on every page — has
been rendering its raw i18n key instead of "Skip to main content". Two faults stacked:
`SkipToContent.tsx` asks for a `Navigation` namespace that doesn't exist (the messages file defines
`Nav`), and the `skipToMainContent` key is absent from both `en.json` and `es.json` regardless. The
component's `|| "Skip to main content"` fallback never fires, because next-intl returns the key
*path* on a miss — a truthy string — not `undefined`.

I haven't fixed it here. It's unrelated to test infrastructure, and `SkipToContent.tsx` is already
being touched by PR #436, so fixing it in this branch would conflict. Filed separately.

But it's a fair argument for the suite existing: this is exactly the class of bug that survives code
review and type-checking indefinitely, because nothing is ever actually looking at the rendered page.

## CI

`.github/workflows/e2e.yml` runs on every push to `main` and every PR. Chromium only — installing
all three engines roughly triples the download for coverage this suite doesn't currently use. The
HTML report uploads as an artifact on failure.

**No secrets are referenced anywhere in that workflow**, which is the entire point: it behaves
identically for a maintainer and for a first-time contributor.

## On the lockfile

This PR adds a dependency, so `package-lock.json` was regenerated on Linux — matching the CI runner
rather than a local Windows install, which resolves a different set of platform-specific optional
dependencies — and then verified with a clean `npm ci`, which completed **without rewriting the
lockfile**. That's the check that confirms it's complete and authoritative rather than merely
present.

## Verification

`npm run test:e2e` — 5/5 passing against a production build.
`npm run type-check`, `npm run lint`, `npm run build` — clean.
`npm ci` reproduces the lockfile byte-for-byte.

## Worth knowing

The fixtures are deliberately thin — two profiles and one snapshot, which is what these five tests
need and nothing more. As the suite grows, that fixture set is the thing that'll want structure
(probably a way to compose per-test data rather than one shared module). Happy to take that as a
follow-up rather than over-engineering it now.