### PR TITLE
feat: Improve empty state for LatestMergedPRs

### DIFF
--- a/src/components/profile/LatestMergedPRs.tsx
+++ b/src/components/profile/LatestMergedPRs.tsx
@@ -6,7 +6,44 @@ interface LatestMergedPRsProps {
 
 export function LatestMergedPRs({ mergedPRs }: LatestMergedPRsProps) {
   if (!mergedPRs || mergedPRs.length === 0) {
-    return null;
+    return (
+      <section style={{ marginTop: '32px' }}>
+        <h2 style={{ fontSize: '16px', fontWeight: 600, color: 'var(--color-ink)', margin: 0, marginBottom: '12px' }}>
+          Latest Merged Pull Requests
+        </h2>
+        <div
+          style={{
+            padding: '40px 20px',
+            border: '1px dashed var(--color-hairline-strong)',
+            borderRadius: '12px',
+            textAlign: 'center',
+            backgroundColor: 'var(--color-canvas-soft)',
+          }}
+        >
+          <svg
+            style={{ margin: '0 auto 12px', color: 'var(--color-ink-mute-2)' }}
+            width="32"
+            height="32"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <circle cx="12" cy="12" r="10" />
+            <path d="M8 12h8" />
+            <path d="M12 8v8" />
+          </svg>
+          <p style={{ fontSize: '14px', fontWeight: 600, color: 'var(--color-ink)', margin: 0 }}>
+            No merged pull requests yet
+          </p>
+          <p style={{ fontSize: '13px', color: 'var(--color-ink-mute)', margin: '4px 0 0 0' }}>
+            Merged PRs will appear here once they land in the contributor&apos;s repositories.
+          </p>
+        </div>
+      </section>
+    );
   }
 
   return (


### PR DESCRIPTION
Replaces the `return null` when there are no merged PRs with a proper empty state that matches the ossfolio design system.

**Before:** The section completely disappeared when no PRs were available.

**After:** A styled empty state with:
- Dashed border container with `var(--color-canvas-soft)` background (consistent with ProfileReposSection and other empty states)
- SVG icon (circle-plus) to visually indicate the absence of data
- Clear heading: "No merged pull requests yet"
- Helpful subtitle: "Merged PRs will appear here once they land in the contributor\u0027s repositories."
- Same CSS variable palette as the rest of the profile view

Closes #317

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a clear empty-state message when no merged pull requests are available.
  * Included helpful explanatory text and visual styling instead of displaying a blank area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->