### PR TITLE
feat: allow users to delete their account (Closes #410)

### DIFF
--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -136,3 +136,60 @@ export async function PUT(request: NextRequest) {
 
   return createApiResponse({ success: true });
 }
+
+/**
+ * Delete the signed-in user's account.
+ *
+ * The identity comes from `auth.getUser()` on a client scoped to the caller's bearer token, never
+ * from a user id in the request body — otherwise anyone holding any valid token could delete anyone
+ * else's account by naming them.
+ *
+ * This deletes the *auth user*, not the profile row, and that is deliberate rather than an
+ * oversight:
+ *
+ *   1. `profiles.id` is `references auth.users(id) on delete cascade`, so removing the auth user
+ *      removes the profile with it. Deleting the row separately would be redundant and would open a
+ *      window where the profile is gone but the account still exists.
+ *
+ *   2. Migration 20260713000000 revokes DELETE on `public.profiles` from `authenticated` outright,
+ *      on the grounds that nothing in the app deletes a profile from the client. That is still the
+ *      right call — re-granting DELETE just to support this endpoint would widen the client's write
+ *      surface permanently to serve one server-side operation. Deleting through the auth admin API
+ *      leaves that hardening intact.
+ *
+ *   3. `auth.admin.deleteUser` requires the service-role key by design. The anon key cannot call it,
+ *      which is precisely why account deletion belongs on the server rather than in the browser.
+ */
+export async function DELETE(request: NextRequest) {
+  const token = extractToken(request);
+  if (!token) {
+    return createErrorResponse("Unauthorized", 401);
+  }
+
+  const authed = createAuthClient(token);
+  const {
+    data: { user },
+    error: authError,
+  } = await authed.auth.getUser();
+
+  if (authError || !user) {
+    return createErrorResponse("Unauthorized", 401);
+  }
+
+  // Checked rather than assumed: without the service key the admin call below fails in a way that
+  // looks like a server bug, and the user would be told their deletion failed with no idea why. A
+  // 503 says "this deployment can't do that", which is the truth.
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!serviceKey) {
+    return createErrorResponse("Account deletion is not configured", 503);
+  }
+
+  const admin = createClient(supabaseUrl, serviceKey);
+  const { error } = await admin.auth.admin.deleteUser(user.id);
+
+  if (error) {
+    return createErrorResponse("Failed to delete account", 500);
+  }
+
+  return createApiResponse({ deleted: true });
+}

--- a/src/app/settings/client.tsx
+++ b/src/app/settings/client.tsx
@@ -33,6 +33,13 @@ export function SettingsClient() {
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
+
+  // Account deletion. `deleteConfirm` holds what the user has typed into the confirmation box: the
+  // button stays disabled until it matches their username exactly, so this cannot be triggered by a
+  // stray click on an irreversible action.
+  const [deleting, setDeleting] = useState(false);
+  const [deleteConfirm, setDeleteConfirm] = useState("");
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   const [loaded, setLoaded] = useState(false);
   const [settings, setSettings] = useState<ProfileSettings>({
     headline: "",
@@ -112,6 +119,35 @@ export function SettingsClient() {
       setSaving(false);
     }
   }, [session, settings, loaded]);
+
+  const handleDelete = useCallback(async () => {
+    if (!session || deleting) return;
+    setDeleting(true);
+    setDeleteError(null);
+
+    try {
+      const resp = await fetch("/api/settings", {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      });
+
+      if (!resp.ok) {
+        const body = await resp.json().catch(() => ({}));
+        setDeleteError(body.error || "Failed to delete account. Please try again.");
+        setDeleting(false);
+        return;
+      }
+
+      // The account is gone, so the session in localStorage now points at a user that no longer
+      // exists. Signing out clears it; a hard navigation rather than a router push, because every
+      // cached server component on this origin was rendered for a user who has just ceased to be.
+      await supabase.auth.signOut();
+      window.location.href = "/";
+    } catch {
+      setDeleteError("Failed to delete account. Please try again.");
+      setDeleting(false);
+    }
+  }, [session, deleting]);
 
   const handleLogin = async () => {
     await supabase.auth.signInWithOAuth({
@@ -304,6 +340,98 @@ export function SettingsClient() {
           {saveError}
         </span>
       )}
+
+      {/*
+        Danger zone. Kept visually and structurally apart from the settings above, because every
+        control up there is reversible and this one is not.
+
+        The confirmation is a typed word rather than a second "are you sure?" dialog: a dialog is
+        dismissed by reflex, typing is not. It asks for DELETE rather than the username because this
+        component has no username prop — it would have to be dug out of `user_metadata`, whose shape
+        depends on the OAuth provider, and a confirmation that silently fails to match is worse than
+        one that's slightly less personal.
+      */}
+      <div
+        style={{
+          marginTop: "48px",
+          paddingTop: "24px",
+          borderTop: "1px solid var(--color-border)",
+        }}
+      >
+        <h2
+          style={{
+            fontSize: "16px",
+            fontWeight: 600,
+            color: "#b91c1c",
+            margin: "0 0 4px",
+          }}
+        >
+          Danger zone
+        </h2>
+        <p
+          style={{
+            fontSize: "13px",
+            color: "var(--color-ink-soft)",
+            margin: "0 0 16px",
+            lineHeight: 1.6,
+          }}
+        >
+          Deleting your account removes your OSSfolio profile, score and settings permanently. Your
+          GitHub account is not affected. This cannot be undone.
+        </p>
+
+        <label
+          htmlFor="delete-confirm"
+          style={{
+            display: "block",
+            fontSize: "13px",
+            color: "var(--color-ink)",
+            marginBottom: "6px",
+          }}
+        >
+          Type <strong>DELETE</strong> to confirm
+        </label>
+        <input
+          id="delete-confirm"
+          type="text"
+          value={deleteConfirm}
+          onChange={(e) => setDeleteConfirm(e.target.value)}
+          disabled={deleting}
+          autoComplete="off"
+          style={{ ...inputStyle, maxWidth: "220px", marginBottom: "12px" }}
+        />
+
+        <div>
+          <button
+            type="button"
+            onClick={handleDelete}
+            disabled={deleteConfirm !== "DELETE" || deleting || !session}
+            style={{
+              padding: "8px 16px",
+              borderRadius: "8px",
+              border: "1px solid #b91c1c",
+              backgroundColor: deleteConfirm === "DELETE" && !deleting ? "#b91c1c" : "transparent",
+              color: deleteConfirm === "DELETE" && !deleting ? "#fff" : "#b91c1c",
+              fontSize: "14px",
+              fontWeight: 500,
+              cursor:
+                deleteConfirm === "DELETE" && !deleting && session ? "pointer" : "not-allowed",
+              opacity: deleteConfirm === "DELETE" && !deleting && session ? 1 : 0.5,
+            }}
+          >
+            {deleting ? "Deleting…" : "Delete my account"}
+          </button>
+
+          {deleteError && (
+            <span
+              role="alert"
+              style={{ fontSize: "13px", color: "#b91c1c", marginLeft: "12px" }}
+            >
+              {deleteError}
+            </span>
+          )}
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Adds a `DELETE /api/settings` endpoint and a Danger zone in `/settings`, so a user can remove their
OSSfolio account.

## Related Issue

Closes #410

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Chore / dependency update

## Changes Made

- **`src/app/api/settings/route.ts`** — a `DELETE` handler
- **`src/app/settings/client.tsx`** — a Danger zone with a typed confirmation

## It deletes the auth user, not the profile row — deliberately

This is the design decision worth reviewing, so I'll spell out the reasoning.

**1. The cascade already does it.** `profiles.id` is `references auth.users(id) on delete cascade`, so
removing the auth user removes the profile with it, in the same transaction. Deleting the row
separately would be redundant, and would open a window where the profile is gone but the account
still exists.

**2. Deleting from the client is revoked, and should stay revoked.** Migration `20260713000000`
does `revoke insert, update, delete on public.profiles from anon, authenticated`, on the grounds that
nothing in the app deletes a profile from the client. That's still the right call — re-granting DELETE
to `authenticated` just to support this one endpoint would permanently widen the client's write
surface to serve a single server-side operation. Going through the auth admin API leaves that
hardening intact.

**3. `auth.admin.deleteUser` requires the service-role key by design.** The anon key can't call it,
which is exactly why account deletion belongs on the server rather than in the browser.

## Security

**The user id comes from `auth.getUser()` on a client scoped to the caller's bearer token — never
from the request body.** If it came from the body, anyone holding any valid token could delete anyone
else's account simply by naming them. This follows the same auth pattern the existing `GET` and `PUT`
handlers in this file already use.

If `SUPABASE_SERVICE_ROLE_KEY` isn't configured, it returns **503** rather than letting the admin call
fail as an opaque 500 — "this deployment can't do that" is the truth, and it's a much easier thing to
debug than a generic server error.

## UI

A Danger zone, visually and structurally separated from the settings above, because every control up
there is reversible and this one isn't.

The confirmation is a **typed word** rather than a second "are you sure?" dialog — a dialog gets
dismissed by reflex, typing doesn't. It asks for `DELETE` rather than the username because this
component has no username prop; it would have to be dug out of `user_metadata`, whose shape depends on
the OAuth provider, and a confirmation that silently fails to match is worse than one that's slightly
less personal. Happy to change it if you'd rather it echoed the username.

On success it signs out and does a **hard navigation** rather than a router push, because every cached
server component on the origin was rendered for a user who has just ceased to exist.

## ⚠️ Overlaps with #441

Both touch `api/settings/route.ts` and `settings/client.tsx`. Different regions — this appends a
`DELETE` handler and a Danger zone; #441 edits the `visibility` allow-list and the dropdown — so they
should merge cleanly, but whichever lands second may want a quick rebase. Happy to rebase this one
onto #441 if you'd rather merge that first.

## AI Usage

- [ ] I did not use AI for any part of the code in this PR
- [x] I used AI for coding (specify which tool below) and I fully understand every change I made,
      including which functions I changed, why I changed them, and what side effects they could create

Used Claude for coding.

## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with `main`
- [x] Code works locally and I have tested it
- [x] No `console.log` left in `src/`
- [ ] If schema changed — both `schema.sql` and a new migration file are included
- [x] If this is a UI change — I read `DESIGN.md` and followed the design system
- [x] Docs updated if needed
- [x] PR title follows Conventional Commits format
- [x] This PR description is written in my own words

(No schema change — the cascade already exists.)

## How I tested it, and what I couldn't test

`tsc`, `lint` and `build` are clean.

I ran the actual `DELETE` handler against a stubbed Supabase and checked the properties that matter:

| | |
|---|---|
| no `Authorization` header | 401, nothing deleted |
| malformed header | 401, nothing deleted |
| `getUser()` rejects the token | 401, nothing deleted |
| expired / invalid token | 401, nothing deleted |
| valid token | 200, and it deletes **the id `getUser()` returned** — not one from the body |
| admin API returns an error | 500, not a false success |
| `SUPABASE_SERVICE_ROLE_KEY` missing | 503, not a confusing 500 |

**What I could not test: the real `auth.admin.deleteUser` call, and the cascade actually firing.** I
don't have a Supabase project, so the admin API was stubbed. The auth logic and every failure branch
are verified; "the row really disappears" rests on the `on delete cascade` in the schema rather than
on something I've watched happen. Worth one manual check on a throwaway account before merging, and
I'd rather flag that than imply I've done it.