### PR TITLE
feat: Filter PRs by status

### DIFF
--- a/src/app/[username]/rss.xml/route.ts
+++ b/src/app/[username]/rss.xml/route.ts
@@ -158,7 +158,7 @@ export async function GET(
   }
 
   const mergedPRs: MergedPR[] = (snapshot.mergedPRs ?? [])
-    .filter((pr) => pr && typeof pr.url === "string" && typeof pr.title === "string")
+    .filter((pr) => pr && typeof pr.url === "string" && typeof pr.title === "string" && (!pr.state || pr.state === "merged"))
     .slice(0, MAX_ITEMS);
 
   const displayName = user.name || username;

--- a/src/components/profile/ContributionTimeline.tsx
+++ b/src/components/profile/ContributionTimeline.tsx
@@ -23,13 +23,17 @@ interface ContributionTimelineProps {
 export function ContributionTimeline({ mergedPRs, badges = [] }: ContributionTimelineProps) {
   const PAGE_SIZE = 10;
 
+  const mergedOnlyPRs = useMemo(() => {
+    return (mergedPRs || []).filter((pr) => !pr.state || pr.state === "merged");
+  }, [mergedPRs]);
+
   // 1. Gather and construct timeline events
   const events: TimelineEvent[] = [];
 
   // Parse PR events
-  if (mergedPRs && mergedPRs.length > 0) {
+  if (mergedOnlyPRs && mergedOnlyPRs.length > 0) {
     // Sort PRs chronologically ascending (oldest first) to find the absolute oldest retrieved PR
-    const sortedAscPRs = [...mergedPRs].sort(
+    const sortedAscPRs = [...mergedOnlyPRs].sort(
       (a, b) => new Date(a.mergedAt).getTime() - new Date(b.mergedAt).getTime()
     );
 

--- a/src/components/profile/LatestMergedPRs.tsx
+++ b/src/components/profile/LatestMergedPRs.tsx
@@ -1,3 +1,4 @@
+import { useState, useMemo } from 'react';
 import type { MergedPR } from '@/types';
 
 interface LatestMergedPRsProps {
@@ -5,66 +6,107 @@ interface LatestMergedPRsProps {
 }
 
 export function LatestMergedPRs({ mergedPRs }: LatestMergedPRsProps) {
-  if (!mergedPRs || mergedPRs.length === 0) {
-     return (
-      <section style={{ marginTop: '32px' }}>
-        <h2 style={{ fontSize: '16px', fontWeight: 600, color: 'var(--color-ink)', margin: 0, marginBottom: '12px' }}>
-          Latest Merged Pull Requests
-        </h2>
-        <div style={{ 
-          padding: "16px", 
-          border: "1px solid var(--color-hairline)", 
-          borderRadius: "6px",
-          color: "var(--color-ink-mute)",
-          fontSize: "13px",
-          backgroundColor: "var(--color-canvas-soft)"
-        }}>
-          No merged pull requests found.
-        </div>
-      </section>
-    );
-  
-  }
+  const [filter, setFilter] = useState<'merged' | 'open' | 'closed'>('merged');
+
+  const filteredPRs = useMemo(() => {
+    return (mergedPRs || []).filter((pr) => {
+      const state = pr.state || 'merged';
+      return state === filter;
+    });
+  }, [mergedPRs, filter]);
+
+  const selectStyle: React.CSSProperties = {
+    fontSize: '12px',
+    padding: '4px 8px',
+    border: '1px solid var(--color-hairline)',
+    borderRadius: '6px',
+    backgroundColor: 'var(--color-canvas-soft)',
+    color: 'var(--color-ink)',
+    cursor: 'pointer',
+    outline: 'none',
+  };
+
+  const getLabelText = (state: 'merged' | 'open' | 'closed', dateStr: string) => {
+    const formattedDate = new Date(dateStr).toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+    if (state === 'open') {
+      return `opened on ${formattedDate}`;
+    }
+    if (state === 'closed') {
+      return `closed on ${formattedDate}`;
+    }
+    return `merged on ${formattedDate}`;
+  };
+
   return (
     <section style={{ marginTop: '32px' }}>
-      <h2 style={{ fontSize: '16px', fontWeight: 600, color: 'var(--color-ink)', margin: 0, marginBottom: '12px' }}>
-        Latest Merged Pull Requests
-      </h2>
-      <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
-        {mergedPRs.map((pr) => (
-          <li key={pr.url} style={{ marginBottom: '12px' }}>
-            <a
-              href={pr.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              style={{
-                display: 'flex',
-                flexDirection: 'column',
-                textDecoration: 'none',
-                color: 'var(--color-ink)',
-                backgroundColor: 'var(--color-canvas-soft)',
-                padding: '8px 12px',
-                borderRadius: '6px',
-                border: '1px solid var(--color-hairline-strong)',
-                transition: 'background-color 0.2s, border-color 0.2s',
-              }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.backgroundColor = 'var(--color-hairline)';
-                e.currentTarget.style.borderColor = 'var(--color-ink)';
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.backgroundColor = 'var(--color-canvas-soft)';
-                e.currentTarget.style.borderColor = 'var(--color-hairline-strong)';
-              }}
-            >
-              <span style={{ fontWeight: 500, marginBottom: '4px' }}>{pr.title}</span>
-              <span style={{ fontSize: '13px', color: 'var(--color-ink-mute)' }}>
-                {pr.repoName} • merged {new Date(pr.mergedAt).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })}
-              </span>
-            </a>
-          </li>
-        ))}
-      </ul>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '12px' }}>
+        <h2 style={{ fontSize: '16px', fontWeight: 600, color: 'var(--color-ink)', margin: 0 }}>
+          Latest Pull Requests
+        </h2>
+        <select
+          value={filter}
+          onChange={(e) => setFilter(e.target.value as 'merged' | 'open' | 'closed')}
+          style={selectStyle}
+          aria-label="Filter pull requests by status"
+        >
+          <option value="merged">Merged</option>
+          <option value="open">Open</option>
+          <option value="closed">Closed</option>
+        </select>
+      </div>
+
+      {filteredPRs.length === 0 ? (
+        <div style={{ 
+          padding: '16px', 
+          border: '1px solid var(--color-hairline)', 
+          borderRadius: '6px',
+          color: 'var(--color-ink-mute)',
+          fontSize: '13px',
+          backgroundColor: 'var(--color-canvas-soft)'
+        }}>
+          No {filter} pull requests found.
+        </div>
+      ) : (
+        <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+          {filteredPRs.map((pr) => (
+            <li key={pr.url} style={{ marginBottom: '12px' }}>
+              <a
+                href={pr.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  textDecoration: 'none',
+                  color: 'var(--color-ink)',
+                  backgroundColor: 'var(--color-canvas-soft)',
+                  padding: '8px 12px',
+                  borderRadius: '6px',
+                  border: '1px solid var(--color-hairline-strong)',
+                  transition: 'background-color 0.2s, border-color 0.2s',
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.backgroundColor = 'var(--color-hairline)';
+                  e.currentTarget.style.borderColor = 'var(--color-ink)';
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.backgroundColor = 'var(--color-canvas-soft)';
+                  e.currentTarget.style.borderColor = 'var(--color-hairline-strong)';
+                }}
+              >
+                <span style={{ fontWeight: 500, marginBottom: '4px' }}>{pr.title}</span>
+                <span style={{ fontSize: '13px', color: 'var(--color-ink-mute)' }}>
+                  {pr.repoName} • {getLabelText(pr.state || 'merged', pr.mergedAt)}
+                </span>
+              </a>
+            </li>
+          ))}
+        </ul>
+      )}
     </section>
   );
 }

--- a/src/lib/profile-data.ts
+++ b/src/lib/profile-data.ts
@@ -176,9 +176,9 @@ export async function fetchOrganizations(username: string): Promise<Org[]> {
   }
 }
 
-/** Fetch recent merged pull requests for a user */
-export async function fetchMergedPRs(username: string, limit: number = 10): Promise<MergedPR[]> {
-  const query = `search/issues?q=author:${encodeURIComponent(username)}+type:pr+is:merged&sort=updated&order=desc&per_page=${limit}`;
+/** Fetch recent pull requests for a user, containing all states */
+export async function fetchMergedPRs(username: string, limit: number = 30): Promise<MergedPR[]> {
+  const query = `search/issues?q=author:${encodeURIComponent(username)}+type:pr&sort=updated&order=desc&per_page=${limit}`;
   try {
     const res = await fetchWithTimeout(
       `https://api.github.com/${query}`,
@@ -195,12 +195,18 @@ export async function fetchMergedPRs(username: string, limit: number = 10): Prom
     }
     const json = await res.json();
     if (!Array.isArray(json.items)) return [];
-    return json.items.map((item: any) => ({
-      title: item.title,
-      url: item.html_url,
-      repoName: item.repository_url.split('/').slice(-1)[0],
-      mergedAt: item.closed_at,
-    }));
+    return json.items.map((item: any) => {
+      const isMerged = !!item.pull_request?.merged_at;
+      const prState = item.state === "open" ? "open" : (isMerged ? "merged" : "closed");
+      return {
+        title: item.title,
+        url: item.html_url,
+        repoName: item.repository_url.split('/').slice(-1)[0],
+        mergedAt: item.pull_request?.merged_at || item.closed_at || item.created_at,
+        state: prState,
+        createdAt: item.created_at,
+      };
+    });
   } catch (e) {
     // A rate limit must not be flattened into "this user has none" — the result is
     // persisted now, so that would cache an empty list as fresh for a full hour.

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -63,10 +63,12 @@ export interface BadgeItem {
   years: number[];
 }
 
-/** Represents a merged pull request */
+/** Represents a pull request and its status */
 export interface MergedPR {
   title: string;
   url: string;
   repoName: string;
   mergedAt: string;
+  state?: "open" | "closed" | "merged";
+  createdAt?: string;
 }


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. Write this in your own words. Do not paste an AI-generated summary here. -->
I have updated the profile's pull request collection logic to retrieve pull requests of all states (Open, Closed, and Merged) from GitHub and implemented a dropdown selector to filter pull requests on the contributor profile interface

## Related Issue

Closes #295

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Chore / dependency update

## Changes Made

<!-- Bullet points of what changed and why you made each change -->
- Extended Types: Extended the MergedPR interface in types/index.ts with optional state ('open' | 'closed' | 'merged') and createdAt (string) fields. This maintains backward compatibility with older database snapshots that lack these fields.
- Updated API Queries



## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with `main`
- [x] Code works locally and I have tested it
- [x] No `console.log` left in `src/`
- [x] If schema changed — both `schema.sql` and a new migration file are included
- [x] If this is a UI change — I read `DESIGN.md` and followed the design system (colors, spacing, typography, components)
- [x] Docs updated if needed
- [x] PR title follows Conventional Commits format (`feat:`, `fix:`, `docs:`, etc.)
- [x] This PR description is written in my own words
