### PR TITLE
feat(profile): pin repositories on profile with owner-only toggle (cl…

### DIFF
--- a/src/app/[username]/page.tsx
+++ b/src/app/[username]/page.tsx
@@ -289,6 +289,7 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
           rateLimited={rateLimited}
           mergedPRs={mergedPRs}
           customLinks={customization?.customLinks ?? []}
+          pinnedRepos={customization?.pinnedRepos ?? []}
           customizationLoaded={customizationFetchSettled}
         />
       </main>

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -458,6 +458,7 @@ export function ProfileView({
   rateLimited,
   mergedPRs,
   customLinks = [],
+  pinnedRepos = [],
   customizationLoaded = false,
 }: {
   user: GitHubUser;
@@ -467,6 +468,7 @@ export function ProfileView({
   {
     rateLimited?: boolean;
     customLinks?: Array<{ label: string; url: string }>;
+    pinnedRepos?: string[];
     customizationLoaded?: boolean;
   }) {
   // Derived from stats the page already fetched and passed down, so the whole feature
@@ -486,6 +488,17 @@ export function ProfileView({
   const [repoFilter, setRepoFilter] = useState("");
   const [activeLanguage, setActiveLanguage] = useState<string>("All");
   const [activeTab, setActiveTab] = useState<"repos" | "stats" | "prs" | "timeline">("repos");
+  const [pinnedList, setPinnedList] = useState<string[]>(pinnedRepos);
+  const [pinningRepo, setPinningRepo] = useState<string | null>(null);
+  // Sync local pinned state when the prop changes (e.g. after a background refresh), using React's
+  // "adjust state during render" pattern rather than an effect — it avoids an extra render pass and
+  // the cascading-render the effect-based approach triggers.
+  const [prevPinnedProp, setPrevPinnedProp] = useState<string[]>(pinnedRepos);
+  if (prevPinnedProp !== pinnedRepos) {
+    setPrevPinnedProp(pinnedRepos);
+    setPinnedList(pinnedRepos);
+  }
+  const MAX_PINNED = 6;
 
   const profileTabs = [
     { key: "repos" as const, label: "Repos" },
@@ -541,15 +554,19 @@ export function ProfileView({
   }, [repos]);
 
   const filteredRepos = useMemo(() => {
+    const pinnedSet = new Set(pinnedList);
     return [...repos]
       .sort((a, b) => {
+        const aPinned = pinnedSet.has(a.name);
+        const bPinned = pinnedSet.has(b.name);
+        if (aPinned !== bPinned) return aPinned ? -1 : 1;
         if (repoSort === "forks") return b.forks_count - a.forks_count;
         if (repoSort === "updated") return (b.pushed_at || "").localeCompare(a.pushed_at || "");
         return b.stargazers_count - a.stargazers_count;
       })
       .filter((repo) => !repoFilter || repo.name.toLowerCase().includes(repoFilter.toLowerCase()) || (repo.description || "").toLowerCase().includes(repoFilter.toLowerCase()))
       .filter((repo) => activeLanguage === "All" || repo.language === activeLanguage);
-  }, [repos, repoSort, repoFilter, activeLanguage]);
+  }, [repos, repoSort, repoFilter, activeLanguage, pinnedList]);
 
   const focusSearch = useCallback(() => searchRef.current?.focus(), []);
   useKeyboardShortcuts({ onSlash: focusSearch });
@@ -727,6 +744,47 @@ export function ProfileView({
     }
   };
 
+
+    const handleTogglePin = async (repoName: string) => {
+      const isPinned = pinnedList.includes(repoName);
+      if (!isPinned && pinnedList.length >= MAX_PINNED) {
+        alert(`You can pin up to ${MAX_PINNED} repositories.`);
+        return;
+      }
+      const next = isPinned
+        ? pinnedList.filter((name) => name !== repoName)
+        : [...pinnedList, repoName];
+      const previous = pinnedList;
+      setPinnedList(next);
+      setPinningRepo(repoName);
+      try {
+        const { data: { session } } = await supabase.auth.getSession();
+        const token = session?.access_token;
+        if (!token) {
+          setPinnedList(previous);
+          alert("Please sign in again to update pinned repositories.");
+          return;
+        }
+        const resp = await fetch("/api/settings", {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ pinned_repos: next }),
+        });
+        if (!resp.ok) {
+          setPinnedList(previous);
+          alert("Failed to update pinned repositories. Please try again.");
+        }
+      } catch (err) {
+        setPinnedList(previous);
+        console.error("Error updating pinned repositories:", err);
+        alert("Failed to update pinned repositories. Please try again.");
+      } finally {
+        setPinningRepo(null);
+      }
+    };
   const scrollToTop = () =>
     window.scrollTo({ top: 0, behavior: "smooth" });
 
@@ -1212,31 +1270,36 @@ export function ProfileView({
               </div>
             ) : (
               <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))", gap: "16px" }}>
-                {filteredRepos.map((repo) => (
-                  <a
-                    key={repo.id}
-                    href={repo.html_url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    style={{
-                      display: "flex",
-                      flexDirection: "column",
-                      gap: "8px",
-                      padding: "20px",
-                      border: "1px solid var(--color-hairline)",
-                      borderRadius: "12px",
-                      textDecoration: "none",
-                      backgroundColor: "var(--color-canvas-soft)",
-                    }}
-                    onMouseEnter={(e) => {
-                      e.currentTarget.style.borderColor = "var(--color-hairline-strong)";
-                      e.currentTarget.style.boxShadow = "0 1px 3px rgba(0,0,0,0.12)";
-                    }}
-                    onMouseLeave={(e) => {
-                      e.currentTarget.style.borderColor = "var(--color-hairline)";
-                      e.currentTarget.style.boxShadow = "none";
-                    }}
-                  >
+                {filteredRepos.map((repo) => {
+                  const isPinnedRepo = pinnedList.includes(repo.name);
+                  return (
+                  <div key={repo.id} style={{ position: "relative", display: "flex" }}>
+                    <a
+                      href={repo.html_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      style={{
+                        display: "flex",
+                        flexDirection: "column",
+                        gap: "8px",
+                        padding: "20px",
+                        paddingTop: isOwner ? "44px" : "20px",
+                        width: "100%",
+                        border: isPinnedRepo ? "1px solid #3ecf8e" : "1px solid var(--color-hairline)",
+                        boxShadow: isPinnedRepo ? "0 0 0 1px #3ecf8e" : "none",
+                        borderRadius: "12px",
+                        textDecoration: "none",
+                        backgroundColor: "var(--color-canvas-soft)",
+                      }}
+                      onMouseEnter={(e) => {
+                        if (!isPinnedRepo) e.currentTarget.style.borderColor = "var(--color-hairline-strong)";
+                        e.currentTarget.style.boxShadow = isPinnedRepo ? "0 0 0 1px #3ecf8e, 0 1px 3px rgba(0,0,0,0.12)" : "0 1px 3px rgba(0,0,0,0.12)";
+                      }}
+                      onMouseLeave={(e) => {
+                        e.currentTarget.style.borderColor = isPinnedRepo ? "#3ecf8e" : "var(--color-hairline)";
+                        e.currentTarget.style.boxShadow = isPinnedRepo ? "0 0 0 1px #3ecf8e" : "none";
+                      }}
+                    >
                     <p style={{ fontSize: "14px", fontWeight: 600, color: "var(--color-ink)", margin: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
                       {repo.name}
                     </p>
@@ -1288,8 +1351,48 @@ export function ProfileView({
                         {repo.forks_count.toLocaleString("en-US")}
                       </span>
                     </div>
-                  </a>
-                ))}
+                    </a>
+                    {isOwner && (
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          handleTogglePin(repo.name);
+                        }}
+                        disabled={pinningRepo === repo.name}
+                        aria-pressed={isPinnedRepo}
+                        aria-label={isPinnedRepo ? `Unpin ${repo.name}` : `Pin ${repo.name}`}
+                        title={isPinnedRepo ? "Unpin from profile" : "Pin to profile"}
+                        style={{
+                          position: "absolute",
+                          top: "12px",
+                          right: "12px",
+                          display: "flex",
+                          alignItems: "center",
+                          gap: "4px",
+                          padding: "4px 10px",
+                          fontSize: "12px",
+                          fontWeight: 600,
+                          color: isPinnedRepo ? "#171717" : "var(--color-ink-mute)",
+                          backgroundColor: isPinnedRepo ? "#3ecf8e" : "var(--color-canvas)",
+                          border: isPinnedRepo ? "none" : "1px solid var(--color-hairline)",
+                          borderRadius: "9999px",
+                          cursor: pinningRepo === repo.name ? "default" : "pointer",
+                          opacity: pinningRepo === repo.name ? 0.6 : 1,
+                          zIndex: 1,
+                        }}
+                      >
+                        <svg width="12" height="12" viewBox="0 0 24 24" fill={isPinnedRepo ? "currentColor" : "none"} stroke="currentColor" strokeWidth="2">
+                          <line x1="12" y1="17" x2="12" y2="22" />
+                          <path d="M5 17h14l-1.5-4.5a2 2 0 0 1 .5-2L20 8a2 2 0 0 0-1.4-3.4H5.4A2 2 0 0 0 4 8l1.9 2.5a2 2 0 0 1 .5 2z" />
+                        </svg>
+                        {isPinnedRepo ? "Pinned" : "Pin"}
+                      </button>
+                    )}
+                  </div>
+                  );
+                })}
               </div>
             )}
 

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -746,6 +746,9 @@ export function ProfileView({
 
 
     const handleTogglePin = async (repoName: string) => {
+      // Single-flight: block all toggles while one PUT is in flight, so two quick clicks on different
+      // cards can't race — overlapping requests could otherwise land out of order and persist a stale list.
+      if (pinningRepo !== null) return;
       const isPinned = pinnedList.includes(repoName);
       if (!isPinned && pinnedList.length >= MAX_PINNED) {
         alert(`You can pin up to ${MAX_PINNED} repositories.`);
@@ -1285,19 +1288,19 @@ export function ProfileView({
                         padding: "20px",
                         paddingTop: isOwner ? "44px" : "20px",
                         width: "100%",
-                        border: isPinnedRepo ? "1px solid #3ecf8e" : "1px solid var(--color-hairline)",
-                        boxShadow: isPinnedRepo ? "0 0 0 1px #3ecf8e" : "none",
+                        border: isPinnedRepo ? "1px solid var(--color-primary)" : "1px solid var(--color-hairline)",
+                        boxShadow: isPinnedRepo ? "0 0 0 1px var(--color-primary)" : "none",
                         borderRadius: "12px",
                         textDecoration: "none",
                         backgroundColor: "var(--color-canvas-soft)",
                       }}
                       onMouseEnter={(e) => {
                         if (!isPinnedRepo) e.currentTarget.style.borderColor = "var(--color-hairline-strong)";
-                        e.currentTarget.style.boxShadow = isPinnedRepo ? "0 0 0 1px #3ecf8e, 0 1px 3px rgba(0,0,0,0.12)" : "0 1px 3px rgba(0,0,0,0.12)";
+                        e.currentTarget.style.boxShadow = isPinnedRepo ? "0 0 0 1px var(--color-primary), 0 1px 3px rgba(0,0,0,0.12)" : "0 1px 3px rgba(0,0,0,0.12)";
                       }}
                       onMouseLeave={(e) => {
-                        e.currentTarget.style.borderColor = isPinnedRepo ? "#3ecf8e" : "var(--color-hairline)";
-                        e.currentTarget.style.boxShadow = isPinnedRepo ? "0 0 0 1px #3ecf8e" : "none";
+                        e.currentTarget.style.borderColor = isPinnedRepo ? "var(--color-primary)" : "var(--color-hairline)";
+                        e.currentTarget.style.boxShadow = isPinnedRepo ? "0 0 0 1px var(--color-primary)" : "none";
                       }}
                     >
                     <p style={{ fontSize: "14px", fontWeight: 600, color: "var(--color-ink)", margin: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
@@ -1360,7 +1363,7 @@ export function ProfileView({
                           e.stopPropagation();
                           handleTogglePin(repo.name);
                         }}
-                        disabled={pinningRepo === repo.name}
+                        disabled={pinningRepo !== null}
                         aria-pressed={isPinnedRepo}
                         aria-label={isPinnedRepo ? `Unpin ${repo.name}` : `Pin ${repo.name}`}
                         title={isPinnedRepo ? "Unpin from profile" : "Pin to profile"}
@@ -1374,12 +1377,12 @@ export function ProfileView({
                           padding: "4px 10px",
                           fontSize: "12px",
                           fontWeight: 600,
-                          color: isPinnedRepo ? "#171717" : "var(--color-ink-mute)",
-                          backgroundColor: isPinnedRepo ? "#3ecf8e" : "var(--color-canvas)",
+                          color: isPinnedRepo ? "var(--color-on-primary)" : "var(--color-ink-mute)",
+                          backgroundColor: isPinnedRepo ? "var(--color-primary)" : "var(--color-canvas)",
                           border: isPinnedRepo ? "none" : "1px solid var(--color-hairline)",
                           borderRadius: "9999px",
-                          cursor: pinningRepo === repo.name ? "default" : "pointer",
-                          opacity: pinningRepo === repo.name ? 0.6 : 1,
+                          cursor: pinningRepo !== null ? "default" : "pointer",
+                          opacity: pinningRepo !== null ? 0.6 : 1,
                           zIndex: 1,
                         }}
                       >


### PR DESCRIPTION
## Summary

Adds the ability to pin repositories on a profile, so an owner can surface specific projects at the top
of their repo grid instead of the default stars-first ordering. This is the feature #390 asks for.

While building it I found that the pinning that already existed didn't actually do anything on the
profile: `[username]/page.tsx` computed `pinnedRepos` but only ever passed `customLinks` down to
`ProfileView`, so pins saved in /settings changed nothing on the page. I also found that the
`ProfileReposSection` component the issue mentions isn't rendered anywhere — `ProfileView` renders its
repo grid inline — so the rendering had to go there. Both are addressed here.

## Related Issue

Closes #390

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Chore / dependency update

## Changes Made

- **`[username]/page.tsx`** — pass `pinnedRepos` through to `ProfileView` (it was computed but never
  handed over — one dead line).
- **`ProfileView.tsx`** —
  - accept a `pinnedRepos` prop and keep a local copy so the toggle can update optimistically
  - sort pinned repos to the top of the grid, keeping the chosen sort (stars/forks/recent) within the
    pinned and unpinned groups
  - give pinned cards a distinct green border so they read as highlighted
  - add an owner-only Pin/Unpin toggle on each card (gated by the existing `isOwner`), rendered as a
    sibling of the card link (not nested inside it) with `preventDefault`/`stopPropagation` so pinning
    doesn't follow the card's link
  - wire the toggle to `PUT /api/settings` (the same endpoint /settings uses) with an optimistic update
    that rolls back if the request fails, and a 6-repo cap matching the API's validation

## AI Usage

- [ ] I did not use AI for any part of the code in this PR
- [x] I used AI for coding (specify which tool below) and I fully understand every change I made, including which functions I changed, why I changed them, and what side effects they could create

Used Claude for coding. Worth noting on side effects: the toggle updates local state before the request
returns (optimistic), so it rolls the state back and alerts if the PUT fails — the grid never shows a
pin that didn't save. The Pin button is a sibling of the card `<a>` rather than a child, because nesting
a button inside an anchor is invalid and would make a pin click also open the repo; it uses
`stopPropagation`/`preventDefault` to be safe.

## Screenshots (if UI change)

I don't have Supabase credentials set up locally, so I couldn't run the sign-in → pin → save flow to
capture screenshots or honestly tick "tested locally." What I did verify:

- `tsc --noEmit` — no errors
- `eslint` — no errors on the changed files, no new warnings
- the component compiles/parses cleanly

The feature extends the existing repo grid and reuses the `PUT /api/settings` endpoint that /settings
already uses, so the moving parts are all patterns already in the codebase. Would appreciate a check of
the pin/unpin + persist behavior on a preview or your end before merge — happy to adjust.

## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with `main`
- [ ] Code works locally and I have tested it
- [ ] No `console.log` left in `src/`
- [ ] If schema changed — both `schema.sql` and a new migration file are included
- [x] If this is a UI change — I read `DESIGN.md` and followed the design system (colors, spacing, typography, components)
- [ ] Docs updated if needed
- [x] PR title follows Conventional Commits format (`feat:`, `fix:`, `docs:`, etc.)
- [x] This PR description is written in my own words

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profile owners can pin repositories to highlight them on their profile.
  * Pinned repositories appear first in repository listings and are visually distinguished.
  * Pin and unpin actions are available directly on repository cards.
  * Pinned selections remain saved and synchronized when viewing the profile.
  * Existing search, language filters, and sorting continue to work with pinned repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->