### PR TITLE
fix(db): correct organizations index to reference real columns, not non-existent login (refs #401)

### DIFF
--- a/supabase/migrations/20260708000001_add_indexes_and_perf.sql
+++ b/supabase/migrations/20260708000001_add_indexes_and_perf.sql
@@ -1,8 +1,12 @@
 -- Create index on score and username for optimized leaderboard and discover pagination
 CREATE INDEX IF NOT EXISTS idx_profiles_score_username ON public.profiles(score DESC, username ASC);
 
--- Create index on organization logins to speed up member retrieval
-CREATE INDEX IF NOT EXISTS idx_organizations_login ON public.organizations(login);
+-- Speed up the Explore org listing, which orders by score desc then slug asc.
+-- (The original index referenced organizations(login), but there is no `login`
+-- column -- that is a field on the GitHub API org object, not this table. The
+-- table's columns are id, name, slug, avatar_url, score, created_at, so the old
+-- index failed to create on a fresh database.)
+CREATE INDEX IF NOT EXISTS idx_organizations_score_slug ON public.organizations(score DESC, slug ASC);
 
 -- Add index for profiles metadata columns
 CREATE INDEX IF NOT EXISTS idx_profiles_updated_at ON public.profiles(updated_at DESC);


### PR DESCRIPTION
Closes #401

`20260708000001_add_indexes_and_perf.sql` creates an index on `organizations(login)`, but the
`organizations` table has no `login` column — that's a field on the GitHub API org object, not this
table (its columns are `id, name, slug, avatar_url, score, created_at`). So the statement fails on a
fresh database:
ERROR: column "login" does not exist

This means `supabase db start` currently fails applying this migration, which blocks the types-generation
CI check #401 is adding (it runs `supabase db start`). Verified against a real Postgres.

## Fix

Point the index at the columns the Explore org listing actually queries. That query
(`src/app/explore/page.tsx`) orders organizations by `score desc, slug asc`, so:

```sql
CREATE INDEX IF NOT EXISTS idx_organizations_score_slug ON public.organizations(score DESC, slug ASC);
```

(The original comment said "speed up member retrieval," but there's no member-join query — the index
supports the score+slug ordering of the listing, mirroring `idx_profiles_score_username` for profiles.)

## On editing the migration in place

The buggy index makes a fresh apply fail, so this migration can't have successfully applied to any
database — nothing depends on its (broken) state, and `supabase db start` always applies from zero. So
correcting the source line is safe here rather than adding a new corrective migration. The matching fix
is in `schema.sql` in #<PR-A number> so the two stay in sync.

Verified: the corrected index applies cleanly on a real Postgres.