### PR TITLE
fix: non-standardized GitHub API rate limit

### DIFF
--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -59,6 +59,21 @@ export class UpstreamError extends AppError {
   }
 }
 
+/**
+ * Thrown when the **GitHub API** (REST or GraphQL) returns a rate-limit response.
+ *
+ * Kept separate from `RateLimitError` (which models the app's own HTTP 429
+ * responses to clients) to avoid conflating the two layers and to allow callers
+ * to distinguish a GitHub quota exhaustion from any other kind of failure with a
+ * simple `instanceof` check rather than fragile message-string comparisons.
+ */
+export class GitHubRateLimitError extends Error {
+  readonly name = "GitHubRateLimitError";
+  constructor(message = "GitHub API rate limit exceeded") {
+    super(message);
+  }
+}
+
 export interface ApiErrorBody {
   error: string;
   code: string;

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,6 +1,7 @@
 import type { ContributorStats, Repo } from "@/types";
 import { redis } from "./redis";
 import { fetchWithTimeout, FetchTimeoutError } from "@/lib/fetch-with-timeout";
+import { GitHubRateLimitError } from "@/lib/errors";
 
 
 const GITHUB_GRAPHQL_URL = "https://api.github.com/graphql";
@@ -39,6 +40,10 @@ async function githubGraphQL<T>(
       );
 
       if (!res.ok) {
+        // GitHub returns 403 for primary rate-limit exhaustion on the GraphQL endpoint.
+        if (res.status === 403) {
+          throw new GitHubRateLimitError();
+        }
         // 429 or 5xx — retryable
         if (res.status === 429 || res.status >= 500) {
           lastError = new Error(`GitHub API error: ${res.status}`);
@@ -55,8 +60,13 @@ async function githubGraphQL<T>(
       }
 
       const json = await res.json();
-      if (json.errors) {
-        lastError = new Error(json.errors[0].message);
+      if (json.errors?.length) {
+        const firstErr = json.errors[0];
+        // GitHub GraphQL signals quota exhaustion with a structured type field.
+        if (firstErr.type === "RATE_LIMITED") {
+          throw new GitHubRateLimitError(firstErr.message);
+        }
+        lastError = new Error(firstErr.message);
         // Some GitHub errors are retryable (e.g. secondary rate limit)
         if (attempt < RETRY_CONFIG.maxRetries) {
           const delay = Math.min(

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -40,9 +40,13 @@ async function githubGraphQL<T>(
       );
 
       if (!res.ok) {
-        // GitHub returns 403 for primary rate-limit exhaustion on the GraphQL endpoint.
         if (res.status === 403) {
-          throw new GitHubRateLimitError();
+          const isRateLimit =
+            res.headers.get("x-ratelimit-remaining") === "0" ||
+            res.headers.has("retry-after");
+          if (isRateLimit) {
+            throw new GitHubRateLimitError();
+          }
         }
         // 429 or 5xx — retryable
         if (res.status === 429 || res.status >= 500) {

--- a/src/lib/profile-data.ts
+++ b/src/lib/profile-data.ts
@@ -1,20 +1,22 @@
 import type { ContributorStats, Org, Repo, TechEntry, MergedPR } from "@/types";
 import { LANG_COLORS } from "@/lib/languages";
 import { fetchWithTimeout } from "@/lib/fetch-with-timeout";
+import { GitHubRateLimitError } from "@/lib/errors";
 
 /**
  * GitHub answers a rate limit with 403/429 and a "rate limit" message. Raise it as
- * an error so callers that persist results can decline to cache a degraded response.
+ * a `GitHubRateLimitError` so callers that persist results can decline to cache a
+ * degraded response and can detect the condition with a reliable `instanceof` check.
  */
 async function throwIfRateLimited(res: Response): Promise<void> {
   if (res.status !== 403 && res.status !== 429) return;
   try {
     const err = await res.clone().json();
     if (typeof err?.message === "string" && err.message.toLowerCase().includes("rate limit")) {
-      throw new Error("RateLimit");
+      throw new GitHubRateLimitError(err.message);
     }
   } catch (e) {
-    if (e instanceof Error && e.message === "RateLimit") throw e;
+    if (e instanceof GitHubRateLimitError) throw e;
   }
 }
 
@@ -171,7 +173,7 @@ export async function fetchOrganizations(username: string): Promise<Org[]> {
   } catch (e) {
     // A rate limit must not be flattened into "this user has none" — the result is
     // persisted now, so that would cache an empty list as fresh for a full hour.
-    if (e instanceof Error && e.message === "RateLimit") throw e;
+    if (e instanceof GitHubRateLimitError) throw e;
     return [];
   }
 }
@@ -210,7 +212,7 @@ export async function fetchMergedPRs(username: string, limit: number = 30): Prom
   } catch (e) {
     // A rate limit must not be flattened into "this user has none" — the result is
     // persisted now, so that would cache an empty list as fresh for a full hour.
-    if (e instanceof Error && e.message === "RateLimit") throw e;
+    if (e instanceof GitHubRateLimitError) throw e;
     return [];
   }
 }
@@ -250,10 +252,10 @@ export async function fetchGitHubUser(username: string): Promise<GitHubUser | nu
     try {
       const err = await res.json();
       if (err.message && err.message.toLowerCase().includes("rate limit")) {
-        throw new Error("RateLimit");
+        throw new GitHubRateLimitError(err.message);
       }
     } catch (e) {
-      if (e instanceof Error && e.message === "RateLimit") throw e;
+      if (e instanceof GitHubRateLimitError) throw e;
     }
     return null;
   }

--- a/src/lib/profile-snapshot.ts
+++ b/src/lib/profile-snapshot.ts
@@ -12,6 +12,7 @@ import {
 } from "@/lib/profile-data";
 import { fetchContributionCalendar, type ContributionCalendar } from "@/lib/github";
 import type { ContributorStats, Org, MergedPR } from "@/types";
+import { GitHubRateLimitError } from "@/lib/errors";
 
 /**
  * DB-first profile data.
@@ -173,9 +174,7 @@ export async function syncProfileSnapshot(rawUsername: string): Promise<void> {
     ]);
 
   const wasRateLimited = (r: PromiseSettledResult<unknown>) =>
-    r.status === "rejected" &&
-    r.reason instanceof Error &&
-    r.reason.message === "RateLimit";
+    r.status === "rejected" && r.reason instanceof GitHubRateLimitError;
 
   const rateLimited = [user, repos, liveStats, mergedPRs, orgs, contributionCalendar].some(
     wasRateLimited


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. Write this in your own words. Do not paste an AI-generated summary here. -->

## Related Issue

Closes #265

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Chore / dependency update

## Changes Made

<!-- Bullet points of what changed and why you made each change -->
- GraphQL layer now catches HTTP 403 and json.errors[0].type === "RATE_LIMITED" as GitHubRateLimitError
- wasRateLimited predicate simplified to r.reason instanceof GitHubRateLimitError



## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with `main`
- [x] Code works locally and I have tested it
- [x] No `console.log` left in `src/`
- [x] If schema changed — both `schema.sql` and a new migration file are included
- [x] If this is a UI change — I read `DESIGN.md` and followed the design system (colors, spacing, typography, components)
- [x] Docs updated if needed
- [x] PR title follows Conventional Commits format (`feat:`, `fix:`, `docs:`, etc.)
- [x] This PR description is written in my own words


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and handling of GitHub API rate limits across REST and GraphQL requests.
  * Rate-limit errors are now clearly distinguished from other application errors.
  * Prevented rate-limited profile data and snapshots from being incorrectly treated as empty or successfully saved.
  * Preserved meaningful rate-limit messages for improved error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->