### PR TITLE
[FEAT] Customizable Headline

### DIFF
--- a/src/app/settings/client.tsx
+++ b/src/app/settings/client.tsx
@@ -211,6 +211,39 @@ export function SettingsClient() {
         <p style={{ fontSize: "12px", color: "var(--color-ink-mute-2)", marginTop: "4px" }}>
           {settings.headline.length}/160 characters
         </p>
+        <div
+  style={{
+    marginTop: "16px",
+    padding: "16px",
+    border: "1px solid var(--color-hairline)",
+    borderRadius: "8px",
+    backgroundColor: "var(--color-canvas-soft)",
+  }}
+>
+  <p
+    style={{
+      fontSize: "12px",
+      fontWeight: 600,
+      color: "var(--color-ink-mute)",
+      margin: "0 0 8px 0",
+    }}
+  >
+    Live Preview
+  </p>
+
+  <p
+    style={{
+      fontSize: "14px",
+      color: "var(--color-ink)",
+      lineHeight: 1.55,
+      margin: 0,
+    }}
+  >
+    {settings.headline.trim()
+      ? settings.headline
+      : "Your GitHub bio will appear here if no custom headline is set."}
+  </p>
+</div>
       </div>
 
       <div style={sectionStyle}>


### PR DESCRIPTION
## Summary

This PR adds a live preview for the Custom Headline feature on the Settings page. As users type their headline, they can immediately see how it will appear, making it easier to personalize their OSSfolio profile before saving. A fallback message is also shown when no custom headline is provided.

Closes #398

## Type of Change

- [ ] Bug fix
- [ x ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Chore / dependency update

## Changes Made

- Added a live preview section below the Custom Headline input.
- Updated the preview to refresh in real time as the user types.
- Added a fallback message when no custom headline is provided.

## AI Usage

- [ ] I did not use AI for any part of the code in this PR
- [ x ] I used AI for coding (specify which tool below) and I fully understand every change I made, including which functions I changed, why I changed them, and what side effects they could create


Used ChatGPT for guidance during implementation and code review.

## Screenshots (if UI change)

Not available. The UI depends on authenticated access through a local Supabase setup, which was not configured in my environment.

## Checklist

- [ x ] I was assigned to the issue before opening this PR
- [ x ] My branch is up to date with `main`
- [ ] Code works locally and I have tested it
- [ x ] No `console.log` left in `src/`
- [ ] If schema changed — both `schema.sql` and a new migration file are included
- [ x ] If this is a UI change — I read `DESIGN.md` and followed the design system (colors, spacing, typography, components)
- [ ] Docs updated if needed
- [ x ] PR title follows Conventional Commits format (`feat:`, `fix:`, `docs:`, etc.)
- [ x ] This PR description is written in my own words


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a styled live preview for custom headlines in settings.
  * Displays the entered headline or a fallback message when no headline is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->