### PR TITLE
fix(explore): keep leaderboard rank cell aligned across emoji and numeric ranks (closes #320)

### DIFF
--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -144,8 +144,7 @@ export default async function ExplorePage({ searchParams }: ExplorePageProps) {
                 const rowData = row as any;
                 const name = isOrg ? rowData.name : (rowData.name || rowData.username);
                 const sub = isOrg ? `@${rowData.slug}` : `@${rowData.username}`;
-               // Replace line 171 with this:
-const avatar = rowData.avatar_url || `https://github.com/${isOrg ? encodeURIComponent(rowData.slug) : encodeURIComponent(rowData.username)}.png`;
+                const avatar = rowData.avatar_url || `https://github.com/${isOrg ? encodeURIComponent(rowData.slug) : encodeURIComponent(rowData.username)}.png`;
                 const score = typeof rowData.score === "number" ? rowData.score : 0;
                 const isTop = rank <= 3;
 
@@ -158,7 +157,7 @@ const avatar = rowData.avatar_url || `https://github.com/${isOrg ? encodeURIComp
   style={{ display: "flex", alignItems: "center", gap: "16px", padding: "14px 18px", border: "1px solid var(--color-hairline)", borderRadius: "12px", textDecoration: "none", background: "var(--color-canvas-soft)" }}
 >
                       {/* Rank Indicator */}
-                      <span aria-label={`Rank ${rank}`} style={{ minWidth: "32px", fontSize: "16px", fontWeight: 600, color: isTop ? "var(--color-primary)" : "var(--color-ink-mute)", textAlign: "center", flexShrink: 0 }}>
+                      <span aria-label={`Rank ${rank}`} style={{ minWidth: "32px", fontSize: "16px", fontWeight: 600, color: isTop ? "var(--color-primary)" : "var(--color-ink-mute)", flexShrink: 0, display: "inline-flex", alignItems: "center", justifyContent: "center", lineHeight: 1 }}>
                         {rank === 1 ? "🥇" : rank === 2 ? "🥈" : rank === 3 ? "🥉" : rank}
                       </span>
 


### PR DESCRIPTION
## Summary

Fixes the vertical alignment of the leaderboard rank cell (#320). Worth flagging up front that the issue's
details didn't match the code, so this targets a different file than the one named — I've explained the
reasoning on the issue as well.

- `src/components/LeaderboardTable.tsx` doesn't exist; the leaderboard is `src/app/explore/page.tsx` (the
  "Leaderboard" nav link points at `/explore`).
- The row container there already had `alignItems: "center"`, so the change the issue describes was
  already in place.

What does cause an offset on *some* rows: the rank cell renders 🥇🥈🥉 for ranks 1-3 and plain digits for
the rest. Emoji resolve to a colour-emoji font whose vertical metrics differ from the body font, so the
rank span's line box isn't the same height on the top-3 rows as on the others. The score span directly
below already guards against this with `lineHeight: 1`; the rank span didn't.

## Related Issue

Closes #320

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Chore / dependency update

## Changes Made

- **`src/app/explore/page.tsx`** — the rank cell now centres its glyph in a deterministic box:
  `display: inline-flex` with `alignItems`/`justifyContent: center` and `lineHeight: 1`, so the rendered
  character sits in the same place whichever font supplies it. `textAlign: "center"` was dropped in the
  same edit because it has no effect on a flex container; `justifyContent` replaces it.
- Same file, two lines up: removed a stray `// Replace line 171 with this:` comment and re-indented the
  `const avatar` line, which had been committed at column 0. Small, but it's inside the block this PR
  touches.

## AI Usage

- [ ] I did not use AI for any part of the code in this PR
- [x] I used AI for coding (specify which tool below) and I fully understand every change I made

Used Claude. On side effects: switching the rank span to `inline-flex` means its children are flex items,
which is why `textAlign` was replaced rather than kept. `minWidth: 32px` and `flexShrink: 0` are unchanged,
so the column width and the row layout are the same as before.

## Screenshots (if UI change)

Rank cell, avatar, name, and score all sit on a consistent centre line. Note the mock ships two fixtures,
so both visible ranks are medal emoji — the digit-rank case isn't exercised by the default fixtures.

<img width="1918" height="996" alt="image" src="https://github.com/user-attachments/assets/f311e5a7-96e1-45dc-baff-783f3810cf83" />

## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with `main`
- [ ] Code works locally and I have tested it
- [x] No `console.log` left in `src/`
- [ ] If schema changed — both `schema.sql` and a new migration file are included
- [x] If this is a UI change — I read `DESIGN.md` and followed the design system (colors, spacing, typography, components)
- [ ] Docs updated if needed
- [x] PR title follows Conventional Commits format
- [x] This PR description is written in my own words

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved leaderboard rank indicator alignment and presentation.
  * Preserved existing contributor and organization avatar and rank displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->