### PR TITLE
feat: add a per-user RSS feed of merged pull requests (Closes #399)

### DIFF
--- a/src/app/[username]/rss.xml/route.ts
+++ b/src/app/[username]/rss.xml/route.ts
@@ -1,0 +1,191 @@
+import { after } from "next/server";
+import { supabase } from "@/lib/supabase";
+import { sanitizeUsername } from "@/lib/validators/api";
+import { getProfileSnapshot, syncProfileSnapshot } from "@/lib/profile-snapshot";
+import type { MergedPR } from "@/types";
+
+export const runtime = "edge";
+
+/** Matches sitemap.ts, which is the only other place that needs an absolute URL. */
+const SITE_URL = "https://ossfolio.qzz.io";
+
+/** Feed readers show a handful of recent items; there's no value in syndicating the whole history. */
+const MAX_ITEMS = 20;
+
+/**
+ * The load-bearing function in this file.
+ *
+ * An unescaped `&` or `<` does not make a feed reader skip one item — it makes the whole document
+ * fail to parse, and the reader drops the entire feed. And PR titles contain both constantly:
+ * "fix: handle a < b", "chore: bump foo & bar", `feat: add <Tooltip>`. So this is the difference
+ * between a feed that works and a feed that silently never works for anybody.
+ *
+ * The control-character strip matters for the same reason: XML 1.0 forbids most of them outright
+ * (there is no escape sequence that makes them legal), so they have to be removed rather than
+ * encoded. They shouldn't appear in a GitHub PR title, but "shouldn't" is doing a lot of work in a
+ * string that arrives from an external API and goes straight into a document that fails closed.
+ */
+function escapeXml(value: string): string {
+  return (
+    value
+      // Illegal in XML 1.0 regardless of escaping — tab, LF and CR are the only ones permitted.
+      .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F]/g, "")
+      // `&` first, or it re-escapes the ampersands introduced by the replacements below.
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&apos;")
+  );
+}
+
+/**
+ * RSS 2.0 requires RFC 822 dates, not ISO 8601 — `2026-07-13T10:00:00Z` is not a valid `pubDate`
+ * and strict readers reject it. `toUTCString()` produces the RFC 822 form.
+ *
+ * `mergedAt` comes from the GitHub API rather than from us, so an unparseable value is treated as
+ * missing rather than being allowed to emit the string "Invalid Date" into the XML.
+ */
+function toRfc822(iso: string | null | undefined): string | null {
+  if (!iso) return null;
+  const parsed = new Date(iso);
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toUTCString();
+}
+
+function buildItem(pr: MergedPR): string {
+  const title = escapeXml(
+    pr.repoName ? `${pr.repoName}: ${pr.title}` : pr.title
+  );
+  const link = escapeXml(pr.url);
+  const pubDate = toRfc822(pr.mergedAt);
+
+  // `isPermaLink="true"` is honest here: the guid *is* the PR's URL, and it's stable and
+  // dereferenceable. Readers use it to decide what they've already shown, so it has to be stable
+  // across rebuilds — which the PR URL is and a generated id would not be.
+  return [
+    "    <item>",
+    `      <title>${title}</title>`,
+    `      <link>${link}</link>`,
+    `      <guid isPermaLink="true">${link}</guid>`,
+    pubDate ? `      <pubDate>${escapeXml(pubDate)}</pubDate>` : null,
+    `      <description>${escapeXml(
+      `Merged pull request in ${pr.repoName || "a repository"}: ${pr.title}`
+    )}</description>`,
+    "    </item>",
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ username: string }> }
+) {
+  const { username: rawUsername } = await params;
+  const username = sanitizeUsername(rawUsername);
+
+  if (!username) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  // A private profile has no page, so it must not have a syndicated feed either — a feed is simply
+  // another read path, and it would hand out precisely what the setting exists to withhold.
+  //
+  // `unlisted` is deliberately still served. It means "don't list me", not "don't exist": the
+  // profile page itself still renders for anyone holding the link, and the feed follows the page
+  // rather than inventing a stricter rule of its own.
+  const { data: profileRow } = await supabase
+    .from("profiles")
+    .select("visibility")
+    .eq("username", username)
+    .maybeSingle();
+
+  if (profileRow?.visibility === "private") {
+    return new Response("Not found", { status: 404 });
+  }
+
+  // The same snapshot the profile page renders from, so the feed can never disagree with the page,
+  // and no GitHub call is made on this path.
+  const stored = await getProfileSnapshot(username);
+
+  // Cold profile: nothing stored yet. The page handles this by kicking the sync off behind the
+  // response and showing a syncing state rather than 404ing, and the feed follows it — a feed that
+  // never triggers the sync that would populate it would 404 forever.
+  //
+  // 503 rather than 404 on purpose. To a feed reader a 404 means "this feed is dead, unsubscribe",
+  // which is exactly the wrong instruction for a profile that is about to have content. 503 with
+  // Retry-After means "come back shortly", which is the truth.
+  //
+  // `after()` runs once this response has already been sent, so the caller waits for nothing, and
+  // the claim inside syncProfileSnapshot() stops a polling reader from stampeding GitHub.
+  if (!stored?.snapshot) {
+    after(() => syncProfileSnapshot(username));
+
+    return new Response("Profile has not been synced yet. Try again shortly.", {
+      status: 503,
+      headers: {
+        "Retry-After": "60",
+        "Cache-Control": "no-store",
+      },
+    });
+  }
+
+  const snapshot = stored.snapshot;
+  const user = snapshot.user;
+
+  // A synced snapshot with no user means GitHub itself returned nothing for this login — the
+  // account does not exist. That genuinely is a 404, and the page agrees (`if (!user && !rateLimited)
+  // return notFound()`).
+  if (!user) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  const mergedPRs: MergedPR[] = (snapshot.mergedPRs ?? [])
+    .filter((pr) => pr && typeof pr.url === "string" && typeof pr.title === "string")
+    .slice(0, MAX_ITEMS);
+
+  const displayName = user.name || username;
+  const profileUrl = `${SITE_URL}/${encodeURIComponent(username)}`;
+  const feedUrl = `${profileUrl}/rss.xml`;
+
+  // The newest item's merge time, falling back to the snapshot's sync time. Readers use this to
+  // decide whether to bother re-parsing, so a value that never changes is worse than none.
+  const lastBuildDate =
+    toRfc822(mergedPRs[0]?.mergedAt) ?? toRfc822(stored?.syncedAt) ?? new Date().toUTCString();
+
+  const xml = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">',
+    "  <channel>",
+    `    <title>${escapeXml(`${displayName} — merged pull requests`)}</title>`,
+    `    <link>${escapeXml(profileUrl)}</link>`,
+    // Required by the RSS Advisory Board's validator, and by several readers, to identify the feed's
+    // own canonical location. Omitting it is the single most common way a feed "validates fine in a
+    // browser" and then misbehaves in an actual reader.
+    `    <atom:link href="${escapeXml(
+      feedUrl
+    )}" rel="self" type="application/rss+xml" />`,
+    `    <description>${escapeXml(
+      `Recent open-source pull requests merged by ${displayName}, via OSSfolio.`
+    )}</description>`,
+    "    <language>en</language>",
+    `    <lastBuildDate>${escapeXml(lastBuildDate)}</lastBuildDate>`,
+    `    <generator>OSSfolio</generator>`,
+    ...mergedPRs.map(buildItem),
+    "  </channel>",
+    "</rss>",
+  ].join("\n");
+
+  return new Response(xml, {
+    status: 200,
+    headers: {
+      // The charset is not optional: without it some readers guess, and a PR title containing an
+      // em-dash or a non-Latin script comes out mangled.
+      "Content-Type": "application/rss+xml; charset=utf-8",
+      // The underlying snapshot has a one-hour TTL (SNAPSHOT_TTL_MS), so there is nothing to gain
+      // from letting readers poll harder than that. `stale-while-revalidate` keeps the feed served
+      // from cache while a fresher copy is fetched, rather than making a reader wait.
+      "Cache-Control": "public, max-age=1800, s-maxage=3600, stale-while-revalidate=86400",
+    },
+  });
+}

--- a/src/app/[username]/rss.xml/route.ts
+++ b/src/app/[username]/rss.xml/route.ts
@@ -94,11 +94,28 @@ export async function GET(
   // `unlisted` is deliberately still served. It means "don't list me", not "don't exist": the
   // profile page itself still renders for anyone holding the link, and the feed follows the page
   // rather than inventing a stricter rule of its own.
-  const { data: profileRow } = await supabase
+  const { data: profileRow, error: visibilityError } = await supabase
     .from("profiles")
     .select("visibility")
     .eq("username", username)
     .maybeSingle();
+
+  // Fail closed. The Supabase client resolves with `{ data: null, error }` rather than throwing, so
+  // discarding the error would leave `profileRow` null on any database failure — the private check
+  // below would pass, and the feed would be served. That is precisely the content the setting exists
+  // to withhold, handed out because a query happened to fail.
+  //
+  // 503 rather than 404, for the same reason as the cold-profile branch: a 404 tells a reader the
+  // feed is dead and it should unsubscribe. A transient database blip is not that.
+  if (visibilityError) {
+    return new Response("Temporarily unavailable", {
+      status: 503,
+      headers: {
+        "Retry-After": "60",
+        "Cache-Control": "no-store",
+      },
+    });
+  }
 
   if (profileRow?.visibility === "private") {
     return new Response("Not found", { status: 404 });


### PR DESCRIPTION
## Summary

Adds `/[username]/rss.xml` — an RSS 2.0 feed of a user's recently merged pull requests, so people can
pipe their open-source activity into a blog, a newsletter, or a reader.

It reads the same snapshot the profile page renders from, so the feed can never disagree with the
page, and it makes no GitHub call of its own.

## Related Issue

Closes #399

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Chore / dependency update

## Changes Made

One new file: `src/app/[username]/rss.xml/route.ts`.

**I didn't use the `rss` npm package, and I want to be upfront about that** since the issue suggests
it. It depends on `mime-types@2.1.13`, a CommonJS package from 2016 that pulls in `mime-db`, and
every route in this repo runs on the edge runtime under OpenNext on Cloudflare Workers. I have no way
to test that package in a Workers environment, and RSS 2.0 is about thirty lines of XML. Hand-rolling
it means no new dependency and escaping I can actually prove. Happy to swap it for the package if
you'd rather — it's a small change.

**The escaping is the part that matters.** An unescaped `&` or `<` doesn't make a reader skip one
item, it makes the whole document fail to parse and the reader drops the entire feed. PR titles
contain both constantly ("fix: handle a < b", "chore: bump foo & bar", "feat: add <Tooltip>"), so
this is the difference between a feed that works and one that silently never works for anyone.
Control characters are stripped rather than escaped, because XML 1.0 has no legal encoding for them.

**A few smaller decisions:**

- `pubDate` is RFC 822, not ISO 8601 — strict readers reject ISO. An unparseable `mergedAt` from
  GitHub drops the `pubDate` rather than emitting "Invalid Date" into the XML.
- The `<atom:link rel="self">` is there because readers and the W3C validator want it. Leaving it out
  is the classic way a feed looks fine in a browser and then misbehaves in an actual reader.
- `guid isPermaLink="true"` is the PR's own URL, which is stable across rebuilds — readers use it to
  decide what they've already shown, so a generated id would make items reappear.
- Cache headers match the snapshot's one-hour TTL. There's nothing to gain from readers polling
  harder than the data changes.

## Visibility

The issue doesn't mention it, but a feed is just another read path, so I made it respect the
`visibility` column:

- **`private` → 404.** A private profile has no page; it shouldn't have a syndicated feed handing out
  exactly what the setting exists to withhold.
- **`unlisted` → still served.** Unlisted means "don't list me", not "don't exist" — the profile page
  still renders for anyone with the link, and the feed follows the page rather than inventing a
  stricter rule of its own.

(Related to #407, which is open — but the `visibility` column has existed since June, so this check
is correct against `main` today regardless of what happens to that PR.)

## Cold profiles get a 503, not a 404

A profile with no stored snapshot has nothing to syndicate yet. The page handles this by kicking the
sync off behind the response and showing a syncing state, and the feed does the same — a feed that
never triggered the sync that would populate it would 404 forever.

It returns **503 with `Retry-After: 60`** rather than 404, because to a feed reader a 404 means "this
feed is dead, unsubscribe" — the wrong instruction entirely for a profile that's about to have
content. The `after()` call runs once the response has already been sent, so the caller waits for
nothing, and the claim inside `syncProfileSnapshot()` stops a polling reader from stampeding GitHub.

404 is reserved for what it actually means: an invalid username, a private profile, or a synced
snapshot where GitHub had no such account (which is what the page does too).

## AI Usage

- [ ] I did not use AI for any part of the code in this PR
- [x] I used AI for coding (specify which tool below) and I fully understand every change I made,
      including which functions I changed, why I changed them, and what side effects they could create

Used Claude for coding.

## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with `main`
- [x] Code works locally and I have tested it
- [x] No `console.log` left in `src/`
- [ ] If schema changed — both `schema.sql` and a new migration file are included
- [ ] If this is a UI change — I read `DESIGN.md` and followed the design system
- [x] Docs updated if needed
- [x] PR title follows Conventional Commits format
- [x] This PR description is written in my own words

(No schema change and no UI change, so those two don't apply.)

## How I tested it, and what I couldn't test

`tsc`, `lint` and `build` are clean, and the route registers as `ƒ /[username]/rss.xml`.

I ran the actual route handler against stubbed dependencies and checked every branch:

| | |
|---|---|
| invalid username | 404 |
| private profile | 404 (and never reads the snapshot) |
| cold profile | 503 + `Retry-After: 60`, sync kicked off |
| synced but GitHub had no such user | 404 |
| unlisted | 200 |
| public + snapshot | 200, `application/rss+xml; charset=utf-8` |

and put the emitted feed through `xmllint`, including PR titles containing `<`, `&`, `>`, quotes and
a control character. It parses, and the titles come back out intact.

**What I could not test: the feed against a live snapshot.** I don't have a Supabase project for
this, so `SUPABASE_SERVICE_ROLE_KEY` isn't set locally and `syncProfileSnapshot` never runs — which
means no snapshot is ever written and the route only ever reaches its cold-profile branch on my
machine. The XML generation and every routing branch are verified; "it renders a real feed for a real
profile" is not something I've seen with my own eyes, and I'd rather say so than imply I have.

If you can point it at a synced profile — or just hit `/PRODHOSH/rss.xml` on a deploy preview and
drop it into https://validator.w3.org/feed/ — that's the last mile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RSS 2.0 feeds for public profiles at `/rss.xml`.
  * Feeds include up to 20 recently merged pull requests with titles, links, descriptions, and publication dates.
  * Added standards-compliant XML formatting and canonical feed links.

* **Bug Fixes**
  * Private or unavailable profiles now return appropriate not-found responses.
  * Temporarily unavailable profile data provides a retry response with caching safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->