### PR TITLE
fix: truncate long repository descriptions with ellipsis

### DIFF
--- a/src/components/profile/ProfileReposSection.tsx
+++ b/src/components/profile/ProfileReposSection.tsx
@@ -196,15 +196,12 @@ export function ProfileReposSection({ repos, username }: ProfileReposSectionProp
                   {repo.name}
                 </p>
                 <p
+                  className="line-clamp-2"
                   style={{
                     fontSize: "13px",
                     color: "var(--color-ink-mute)",
                     margin: 0,
                     lineHeight: 1.45,
-                    display: "-webkit-box",
-                    WebkitLineClamp: 2,
-                    WebkitBoxOrient: "vertical" as const,
-                    overflow: "hidden",
                     minHeight: "38px",
                   }}
                 >


### PR DESCRIPTION
## Summary

This PR updates the repository description in `ProfileReposSection` to use Tailwind's `line-clamp-2` utility instead of the existing inline WebKit line-clamp styles. This keeps long repository descriptions from stretching the repository cards while preserving a consistent layout.

## Related Issue

Closes #327

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Chore / dependency update

## Changes Made

- Replaced the inline WebKit line-clamp styles with Tailwind's `line-clamp-2` utility.
- Preserved the existing spacing and typography.
- Kept repository cards at a consistent height when descriptions are long.

## AI Usage

- [x] I used AI for coding (ChatGPT) and I fully understand every change I made, including which functions I changed, why I changed them, and what side effects they could create

Used ChatGPT for guidance.

## Screenshots (if UI change)

N/A

## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with `main`
- [x] Code works locally and I have tested it
- [x] No `console.log` left in `src/`
- [ ] If schema changed — both `schema.sql` and a new migration file are included
- [x] If this is a UI change — I read `DESIGN.md` and followed the design system (colors, spacing, typography, components)
- [ ] Docs updated if needed
- [x] PR title follows Conventional Commits format (`feat:`, `fix:`, `docs:`, etc.)
- [x] This PR description is written in my own words

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved repository description display by consistently limiting descriptions to two lines.
  * Preserved existing typography and spacing while simplifying the visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->