### PR TITLE
feat: add duplicate schedule lock, cross-tab sync, tab validation and debounce

### DIFF
--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -100,8 +100,10 @@ export default async function ExplorePage({ searchParams }: ExplorePageProps) {
   const { page: pageParam, q: qParam, sortBy: sortByParam, type: typeParam } = await searchParams;
   const page = Math.max(1, Math.floor(Number(pageParam)) || 1);
   const searchQuery = typeof qParam === "string" ? qParam.trim() : "";
-  const sortBy = typeof sortByParam === "string" ? sortByParam : "score";
-  const type = typeParam === "organizations" ? "organizations" : "users";
+  const VALID_SORT_OPTIONS = new Set(["score", "prs", "commits", "issues", "improvement"]);
+  const sortBy = typeof sortByParam === "string" && VALID_SORT_OPTIONS.has(sortByParam) ? sortByParam : "score";
+  const VALID_TYPES = new Set(["users", "organizations"]);
+  const type = typeof typeParam === "string" && VALID_TYPES.has(typeParam) ? typeParam : "users";
 
   const { rows, hasNext } = await fetchPage(page, searchQuery, sortBy, type);
   const hasPrev = page > 1;

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -10,6 +10,8 @@ import { ContributionTimeline } from '@/components/profile/ContributionTimeline'
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
+import { useBroadcastChannel } from "@/hooks/useBroadcastChannel";
+import { useVisibility } from "@/hooks/useVisibility";
 import { SkeletonCard } from "@/components/ui/skeleton-card";
 import { evaluateAchievements, countUnlocked } from "@/lib/achievements";
 import { AchievementsGrid } from "@/components/profile/AchievementsGrid";
@@ -558,6 +560,7 @@ export function ProfileView({
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [lastRefresh, setLastRefresh] = useState(updatedAt);
   const [relativeTime, setRelativeTime] = useState("...");
+  const [tabVisible, setTabVisible] = useState(true);
 
   useEffect(() => {
     const compute = () => {
@@ -572,12 +575,14 @@ export function ProfileView({
       return `${days}d ago`;
     };
     const initialUpdate = setTimeout(() => setRelativeTime(compute()), 0);
-    const interval = setInterval(() => setRelativeTime(compute()), 60000);
+    const interval = setInterval(() => {
+      if (tabVisible) setRelativeTime(compute());
+    }, 60000);
     return () => {
       clearInterval(interval);
       clearTimeout(initialUpdate);
     };
-  }, [lastRefresh]);
+  }, [lastRefresh, tabVisible]);
 
   const handleRefresh = async () => {
     setIsRefreshing(true);
@@ -586,6 +591,7 @@ export function ProfileView({
       if (res.ok) {
         const data = await res.json();
         setLastRefresh(data.refreshedAt);
+        postMessage({ type: "refreshed", username: user.login });
         router.refresh();
       } else {
         const payload = await res.json().catch(() => ({}));
@@ -643,6 +649,38 @@ export function ProfileView({
     return () => {
       active = false;
       sub.subscription.unsubscribe();
+    };
+  }, []);
+
+  // Cross-tab sync: when a refresh completes in another tab, reload data.
+  const { postMessage } = useBroadcastChannel<{ type: string; username: string }>(
+    "ossfolio:refresh",
+    useCallback((data) => {
+      if (data.type === "refreshed" && data.username === user.login) {
+        router.refresh();
+      }
+    }, [user.login, router])
+  );
+
+  // Pause relative-time updates when the tab is hidden.
+  useVisibility(
+    useCallback(() => setTabVisible(true), []),
+    useCallback(() => setTabVisible(false), [])
+  );
+
+  // Debounced tab setter to prevent rapid switching from queuing
+  // multiple AnimatePresence transitions.
+  const tabDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const setActiveTabDebounced = useCallback((key: "repos" | "stats" | "prs" | "timeline") => {
+    if (tabDebounceRef.current) clearTimeout(tabDebounceRef.current);
+    tabDebounceRef.current = setTimeout(() => {
+      setActiveTab(key);
+    }, 150);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (tabDebounceRef.current) clearTimeout(tabDebounceRef.current);
     };
   }, []);
 
@@ -1052,7 +1090,7 @@ export function ProfileView({
             aria-selected={activeTab === tab.key}
             aria-controls={`profile-tabpanel-${tab.key}`}
             tabIndex={activeTab === tab.key ? 0 : -1}
-            onClick={() => setActiveTab(tab.key)}
+            onClick={() => setActiveTabDebounced(tab.key)}
             onKeyDown={handleTabKeyDown}
             style={{
               position: "relative",

--- a/src/hooks/useBroadcastChannel.ts
+++ b/src/hooks/useBroadcastChannel.ts
@@ -1,0 +1,49 @@
+import { useEffect, useCallback, useRef } from "react";
+
+type MessageHandler<T> = (data: T) => void;
+
+/**
+ * Syncs state across browser tabs via the BroadcastChannel API.
+ * Falls back silently when the API is unavailable (SSR, older browsers).
+ *
+ * Usage:
+ *   const { postMessage } = useBroadcastChannel("ossfolio:refresh", (data) => {
+ *     if (data.username === currentUser) refreshPage();
+ *   });
+ */
+export function useBroadcastChannel<T = unknown>(
+  channelName: string,
+  onMessage: MessageHandler<T>
+) {
+  const handlerRef = useRef<MessageHandler<T>>(onMessage);
+  handlerRef.current = onMessage;
+
+  useEffect(() => {
+    if (typeof BroadcastChannel === "undefined") return;
+
+    const channel = new BroadcastChannel(channelName);
+    channel.onmessage = (event: MessageEvent<T>) => {
+      handlerRef.current(event.data);
+    };
+
+    return () => {
+      channel.close();
+    };
+  }, [channelName]);
+
+  const postMessage = useCallback(
+    (data: T) => {
+      if (typeof BroadcastChannel === "undefined") return;
+      try {
+        const channel = new BroadcastChannel(channelName);
+        channel.postMessage(data);
+        channel.close();
+      } catch {
+        // BroadcastChannel can throw in some restricted contexts.
+      }
+    },
+    [channelName]
+  );
+
+  return { postMessage };
+}

--- a/src/hooks/useVisibility.ts
+++ b/src/hooks/useVisibility.ts
@@ -1,0 +1,31 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Fires callbacks when the page visibility changes.
+ * Useful for pausing/resuming polling, intervals, or animations
+ * when the user switches to another tab.
+ */
+export function useVisibility(
+  onVisible?: () => void,
+  onHidden?: () => void
+) {
+  const visibleRef = useRef(onVisible);
+  const hiddenRef = useRef(onHidden);
+  visibleRef.current = onVisible;
+  hiddenRef.current = onHidden;
+
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+
+    const handler = () => {
+      if (document.visibilityState === "visible") {
+        visibleRef.current?.();
+      } else {
+        hiddenRef.current?.();
+      }
+    };
+
+    document.addEventListener("visibilitychange", handler);
+    return () => document.removeEventListener("visibilitychange", handler);
+  }, []);
+}

--- a/supabase/functions/scheduled-refresh/index.ts
+++ b/supabase/functions/scheduled-refresh/index.ts
@@ -3,6 +3,8 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
 const GITHUB_API = "https://api.github.com";
 const BATCH_SIZE = 50;
+const LOCK_KEY = "scheduled_refresh";
+const LOCK_TTL_MS = 10 * 60 * 1000; // 10 minutes — same as column default
 
 serve(async (req) => {
   const schedulerSecret = Deno.env.get("SCHEDULER_SECRET");
@@ -26,6 +28,46 @@ serve(async (req) => {
     const supabaseKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
     const supabase = createClient(supabaseUrl, supabaseKey);
 
+    // ── Acquire lock ────────────────────────────────────────────────────
+    // Prevent duplicate concurrent runs.  A stale lock (older than 10 min)
+    // is replaced so a crashed invocation doesn't permanently block the cron.
+    const now = new Date();
+    const { data: lock } = await supabase
+      .from("scheduler_locks")
+      .upsert(
+        { key: LOCK_KEY, locked_at: now, expires_at: new Date(now.getTime() + LOCK_TTL_MS) },
+        { onConflict: "key", ignoreDuplicates: true }
+      )
+      .select("locked_at")
+      .single();
+
+    // If the row exists but was NOT updated by this upsert, another run is
+    // already in progress (or a stale lock hasn't expired yet).
+    if (!lock) {
+      // Check if the existing lock is stale.
+      const { data: existing } = await supabase
+        .from("scheduler_locks")
+        .select("locked_at, expires_at")
+        .eq("key", LOCK_KEY)
+        .single();
+
+      if (existing && new Date(existing.expires_at) > now) {
+        return new Response(
+          JSON.stringify({ skipped: true, reason: "concurrent run in progress" }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+      }
+
+      // Stale lock — overwrite it.
+      await supabase
+        .from("scheduler_locks")
+        .upsert(
+          { key: LOCK_KEY, locked_at: now, expires_at: new Date(now.getTime() + LOCK_TTL_MS) },
+          { onConflict: "key" }
+        );
+    }
+
+    // ── Run refresh ─────────────────────────────────────────────────────
     const { data: profiles, error } = await supabase
       .from("profiles")
       .select("username")
@@ -33,6 +75,8 @@ serve(async (req) => {
       .limit(BATCH_SIZE);
 
     if (error || !profiles) {
+      // Release lock on failure so the next run can proceed.
+      await supabase.from("scheduler_locks").delete().eq("key", LOCK_KEY);
       return new Response(
         JSON.stringify({ error: error?.message || "No profiles found" }),
         { status: 500, headers: { "Content-Type": "application/json" } }
@@ -76,11 +120,28 @@ serve(async (req) => {
       }
     }
 
+    // ── Release lock ────────────────────────────────────────────────────
+    await supabase.from("scheduler_locks").delete().eq("key", LOCK_KEY);
+
     return new Response(
-      JSON.stringify({ refreshed: results.filter((r) => r.status === "refreshed").length, total: profiles.length, results }),
+      JSON.stringify({
+        refreshed: results.filter((r) => r.status === "refreshed").length,
+        total: profiles.length,
+        results,
+      }),
       { status: 200, headers: { "Content-Type": "application/json" } }
     );
   } catch (err) {
+    // Best-effort lock release so the cron doesn't stay stuck on error.
+    try {
+      const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+      const supabaseKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+      const supabase = createClient(supabaseUrl, supabaseKey);
+      await supabase.from("scheduler_locks").delete().eq("key", LOCK_KEY);
+    } catch {
+      // Nothing more we can do.
+    }
+
     return new Response(
       JSON.stringify({ error: err.message || "Internal error" }),
       { status: 500, headers: { "Content-Type": "application/json" } }

--- a/supabase/migrations/20260714000000_add_scheduler_locks.sql
+++ b/supabase/migrations/20260714000000_add_scheduler_locks.sql
@@ -1,0 +1,27 @@
+-- Scheduler lock table to prevent concurrent runs of the scheduled-refresh
+-- edge function.  The function acquires a lock at the start of a run and
+-- releases it when done.  Because the function can be invoked via cron at a
+-- fixed interval (e.g. every 5 minutes), two overlapping invocations would
+-- duplicate work and strain the GitHub API — this migration closes that gap.
+--
+-- A simple `INSERT ... ON CONFLICT DO NOTHING` with a TTL-check is enough:
+-- there is only one schedule (single row, key = 'scheduled_refresh'), and
+-- we treat any lock older than 10 minutes as stale and replace it.
+
+create table if not exists public.scheduler_locks (
+  key        text primary key,
+  locked_at  timestamptz not null default now(),
+  expires_at timestamptz not null default now() + interval '10 minutes'
+);
+
+comment on table public.scheduler_locks is
+  'Exclusive locks for edge-function cron jobs. Each row guards one schedule.';
+
+-- Allow the service-role (used by the edge function) to read & write the lock.
+-- No other role needs access.
+alter table public.scheduler_locks enable row level security;
+
+create policy "service role can manage locks"
+  on public.scheduler_locks
+  using (true)
+  with check (true);


### PR DESCRIPTION
Closes #419 

## Summary
Prevents duplicate scheduled refresh runs, adds cross-tab state sync, and validates tab query parameters with debounced switching.

## Changes
- `supabase/migrations/20260714000000_add_scheduler_locks.sql` — new `scheduler_locks` table for exclusive cron locks
- `supabase/functions/scheduled-refresh/index.ts` — acquire/release lock via upsert; skips if concurrent run active; release on error
- `src/hooks/useBroadcastChannel.ts` — new: BroadcastChannel API hook for cross-tab communication
- `src/hooks/useVisibility.ts` — new: visibilitychange listener hook
- `src/components/profile/ProfileView.tsx` — debounced tab switching (150ms), cross-tab refresh sync via BroadcastChannel, pause relative-time updates on tab hide
- `src/app/explore/page.tsx` — whitelist validation for `sortBy` and `type` query params
