### PR TITLE
chore: document the Upstash Redis env vars in .env.example (Closes #384)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,13 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=
 
 # ── AI Features (optional) ───────────────────────────────────────────
 # ANTHROPIC_API_KEY=
+
+# ── Upstash Redis (REST) ─────────────────────────────────────────────
+# Used by the GitHub response cache in `src/lib/github.ts`.
+#
+# Worth knowing: `src/lib/redis.ts` falls back to a no-op stub when these are missing, so the
+# app still builds and runs without them — but the cache goes silently inert, and every profile
+# view hits the GitHub API directly. Locally that's convenient; in production it's the rate
+# limiting this cache exists to prevent. Set these in any deployed environment.
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=


### PR DESCRIPTION
Closes #384

The small PR from the discussion on #384 — the Redis caching layer is already in place, this is
the one piece that was genuinely missing.

`src/lib/redis.ts` falls back to a no-op stub when `UPSTASH_REDIS_REST_URL` and
`UPSTASH_REDIS_REST_TOKEN` aren't set:

    export const redis = url && token
      ? new Redis({ url, token })
      : ({ get: async () => null, set: async () => "OK" } as unknown as Redis);

That's a sensible default — it keeps CI builds and local development working without credentials.
But because they were never documented in `.env.example`, there was nothing to tell you they
existed. A deployment without them builds fine, runs fine, and silently has **no cache at all** —
every profile view goes straight to the GitHub API, which is the exact rate limiting the cache was
added to prevent.

So the comment says that out loud rather than just naming the variables. Someone skimming
`.env.example` should be able to see that leaving these blank has a real consequence in production,
not just assume they're optional.

No code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added configuration guidance for optional Upstash Redis REST caching.
  * Documented the required URL and token environment variables.
  * Clarified that the app continues running with a fallback when these values are not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->