### PR TITLE
feat: Persist the selected year in localStorage

### DIFF
--- a/src/components/profile/HeatmapWithYearNav.tsx
+++ b/src/components/profile/HeatmapWithYearNav.tsx
@@ -134,10 +134,13 @@ function HeatmapWithYearNavInner({
 
   const fetchYear = useCallback(
     async (year: number) => {
-      if (typeof window !== "undefined") {
-        localStorage.setItem("heatmap_selected_year", String(year));
+      try {
+        if (typeof window !== "undefined") {
+          localStorage.setItem("heatmap_selected_year", String(year));
+        }
+      } catch {
+        // Ignore storage errors to ensure the fetch still proceeds
       }
-
       if (year === selectedYear && weeks.length > 0) return;
       if (year === currentYear && initialWeeks.length > 0) {
         setWeeks(initialWeeks);

--- a/src/components/profile/HeatmapWithYearNav.tsx
+++ b/src/components/profile/HeatmapWithYearNav.tsx
@@ -172,18 +172,18 @@ function HeatmapWithYearNavInner({
     if (hasInitialized.current) return;
     hasInitialized.current = true;
 
-    const savedYearStr = localStorage.getItem("heatmap_selected_year");
-    if (savedYearStr) {
-      const savedYear = parseInt(savedYearStr, 10);
-      if (years.includes(savedYear) && savedYear !== currentYear) {
-        const timer = setTimeout(() => {
+    try {
+      const savedYearStr = localStorage.getItem("heatmap_selected_year");
+      if (savedYearStr) {
+        const savedYear = parseInt(savedYearStr, 10);
+        if (years.includes(savedYear) && savedYear !== currentYear) {
           fetchYear(savedYear);
-        }, 0);
-        return () => clearTimeout(timer);
+        }
       }
+    } catch {
+      // Ignore errors from blocked storage access
     }
   }, [fetchYear]);
-
   const displayedWeeks = useMemo(() => {
     return getFilteredWeeks(
       weeks,

--- a/src/components/profile/HeatmapWithYearNav.tsx
+++ b/src/components/profile/HeatmapWithYearNav.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, memo, useMemo } from "react";
+import { useState, useCallback, memo, useMemo, useEffect, useRef } from "react";
 import type { HeatmapWeek } from "@/types";
 import { computeStreaks } from "@/lib/mock";
 
@@ -134,6 +134,10 @@ function HeatmapWithYearNavInner({
 
   const fetchYear = useCallback(
     async (year: number) => {
+      if (typeof window !== "undefined") {
+        localStorage.setItem("heatmap_selected_year", String(year));
+      }
+
       if (year === selectedYear && weeks.length > 0) return;
       if (year === currentYear && initialWeeks.length > 0) {
         setWeeks(initialWeeks);
@@ -158,6 +162,24 @@ function HeatmapWithYearNavInner({
     },
     [username, selectedYear, weeks.length, initialWeeks],
   );
+
+  const hasInitialized = useRef(false);
+
+  useEffect(() => {
+    if (hasInitialized.current) return;
+    hasInitialized.current = true;
+
+    const savedYearStr = localStorage.getItem("heatmap_selected_year");
+    if (savedYearStr) {
+      const savedYear = parseInt(savedYearStr, 10);
+      if (years.includes(savedYear) && savedYear !== currentYear) {
+        const timer = setTimeout(() => {
+          fetchYear(savedYear);
+        }, 0);
+        return () => clearTimeout(timer);
+      }
+    }
+  }, [fetchYear]);
 
   const displayedWeeks = useMemo(() => {
     return getFilteredWeeks(


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. Write this in your own words. Do not paste an AI-generated summary here. -->
updated the contribution heatmap component to persist the selected year in localStorage and initialize the state from it upon mounting

## Related Issue

Closes #294

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Chore / dependency update

## Changes Made

<!-- Bullet points of what changed and why you made each change -->
- Imports Update: Added useEffect and useRef to the React imports in HeatmapWithYearNav.tsx.
- State Persistence: Modified the fetchYear callback inside HeatmapWithYearNavInner to save the updated year to localStorage under the key heatmap_selected_year.



## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with `main`
- [x] Code works locally and I have tested it
- [x] No `console.log` left in `src/`
- [x] If schema changed — both `schema.sql` and a new migration file are included
- [x] If this is a UI change — I read `DESIGN.md` and followed the design system (colors, spacing, typography, components)
- [x] Docs updated if needed
- [x] PR title follows Conventional Commits format (`feat:`, `fix:`, `docs:`, etc.)
- [x] This PR description is written in my own words


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The heatmap now remembers the selected year between visits.
  * Restores the saved year automatically when the heatmap loads.
  * If the saved year is invalid, unavailable, or equal to the current year, it’s safely ignored.
  * Storage failures won’t interrupt the heatmap experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->