### PR TITLE
style: replace hardcoded UI colors with design system tokens

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -19,8 +19,8 @@ const primaryButton: CSSProperties = {
   minWidth: "130px",
   padding: "10px 28px",
   borderRadius: "8px",
-  backgroundColor: "#3ecf8e",
-  color: "#171717",
+  backgroundColor: "var(--color-primary)",
+  color: "var(--color-on-primary)",
   fontSize: "16px",
   fontWeight: 600,
   textDecoration: "none",
@@ -30,7 +30,7 @@ export default function NotFound() {
   return (
     <main
       style={{
-        backgroundColor: "#ffffff",
+        backgroundColor: "var(--color-canvas)",
         minHeight: "100vh",
         display: "flex",
         alignItems: "center",
@@ -130,7 +130,7 @@ export default function NotFound() {
             fontSize: "72px",
             fontWeight: 700,
             lineHeight: 1,
-            color: "#3ecf8e",
+            color: "var(--color-primary)",
           }}
         >
           404
@@ -140,12 +140,12 @@ export default function NotFound() {
             marginTop: "16px",
             fontSize: "24px",
             fontWeight: 600,
-            color: "#171717",
+            color: "var(--color-ink)",
           }}
         >
           Page not found
         </h1>
-        <p style={{ marginTop: "12px", fontSize: "16px", color: "#707070" }}>
+        <p style={{ marginTop: "12px", fontSize: "16px",color: "var(--color-ink-mute)" }}>
           The page you are looking for does not exist or may have moved.
         </p>
         <div style={{ display: "flex", justifyContent: "center", marginTop: "28px" }}>


### PR DESCRIPTION
## 📋 Summary

This PR replaces hardcoded UI color values in the global **404 (`not-found`) page** with the project's existing semantic design system tokens.

The goal is to improve consistency across the application, simplify future theme updates, and encourage reuse of the centralized color system without changing the existing UI.

**Closes #497**

---

## ✨ Changes Made

- Replaced hardcoded UI colors with existing semantic design tokens.
- Updated the primary button to use:
  - `--color-primary`
  - `--color-on-primary`
- Replaced the page background with `--color-canvas`.
- Replaced heading text color with `--color-ink`.
- Replaced muted description text with `--color-ink-mute`.
- Preserved the current appearance without introducing any new design tokens.
- Left SVG illustration colors unchanged since they are part of the artwork rather than semantic UI colors.

---

## 🎨 Design Tokens Used

| Design Token | Purpose |
|--------------|---------|
| `--color-primary` | Primary button background |
| `--color-on-primary` | Primary button text |
| `--color-canvas` | Page background |
| `--color-ink` | Heading text |
| `--color-ink-mute` | Description text |

---

## 🧪 Testing

- [x] Verified the application builds successfully.
- [x] Confirmed the page maintains the same visual appearance.
- [x] Verified only semantic UI colors were replaced.
- [x] Confirmed no new design tokens or hardcoded UI colors were introduced.

---

## ✅ Checklist

- [x] Uses existing design system tokens.
- [x] Does not introduce new color tokens.
- [x] Preserves the existing UI appearance.
- [x] No unrelated changes included.
- [x] Ready for review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the 404 page to use the app’s color palette for a more consistent visual appearance.
  * Preserved the existing illustration, messaging, and “Back to home” navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->