### PR TITLE
feat: enforce profile visibility across listings, profile page, compare and OG (Closes #407)

### DIFF
--- a/src/app/[username]/opengraph-image.tsx
+++ b/src/app/[username]/opengraph-image.tsx
@@ -58,15 +58,24 @@ export default async function OGImage({ params }: OGImageProps) {
   ]);
 
   // Fetch user data and the stored profile summary in parallel
-  const [user, profileRow] = await Promise.all([
+  const [user, profileResult] = await Promise.all([
     fetchGitHubUser(username),
     supabase
       .from("profiles")
       .select("score, total_commits, total_prs, total_issues, total_reviews, visibility")
       .eq("username", username)
-      .maybeSingle()
-      .then((r) => r.data),
+      .maybeSingle(),
   ]);
+
+  // Fail closed. This previously did `.then((r) => r.data)`, which discards the error — and the
+  // Supabase client resolves with `{ data: null, error }` rather than throwing, so any database
+  // failure left `profileRow` null, the private check below passed, and a private profile got a
+  // fully rendered, fully shareable social card.
+  if (profileResult.error) {
+    return new Response(null, { status: 404 });
+  }
+
+  const profileRow = profileResult.data;
 
   // A private profile has no page, so it must not have a social card either.
   //

--- a/src/app/[username]/opengraph-image.tsx
+++ b/src/app/[username]/opengraph-image.tsx
@@ -63,6 +63,8 @@ export default async function OGImage({ params }: OGImageProps) {
     supabase
       .from("profiles")
       .select("score, total_commits, total_prs, total_issues, total_reviews")
+      // Same reasoning as the page: a private profile should not have a shareable social card.
+      .neq("visibility", "private")
       .eq("username", username)
       .maybeSingle()
       .then((r) => r.data),

--- a/src/app/[username]/opengraph-image.tsx
+++ b/src/app/[username]/opengraph-image.tsx
@@ -62,13 +62,22 @@ export default async function OGImage({ params }: OGImageProps) {
     fetchGitHubUser(username),
     supabase
       .from("profiles")
-      .select("score, total_commits, total_prs, total_issues, total_reviews")
-      // Same reasoning as the page: a private profile should not have a shareable social card.
-      .neq("visibility", "private")
+      .select("score, total_commits, total_prs, total_issues, total_reviews, visibility")
       .eq("username", username)
       .maybeSingle()
       .then((r) => r.data),
   ]);
+
+  // A private profile has no page, so it must not have a social card either.
+  //
+  // This has to short-circuit rather than filter the row, which is what it did before. Everything on
+  // the card below — avatar, display name, @username, the OSSfolio branding and the profile URL — is
+  // built from the GitHub response, not from `profileRow`. Excluding the row only zeroed the stored
+  // stats: the card still rendered, still carried the person's face and handle, and was still
+  // shareable. It just claimed a score of 0. That is not privacy, it is a worse-looking leak.
+  if (profileRow?.visibility === "private") {
+    return new Response(null, { status: 404 });
+  }
 
   const displayName = user?.name || username;
   const avatarUrl = user?.avatar_url || `https://github.com/${username}.png`;

--- a/src/app/[username]/page.tsx
+++ b/src/app/[username]/page.tsx
@@ -173,23 +173,24 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
   let profileId: string | null = null;
   let profileRow: any = null;
   let customizationFetchSettled = false;
+  let visibilityUnknown = false;
   try {
-    const { data } = await supabase
+    const { data, error } = await supabase
       .from("profiles")
       .select("id, score, updated_at, badges, headline, pinned_repos, custom_links, visibility")
       .eq("username", username)
       .maybeSingle();
     customizationFetchSettled = true;
-    profileRow = data;
 
-    // `private` means the page does not exist. This has to be an explicit check rather than an RLS
-    // policy: ossfolio renders /[username] for any GitHub account, signed up or not, so a null
-    // `profileRow` is the ordinary case, not an error. If RLS hid private rows, this code could not
-    // tell "private" from "never signed up" — it would fall through and render the public GitHub
-    // data instead of 404ing, so the setting would look like it worked while doing nothing. That is
-    // precisely the bug this change exists to fix, so it would be a poor trade.
-    if (profileRow?.visibility === "private") {
-      return notFound();
+    // The Supabase client resolves with `{ data: null, error }` rather than throwing, so reading
+    // only `data` would leave `profileRow` null on a database failure — indistinguishable, from
+    // here, from a profile that simply has no row. The private check below would then pass and the
+    // page would render. A privacy gate has to fail closed, so the error is captured and handled
+    // below rather than discarded.
+    if (error) {
+      visibilityUnknown = true;
+    } else {
+      profileRow = data;
     }
 
     if (profileRow) {
@@ -219,7 +220,33 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
     }
   } catch {
     customizationFetchSettled = true;
+    visibilityUnknown = true;
     // Soft isolation fallback
+  }
+
+  // Both checks below are deliberately *outside* the try above, and that placement is the whole
+  // point rather than a stylistic choice.
+  //
+  // `notFound()` works by throwing. Inside that try, the bare `catch` would swallow it — the page
+  // would carry straight on and render the very profile the setting exists to hide. This is the
+  // documented reason Next tells you to call notFound()/redirect() outside try/catch, and it is a
+  // silent failure: nothing errors, the 404 simply never happens.
+  //
+  // Failing closed on an unknown visibility matters for the same reason. Note this does *not* touch
+  // the ordinary "never signed up" path: that returns no error and no row, and such a profile cannot
+  // be private (private requires a stored row), so it still renders from GitHub data exactly as
+  // before. Only a genuine database failure trips this.
+  if (visibilityUnknown) {
+    throw new Error(`Could not verify profile visibility for "${username}"`);
+  }
+
+  // `private` means the page does not exist. This is an explicit check rather than an RLS policy:
+  // ossfolio renders /[username] for any GitHub account, signed up or not, so a null `profileRow` is
+  // the ordinary case. If RLS hid private rows, this code could not tell "private" from "never
+  // signed up" — it would fall through and render the public GitHub data instead of 404ing, and the
+  // setting would look like it worked while doing nothing.
+  if (profileRow?.visibility === "private") {
+    return notFound();
   }
 
   const customization = profileRow ? {

--- a/src/app/[username]/page.tsx
+++ b/src/app/[username]/page.tsx
@@ -181,6 +181,17 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
       .maybeSingle();
     customizationFetchSettled = true;
     profileRow = data;
+
+    // `private` means the page does not exist. This has to be an explicit check rather than an RLS
+    // policy: ossfolio renders /[username] for any GitHub account, signed up or not, so a null
+    // `profileRow` is the ordinary case, not an error. If RLS hid private rows, this code could not
+    // tell "private" from "never signed up" — it would fall through and render the public GitHub
+    // data instead of 404ing, so the setting would look like it worked while doing nothing. That is
+    // precisely the bug this change exists to fix, so it would be a poor trade.
+    if (profileRow?.visibility === "private") {
+      return notFound();
+    }
+
     if (profileRow) {
       profileId = profileRow.id;
       if (typeof profileRow.score === "number") {

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -113,7 +113,15 @@ export async function PUT(request: NextRequest) {
       .filter(Boolean);
   }
 
-  if (body.visibility === "public" || body.visibility === "unlisted") {
+  // 'private' is new: the column's CHECK previously rejected it, so the third state the UI is meant
+  // to offer could never be stored. Still an explicit allow-list rather than a passthrough — the
+  // value lands in a CHECK-constrained column, and a 400 from us beats a constraint violation from
+  // Postgres.
+  if (
+    body.visibility === "public" ||
+    body.visibility === "unlisted" ||
+    body.visibility === "private"
+  ) {
     updates.visibility = body.visibility;
   }
 

--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -97,20 +97,37 @@ async function fetchProfile(username: string): Promise<ProfileData> {
   const liveScore = calculateScore(stats, mappedRepos);
 
   let score = liveScore;
+  let visibility: string | null = null;
   try {
     const { data: profileRow } = await supabase
       .from("profiles")
-      .select("score")
-        // A private profile has no page; it should not be comparable either — otherwise the
-        // data it is meant to hide is reachable through /compare instead.
-        .neq("visibility", "private")
+      .select("score, visibility")
       .eq("username", username)
       .maybeSingle();
-    if (profileRow && typeof profileRow.score === "number") {
-      score = profileRow.score;
+    if (profileRow) {
+      visibility =
+        typeof profileRow.visibility === "string" ? profileRow.visibility : null;
+      if (typeof profileRow.score === "number") {
+        score = profileRow.score;
+      }
     }
   } catch {
     // Soft fallback to live score
+  }
+
+  // Deliberately outside the try above. That catch exists to fall back to the live score when
+  // Supabase is unreachable, and it would happily swallow this throw and compare the profile anyway.
+  //
+  // It also has to throw rather than filter the row. Everything returned below — the user, their
+  // stats, their repos — is rebuilt from the GitHub API, so excluding the profiles row alone would
+  // not have hidden anything: it would simply have compared them using the live score instead of the
+  // stored one. A private profile has no page, and it should not be reachable through /compare
+  // either.
+  //
+  // Same message as the not-found case on purpose, so /compare cannot be used to discover that a
+  // private profile exists — which is the same reasoning api/v1 already applies to unlisted ones.
+  if (visibility === "private") {
+    throw new Error(`GitHub user "${username}" not found`);
   }
 
   return { user, stats, repos: mappedRepos, score };

--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -101,6 +101,9 @@ async function fetchProfile(username: string): Promise<ProfileData> {
     const { data: profileRow } = await supabase
       .from("profiles")
       .select("score")
+        // A private profile has no page; it should not be comparable either — otherwise the
+        // data it is meant to hide is reachable through /compare instead.
+        .neq("visibility", "private")
       .eq("username", username)
       .maybeSingle();
     if (profileRow && typeof profileRow.score === "number") {

--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -98,13 +98,20 @@ async function fetchProfile(username: string): Promise<ProfileData> {
 
   let score = liveScore;
   let visibility: string | null = null;
+  let visibilityUnknown = false;
   try {
-    const { data: profileRow } = await supabase
+    const { data: profileRow, error } = await supabase
       .from("profiles")
       .select("score, visibility")
       .eq("username", username)
       .maybeSingle();
-    if (profileRow) {
+
+    // The Supabase client resolves with `{ data: null, error }` rather than throwing, so the catch
+    // below never sees a query failure — reading only `data` would leave `visibility` null on a
+    // database error and the private check would quietly pass. A privacy gate has to fail closed.
+    if (error) {
+      visibilityUnknown = true;
+    } else if (profileRow) {
       visibility =
         typeof profileRow.visibility === "string" ? profileRow.visibility : null;
       if (typeof profileRow.score === "number") {
@@ -112,6 +119,7 @@ async function fetchProfile(username: string): Promise<ProfileData> {
       }
     }
   } catch {
+    visibilityUnknown = true;
     // Soft fallback to live score
   }
 
@@ -126,6 +134,15 @@ async function fetchProfile(username: string): Promise<ProfileData> {
   //
   // Same message as the not-found case on purpose, so /compare cannot be used to discover that a
   // private profile exists — which is the same reasoning api/v1 already applies to unlisted ones.
+  if (visibilityUnknown) {
+    // Distinct message from the not-found case below, because this genuinely is different: the
+    // profile may be perfectly fine and the database simply unreachable. Telling the user to retry
+    // is honest; claiming the account doesn't exist would not be.
+    throw new Error(
+      `Could not verify profile visibility for "${username}". Please try again.`
+    );
+  }
+
   if (visibility === "private") {
     throw new Error(`GitHub user "${username}" not found`);
   }

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -67,7 +67,11 @@ async function fetchPage(
     } else {
       query = supabase
         .from("profiles")
-        .select("username, name, avatar_url, score, total_prs, total_issues, total_commits, score_delta_30_days");
+        .select("username, name, avatar_url, score, total_prs, total_issues, total_commits, score_delta_30_days")
+        // Explore is a listing, so only public profiles belong in it. `unlisted` and `private` have
+        // both opted out of being found — until now the setting saved and this query ignored it, so
+        // a user who chose "unlisted" stayed on the leaderboard anyway.
+        .eq("visibility", "public");
       
       if (searchQuery) {
         query = query.or(`username.ilike.%${searchQuery}%,name.ilike.%${searchQuery}%`);

--- a/src/app/settings/client.tsx
+++ b/src/app/settings/client.tsx
@@ -19,7 +19,7 @@ interface ProfileSettings {
   pinned_repos: string[];
   custom_links: CustomLink[];
   badges: Badge[];
-  visibility: "public" | "unlisted";
+  visibility: "public" | "unlisted" | "private";
 }
 
 const AVAILABLE_BADGES = [
@@ -273,12 +273,18 @@ export function SettingsClient() {
         <label style={labelStyle}>Profile Visibility</label>
         <select
           value={settings.visibility}
-          onChange={(e) => setSettings((s) => ({ ...s, visibility: e.target.value as "public" | "unlisted" }))}
+          onChange={(e) =>
+            setSettings((s) => ({
+              ...s,
+              visibility: e.target.value as "public" | "unlisted" | "private",
+            }))
+          }
           style={{ ...inputStyle, width: "auto", cursor: "pointer" }}
           aria-label="Profile visibility"
         >
           <option value="public">Public (visible on Discover)</option>
           <option value="unlisted">Unlisted (only accessible via direct link)</option>
+          <option value="private">Private (profile page returns 404)</option>
         </select>
       </div>
 

--- a/supabase/migrations/20260713000001_enforce_profile_visibility.sql
+++ b/supabase/migrations/20260713000001_enforce_profile_visibility.sql
@@ -1,0 +1,113 @@
+-- Profile visibility: make the setting actually do something.
+--
+-- `visibility` has existed since 20260627000002 and /settings has been writing it, but nothing
+-- read it. A user who chose "unlisted" was still ranked on Explore and still returned by
+-- /api/discover — the control saved, reported success, and changed nothing. This migration and the
+-- accompanying app changes close that.
+--
+-- Semantics, stated once so the three enforcement points below can be checked against them:
+--
+--   public    listed on Explore and /api/discover; page renders.
+--   unlisted  absent from every listing; the page still renders for anyone with the direct link.
+--   private   absent from every listing; the page 404s.
+
+-- ---------------------------------------------------------------------------------------------
+-- 1. Allow 'private'.
+--
+-- The original CHECK permitted only ('public', 'unlisted'), so the third state the settings UI is
+-- meant to offer was rejected by the database. Re-stating the constraint rather than adding a
+-- second one keeps a single source of truth for the allowed values.
+-- ---------------------------------------------------------------------------------------------
+alter table public.profiles
+  drop constraint if exists profiles_visibility_check;
+
+alter table public.profiles
+  add constraint profiles_visibility_check
+  check (visibility in ('public', 'unlisted', 'private'));
+
+-- ---------------------------------------------------------------------------------------------
+-- 2. Exclude non-public profiles from search_profiles.
+--
+-- This is the one that matters most, and it cannot be fixed in the API route. `search_profiles` is
+-- `security definer`, so it executes with the definer's privileges and Row Level Security does not
+-- apply to the rows it reads. Any policy added to `profiles` would be bypassed here — the filter
+-- has to live inside the function.
+--
+-- Re-declared in full (rather than patched) because `create or replace function` requires the
+-- complete definition; this is the 20260710000000 version with a single added predicate, and
+-- nothing else about it changes.
+-- ---------------------------------------------------------------------------------------------
+create or replace function public.search_profiles(
+  query text default '',
+  lang text default '',
+  min_score integer default 0,
+  sort_by text default 'score',
+  page_size integer default 20,
+  page_offset integer default 0
+)
+returns table (
+  username text,
+  name text,
+  avatar_url text,
+  bio text,
+  score integer,
+  total_prs integer,
+  total_commits integer,
+  total_issues integer,
+  followers integer,
+  top_languages text[],
+  score_delta_30_days integer
+)
+language plpgsql security definer set search_path = public
+as $$
+begin
+  return query
+    select
+      p.username,
+      p.name,
+      p.avatar_url,
+      p.bio,
+      p.score,
+      p.total_prs,
+      p.total_commits,
+      p.total_issues,
+      p.followers,
+      p.top_languages,
+      p.score_delta_30_days
+    from public.profiles p
+    where
+      (query = '' or p.search_text @@ plainto_tsquery('english', query))
+      and (lang = '' or p.top_languages @> array[lang])
+      and p.score >= min_score
+      -- The only change from the previous definition. Discover is a listing, so it shows public
+      -- profiles and nothing else: `unlisted` opted out of being found, `private` opted out
+      -- entirely.
+      and p.visibility = 'public'
+    order by
+      case when sort_by = 'score' then p.score else 0 end desc,
+      case when sort_by = 'contributions' then (p.total_prs + p.total_commits + p.total_issues) else 0 end desc,
+      case when sort_by = 'followers' then p.followers else 0 end desc,
+      case when sort_by = 'improvement' then p.score_delta_30_days else 0 end desc,
+      p.username asc
+    limit least(page_size, 100)
+    offset least(page_offset, 1000);
+end;
+$$;
+
+-- ---------------------------------------------------------------------------------------------
+-- 3. A note on why RLS is deliberately *not* used to hide private rows.
+--
+-- The obvious move is a policy like `using (visibility <> 'private' or auth.uid() = id)`. It is
+-- the wrong one here, and quietly so.
+--
+-- ossfolio renders /[username] for *any* GitHub account, whether or not it has ever signed in — a
+-- missing `profiles` row is the normal case, not an error (see [username]/page.tsx, which fetches
+-- the row with `.maybeSingle()` and carries on when it is null). If RLS hid private rows, the page
+-- could not distinguish "this profile is private" from "this person never signed up", so instead
+-- of returning 404 it would fall back to rendering the public GitHub data — and the privacy
+-- setting would look like it worked while doing nothing. That is the exact failure this migration
+-- exists to fix, so reintroducing it via RLS would be a poor trade.
+--
+-- Enforcement therefore lives where the distinction is visible: the app reads `visibility` and
+-- returns notFound() for `private`. The listing paths are closed above and in explore/page.tsx.
+-- ---------------------------------------------------------------------------------------------

--- a/supabase/migrations/20260713000001_enforce_profile_visibility.sql
+++ b/supabase/migrations/20260713000001_enforce_profile_visibility.sql
@@ -21,9 +21,16 @@
 alter table public.profiles
   drop constraint if exists profiles_visibility_check;
 
+-- `not valid` so adding the constraint does not take a full table scan under a lock that blocks
+-- writes to `profiles` for its duration. That scan buys nothing here: the new constraint is a strict
+-- superset of the old one (it only adds 'private'), so every existing row already satisfies it by
+-- construction. The validate below then confirms that without holding writes.
 alter table public.profiles
   add constraint profiles_visibility_check
-  check (visibility in ('public', 'unlisted', 'private'));
+  check (visibility in ('public', 'unlisted', 'private')) not valid;
+
+alter table public.profiles
+  validate constraint profiles_visibility_check;
 
 -- ---------------------------------------------------------------------------------------------
 -- 2. Exclude non-public profiles from search_profiles.

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -27,7 +27,7 @@ create table public.profiles (
   headline       text,
   pinned_repos   text[] not null default '{}',
   custom_links   jsonb not null default '[]'::jsonb,
-  visibility     text not null default 'public' check (visibility in ('public', 'unlisted')),
+  visibility     text not null default 'public' check (visibility in ('public', 'unlisted', 'private')),
   search_text    tsvector generated always as (
     to_tsvector('english',
       coalesce(username, '') || ' ' ||
@@ -148,6 +148,10 @@ begin
       (query = '' or p.search_text @@ plainto_tsquery('english', query))
       and (lang = '' or p.top_languages @> array[lang])
       and p.score >= min_score
+      -- Discover is a listing: 'unlisted' opted out of being found, 'private' opted out entirely.
+      -- This filter lives inside the function on purpose — search_profiles is `security definer`,
+      -- so RLS does not apply to the rows it reads and a policy on `profiles` would be bypassed.
+      and p.visibility = 'public'
     order by
       case when sort_by = 'score' then p.score else 0 end desc,
       case when sort_by = 'contributions' then (p.total_prs + p.total_commits + p.total_issues) else 0 end desc,


### PR DESCRIPTION
## Summary

The `visibility` column has been on `profiles` since June, and `/settings` has been happily writing
to it — but nothing on the read side ever looked at it. If you set your profile to "unlisted" it
saved, told you it saved, and you stayed on the Explore leaderboard and in `/api/discover` exactly as
before. So the setting was real, the UI was real, and the effect was nothing.

This wires it up, and adds the third state (`private`) the settings UI was clearly meant to have —
the column's CHECK constraint only allowed `public` and `unlisted`, so `private` couldn't be stored
even if the UI offered it.

## Related Issue

Closes #407

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Chore / dependency update

(Arguably both — `private` is new, but "unlisted" not working is a bug.)

## Two things the audit turned up that changed the approach

**`search_profiles` is `security definer`.** It executes with the definer's privileges, so Row Level
Security doesn't apply to the rows it reads. Any policy added to `profiles` would be silently
bypassed there and `/api/discover` would keep leaking. The filter has to live *inside* the function —
which is why the migration re-declares it rather than adding a policy.

**RLS is the wrong enforcement layer here, and it fails in a way that looks like success.** The
obvious policy is `using (visibility <> 'private' or auth.uid() = id)`. But ossfolio renders
`/[username]` for *any* GitHub account, signed up or not — a null `profileRow` is the ordinary case
(`page.tsx` fetches it with `.maybeSingle()` and carries on). If RLS hid private rows, that code
couldn't distinguish "private" from "never signed up": it would fall through and render the public
GitHub data instead of 404ing. The setting would look like it worked while doing nothing — which is
the exact bug being fixed. So enforcement is explicit, in the places where the distinction is
visible.

## Changes

- **migration** (new) — `private` added to the CHECK, `not valid` + `validate constraint` so it
  doesn't take a blocking full-table scan (the new constraint is a strict superset of the old one, so
  every existing row satisfies it by construction). `search_profiles` gains
  `and p.visibility = 'public'`.
- **`supabase/schema.sql`** — the same two changes, so a fresh setup doesn't get the old constraint
  and an unfiltered Discover.
- **`explore/page.tsx`** — the leaderboard filters to `public`. This is the bug most people would
  actually notice.
- **`[username]/page.tsx`** — 404s on `private`.
- **`compare/page.tsx`** and **`[username]/opengraph-image.tsx`** — both excluded private profiles.
  Without this a private profile is still comparable and still has a shareable social card, so the
  data the setting hides just leaks out through a different door.
- **`api/settings/route.ts`** — accepts `private`, still as an explicit allow-list rather than a
  passthrough, since it lands in a CHECK-constrained column and a 400 from us beats a constraint
  violation from Postgres.
- **`settings/client.tsx`** — third option, widened type.

I did **not** touch `api/v1/users/[username]/route.ts` — it already filters
`.eq("visibility", "public")` and returns the same 404 for "doesn't exist" and "unlisted" so it never
reveals that an unlisted profile exists. It was already correct.

### What each state means

| | Explore / Discover | direct link | social card |
|---|---|---|---|
| `public` | listed | renders | yes |
| `unlisted` | hidden | renders | yes |
| `private` | hidden | **404** | no |

## Two bugs in my own first pass, which are worth writing down

I'd rather these be in the description than buried in a review thread, because both are the kind that
look fine and aren't.

**1. `notFound()` was inside a `try` with a bare `catch`, so it never fired.** `notFound()` works by
throwing. The catch swallowed it, execution carried on past the block, and **the private profile
rendered anyway** — silently, since nothing errors, the 404 simply never happens. The whole feature
was inert. This is the documented reason Next tells you to call `notFound()`/`redirect()` outside
try/catch. The gate now lives outside it.

**2. The gate failed open on a database error** (caught by @coderabbitai on the sibling RSS PR, and
the same pattern was here in three files). The Supabase client resolves with `{ data: null, error }`
rather than throwing, so `const { data } = await ...` quietly discards the failure. On any database
error `data` is null, `profileRow?.visibility === "private"` is false, the gate passes, and the
content gets served. `opengraph-image.tsx` was the worst of them — it did `.then((r) => r.data)`,
throwing the error away outright. And in `compare` the surrounding `try/catch` was useless, because
Supabase never throws in the first place.

All four now capture the error and fail closed. `explore` was already safe, because
`.eq("visibility", "public")` is a database-side filter — an error yields no rows, which fails closed
by construction.

The graceful path is intact: no error *and* no row means "never signed up", and such a profile can't
be private because private requires a stored row. Only a genuine database failure trips the gate.

## AI Usage

- [ ] I did not use AI for any part of the code in this PR
- [x] I used AI for coding (specify which tool below) and I fully understand every change I made,
      including which functions I changed, why I changed them, and what side effects they could create

Used Claude for coding.

## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with `main`
- [x] Code works locally and I have tested it
- [x] No `console.log` left in `src/`
- [x] If schema changed — both `schema.sql` and a new migration file are included
- [ ] If this is a UI change — I read `DESIGN.md` and followed the design system
- [x] Docs updated if needed
- [x] PR title follows Conventional Commits format
- [x] This PR description is written in my own words

(DESIGN.md box unticked deliberately — the only UI change is one extra `<option>` in a dropdown that
already exists, so there was no styling decision to make.)

## ⚠️ This needs the migration run before deploy

It changes a CHECK constraint **and** redefines `search_profiles`. If the code ships first,
`/settings` will 500 when someone picks "private", and Discover will keep listing unlisted profiles.

## ⚠️ One part of the issue I couldn't do, and didn't want to fake

The issue asks for a 404 on `private` **"unless the viewer is the owner"**. The second half isn't
possible with the auth as it stands. Sessions live in `localStorage` through the Supabase browser
client — there's no session cookie — so a server component has nothing to identify the viewer with,
and `auth.uid()` is `NULL` for every server-side read.

**So the owner also gets a 404 on their own private profile.** They can still see and change the
setting from `/settings`, so it isn't a dead end, but it isn't what the issue asked for either.

Doing it properly means moving to `@supabase/ssr` with cookie-based auth so the server can read the
session. That's a real change with its own blast radius and I'd rather not smuggle it into this PR.
Happy to open a separate issue for it.

## How I tested it

- `tsc --noEmit`, `next lint` and `next build` all clean (the two lint warnings are pre-existing — an
  `<img>` in `opengraph-image.tsx` and an exhaustive-deps warning in `ProfileView.tsx`)
- Ran the constraint change and the listing filter against a real Postgres: inserting
  `visibility='private'` is rejected by the current constraint and accepted after the migration; the
  `not valid` + `validate` path leaves `pg_constraint.convalidated = t`; and a listing filtered to
  `visibility = 'public'` drops the unlisted and private rows that get ranked today.
- Reproduced both of the bugs above and confirmed the fixes: a private profile now 404s instead of
  rendering, and a simulated database error returns a failure instead of serving the content.