### PR TITLE
feat(compare): add multi-axis contribution radar chart (closes #562)

### DIFF
--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -16,6 +16,7 @@ import { getProfileByUsername } from "@/lib/db";
 import type { ContributorStats, Repo } from "@/types";
 import { CompareForm } from "@/components/profile/CompareForm";
 import { CompareCharts } from "@/components/profile/CompareCharts";
+import { CompareRadarChart } from "@/components/profile/CompareRadarChart";
 
 // Runtime managed by @opennextjs/cloudflare
 
@@ -503,6 +504,23 @@ export default async function ComparePage({ searchParams }: ComparePageProps) {
                   </div>
                 );
               })}
+            </div>
+          )}
+
+          {profileA && profileB && (
+            <div style={{ marginTop: "40px" }}>
+              <CompareRadarChart
+                userA={{
+                  username: a,
+                  stats: profileA.stats,
+                  repos: profileA.repos,
+                }}
+                userB={{
+                  username: b,
+                  stats: profileB.stats,
+                  repos: profileB.repos,
+                }}
+              />
             </div>
           )}
 

--- a/src/components/profile/CompareRadarChart.tsx
+++ b/src/components/profile/CompareRadarChart.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import {
+  ResponsiveContainer,
+  RadarChart,
+  PolarGrid,
+  PolarAngleAxis,
+  PolarRadiusAxis,
+  Radar,
+  Tooltip,
+  Legend,
+} from "recharts";
+import { buildRadarData, isRadarEmpty, type RadarMetricInput } from "@/lib/radar-metrics";
+
+interface CompareRadarChartProps {
+  userA: RadarMetricInput;
+  userB: RadarMetricInput;
+}
+
+/**
+ * Palette per DESIGN.md: a single emerald primary is the only chromatic event,
+ * everything else stays on the monochrome grey ladder. Contributor A takes the
+ * emerald, contributor B the ink-mute grey.
+ */
+const COLOR_A = "#3ecf8e";
+const COLOR_B = "#707070";
+
+interface TooltipPayloadEntry {
+  payload?: {
+    metric?: string;
+    aRaw?: number;
+    bRaw?: number;
+  };
+}
+
+interface RadarTooltipProps {
+  active?: boolean;
+  payload?: TooltipPayloadEntry[];
+  usernameA: string;
+  usernameB: string;
+}
+
+/**
+ * Reports the raw metric values rather than the normalised percentages the
+ * chart plots. The normalisation exists to make the shape readable; a reader
+ * hovering an axis wants the real number.
+ */
+const RadarTooltip = ({
+  active,
+  payload,
+  usernameA,
+  usernameB,
+}: RadarTooltipProps) => {
+  if (!active || !payload?.length) return null;
+
+  const point = payload[0]?.payload;
+  if (!point) return null;
+
+  const rowStyle: React.CSSProperties = {
+    display: "flex",
+    alignItems: "center",
+    gap: "8px",
+    fontSize: "12px",
+    color: "var(--color-ink)",
+  };
+
+  const swatch = (color: string): React.CSSProperties => ({
+    width: "8px",
+    height: "8px",
+    borderRadius: "2px",
+    backgroundColor: color,
+    flexShrink: 0,
+  });
+
+  return (
+    <div
+      style={{
+        backgroundColor: "var(--color-canvas)",
+        border: "1px solid var(--color-hairline)",
+        borderRadius: "8px",
+        padding: "10px 12px",
+        boxShadow: "0 2px 8px rgba(0,0,0,0.06)",
+      }}
+    >
+      <p
+        style={{
+          fontSize: "12px",
+          fontWeight: 600,
+          color: "var(--color-ink)",
+          margin: "0 0 6px 0",
+        }}
+      >
+        {point.metric}
+      </p>
+      <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+        <div style={rowStyle}>
+          <span style={swatch(COLOR_A)} />
+          <span>
+            {usernameA}: <strong>{(point.aRaw ?? 0).toLocaleString("en-US")}</strong>
+          </span>
+        </div>
+        <div style={rowStyle}>
+          <span style={swatch(COLOR_B)} />
+          <span>
+            {usernameB}: <strong>{(point.bRaw ?? 0).toLocaleString("en-US")}</strong>
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+/**
+ * Multi-axis comparison of two contributors.
+ *
+ * A bar chart ranks each metric independently; a radar makes the overall shape
+ * legible, so a reviewer-heavy contributor and a commit-heavy one produce
+ * visibly different polygons rather than two similar-looking bar groups.
+ */
+export function CompareRadarChart({ userA, userB }: CompareRadarChartProps) {
+  const data = buildRadarData(userA, userB);
+  const empty = isRadarEmpty(data);
+
+  return (
+    <div
+      style={{
+        border: "1px solid var(--color-hairline)",
+        borderRadius: "12px",
+        padding: "24px",
+        backgroundColor: "var(--color-canvas-soft)",
+      }}
+    >
+      <h3
+        style={{
+          fontSize: "16px",
+          fontWeight: 600,
+          color: "var(--color-ink)",
+          margin: "0 0 4px 0",
+        }}
+      >
+        Contribution Profile Shape
+      </h3>
+      <p
+        style={{
+          fontSize: "13px",
+          color: "var(--color-ink-mute)",
+          margin: "0 0 20px 0",
+        }}
+      >
+        Each axis is scaled against the higher of the two contributors, so the
+        leader on a metric reaches the edge. Hover any axis for raw totals.
+      </p>
+
+      {empty ? (
+        <p
+          style={{
+            fontSize: "14px",
+            color: "var(--color-ink-mute)",
+            textAlign: "center",
+            padding: "48px 0",
+            margin: 0,
+          }}
+        >
+          No contribution data available to compare.
+        </p>
+      ) : (
+        <div style={{ width: "100%", height: 360 }}>
+          <ResponsiveContainer width="100%" height="100%">
+            <RadarChart data={data} outerRadius="72%">
+              <PolarGrid stroke="var(--color-hairline)" />
+              <PolarAngleAxis
+                dataKey="metric"
+                tick={{ fill: "var(--color-ink-mute)", fontSize: 12 }}
+              />
+              <PolarRadiusAxis
+                angle={90}
+                domain={[0, 100]}
+                tick={false}
+                axisLine={false}
+              />
+              <Tooltip
+                content={
+                  <RadarTooltip
+                    usernameA={userA.username}
+                    usernameB={userB.username}
+                  />
+                }
+              />
+              <Legend verticalAlign="bottom" height={32} />
+              <Radar
+                name={userA.username}
+                dataKey="a"
+                stroke={COLOR_A}
+                fill={COLOR_A}
+                fillOpacity={0.28}
+              />
+              <Radar
+                name={userB.username}
+                dataKey="b"
+                stroke={COLOR_B}
+                fill={COLOR_B}
+                fillOpacity={0.18}
+              />
+            </RadarChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+
+      <p
+        style={{
+          fontSize: "11px",
+          color: "var(--color-ink-mute-2)",
+          margin: "12px 0 0 0",
+        }}
+      >
+        Repo Stars counts stargazers across each contributor&apos;s top
+        repositories, measured identically for both.
+      </p>
+    </div>
+  );
+}

--- a/src/components/profile/CompareRadarChart.tsx
+++ b/src/components/profile/CompareRadarChart.tsx
@@ -21,9 +21,15 @@ interface CompareRadarChartProps {
  * Palette per DESIGN.md: a single emerald primary is the only chromatic event,
  * everything else stays on the monochrome grey ladder. Contributor A takes the
  * emerald, contributor B the ink-mute grey.
+ *
+ * Referenced as design tokens rather than literal hex so the chart follows the
+ * theme: `--color-ink-mute` resolves to #707070 in light mode and #a3a3a3 in
+ * dark, where the lighter grey is what stays legible. The existing recharts
+ * usage in CompareCharts.tsx already passes `var(--color-*)` into SVG stroke
+ * props, so this follows a pattern the codebase has proven works.
  */
-const COLOR_A = "#3ecf8e";
-const COLOR_B = "#707070";
+const COLOR_A = "var(--color-primary)";
+const COLOR_B = "var(--color-ink-mute)";
 
 interface TooltipPayloadEntry {
   payload?: {
@@ -45,7 +51,7 @@ interface RadarTooltipProps {
  * chart plots. The normalisation exists to make the shape readable; a reader
  * hovering an axis wants the real number.
  */
-const RadarTooltip = ({
+export const RadarTooltip = ({
   active,
   payload,
   usernameA,

--- a/src/components/profile/__tests__/CompareRadarChart.test.tsx
+++ b/src/components/profile/__tests__/CompareRadarChart.test.tsx
@@ -1,0 +1,218 @@
+// Registers jest-dom's matchers *and* their TypeScript declarations. The shared
+// vitest.setup.ts calls expect.extend, which works at runtime, but does not
+// declare the matcher types — no existing test used DOM matchers, so this is
+// the first place it matters. Importing here keeps the fix scoped to this file
+// rather than changing shared test config.
+import "@testing-library/jest-dom/vitest";
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { ContributorStats, Repo } from "@/types";
+
+/**
+ * Component tests for the comparison radar.
+ *
+ * Recharts measures its container to decide what to draw, and jsdom reports
+ * every element as zero-sized, so `ResponsiveContainer` renders nothing at all
+ * under test. Stubbing it with a fixed-size wrapper is the standard way round
+ * that and lets the chart's own children mount.
+ *
+ * Even then the SVG internals are not worth asserting on — they are recharts'
+ * implementation, not ours. What these tests pin is the part this component
+ * actually owns: the empty-state branch, the explanatory copy, the derivation
+ * footnote, and the tooltip's raw-value output.
+ */
+vi.mock("recharts", async () => {
+  const actual = await vi.importActual<typeof import("recharts")>("recharts");
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+      <div style={{ width: 800, height: 400 }}>{children}</div>
+    ),
+  };
+});
+
+const { CompareRadarChart, RadarTooltip } = await import(
+  "../CompareRadarChart"
+);
+
+const stats = (
+  totalCommits = 0,
+  totalPRs = 0,
+  totalReviews = 0,
+  totalIssues = 0,
+): ContributorStats => ({
+  totalCommits,
+  totalPRs,
+  totalReviews,
+  totalIssues,
+  totalContributions: totalCommits + totalPRs + totalReviews + totalIssues,
+});
+
+const repo = (stars: number): Repo =>
+  ({
+    name: "r",
+    description: null,
+    stars,
+    forks: 0,
+    language: null,
+    languageColor: null,
+    url: "",
+    topics: [],
+  }) as Repo;
+
+beforeAll(() => {
+  // Recharts warns about zero-size containers under jsdom; the stub above
+  // handles rendering, and the noise obscures real failures.
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+describe("CompareRadarChart", () => {
+  const userA = {
+    username: "alice",
+    stats: stats(1000, 50, 200, 10),
+    repos: [repo(500)],
+  };
+  const userB = {
+    username: "bob",
+    stats: stats(500, 100, 20, 40),
+    repos: [repo(250)],
+  };
+
+  it("renders the section heading", () => {
+    render(<CompareRadarChart userA={userA} userB={userB} />);
+    expect(screen.getByText("Contribution Profile Shape")).toBeInTheDocument();
+  });
+
+  it("explains that axes are scaled, so a reader is not misled by the shape", () => {
+    render(<CompareRadarChart userA={userA} userB={userB} />);
+    expect(screen.getByText(/scaled against the higher/i)).toBeInTheDocument();
+  });
+
+  it("discloses that Repo Stars is derived from top repositories", () => {
+    render(<CompareRadarChart userA={userA} userB={userB} />);
+    expect(screen.getByText(/top\s+repositories/i)).toBeInTheDocument();
+  });
+
+  it("shows an empty state when neither contributor has any data", () => {
+    const empty = { username: "x", stats: stats(), repos: [] };
+    render(<CompareRadarChart userA={empty} userB={{ ...empty, username: "y" }} />);
+    expect(
+      screen.getByText("No contribution data available to compare."),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show the empty state when either contributor has data", () => {
+    const empty = { username: "x", stats: stats(), repos: [] };
+    render(
+      <CompareRadarChart
+        userA={{ ...empty, stats: stats(1) }}
+        userB={{ ...empty, username: "y" }}
+      />,
+    );
+    expect(
+      screen.queryByText("No contribution data available to compare."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps the derivation footnote visible in the empty state too", () => {
+    const empty = { username: "x", stats: stats(), repos: [] };
+    render(<CompareRadarChart userA={empty} userB={{ ...empty, username: "y" }} />);
+    expect(screen.getByText(/top\s+repositories/i)).toBeInTheDocument();
+  });
+
+  it("renders without throwing when stats and repos are missing", () => {
+    const broken = { username: "b" } as unknown as typeof userA;
+    expect(() =>
+      render(<CompareRadarChart userA={broken} userB={broken} />),
+    ).not.toThrow();
+  });
+});
+
+describe("RadarTooltip", () => {
+  const payload = [
+    { payload: { metric: "Code Reviews", aRaw: 200, bRaw: 20 } },
+  ];
+
+  it("renders nothing when inactive", () => {
+    const { container } = render(
+      <RadarTooltip
+        active={false}
+        payload={payload}
+        usernameA="alice"
+        usernameB="bob"
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when there is no payload", () => {
+    const { container } = render(
+      <RadarTooltip active payload={[]} usernameA="alice" usernameB="bob" />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("names the hovered metric", () => {
+    render(
+      <RadarTooltip
+        active
+        payload={payload}
+        usernameA="alice"
+        usernameB="bob"
+      />,
+    );
+    expect(screen.getByText("Code Reviews")).toBeInTheDocument();
+  });
+
+  it("reports raw totals for both contributors, not the normalised values", () => {
+    render(
+      <RadarTooltip
+        active
+        payload={payload}
+        usernameA="alice"
+        usernameB="bob"
+      />,
+    );
+    // The chart plots 100 and 10 for these; the tooltip must show 200 and 20.
+    expect(screen.getByText("200")).toBeInTheDocument();
+    expect(screen.getByText("20")).toBeInTheDocument();
+    expect(screen.getByText(/alice/)).toBeInTheDocument();
+    expect(screen.getByText(/bob/)).toBeInTheDocument();
+  });
+
+  it("thousand-separates large totals", () => {
+    render(
+      <RadarTooltip
+        active
+        payload={[{ payload: { metric: "Commits", aRaw: 12345, bRaw: 0 } }]}
+        usernameA="alice"
+        usernameB="bob"
+      />,
+    );
+    expect(screen.getByText("12,345")).toBeInTheDocument();
+  });
+
+  it("falls back to zero when a raw value is absent", () => {
+    render(
+      <RadarTooltip
+        active
+        payload={[{ payload: { metric: "Issues Opened" } }]}
+        usernameA="alice"
+        usernameB="bob"
+      />,
+    );
+    expect(screen.getAllByText("0")).toHaveLength(2);
+  });
+
+  it("renders nothing when the payload entry has no data", () => {
+    const { container } = render(
+      <RadarTooltip
+        active
+        payload={[{}]}
+        usernameA="alice"
+        usernameB="bob"
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/lib/__tests__/radar-metrics.test.ts
+++ b/src/lib/__tests__/radar-metrics.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildRadarData,
+  normalizePair,
+  sumRepoStars,
+  isRadarEmpty,
+  type RadarMetricInput,
+} from "../radar-metrics";
+import type { ContributorStats, Repo } from "@/types";
+
+const stats = (over: Partial<ContributorStats> = {}): ContributorStats => ({
+  totalCommits: 0,
+  totalPRs: 0,
+  totalIssues: 0,
+  totalReviews: 0,
+  totalContributions: 0,
+  ...over,
+});
+
+const repo = (stars: number, name = "r"): Repo =>
+  ({
+    name,
+    description: null,
+    stars,
+    forks: 0,
+    language: null,
+    languageColor: null,
+    url: "",
+    topics: [],
+  }) as Repo;
+
+const user = (
+  username: string,
+  over: Partial<ContributorStats> = {},
+  repos: Repo[] = [],
+): RadarMetricInput => ({ username, stats: stats(over), repos });
+
+describe("sumRepoStars", () => {
+  it("sums stars across repositories", () => {
+    expect(sumRepoStars([repo(10), repo(5), repo(1)])).toBe(16);
+  });
+
+  it("returns zero for an empty list", () => {
+    expect(sumRepoStars([])).toBe(0);
+  });
+
+  it("tolerates a missing or malformed list", () => {
+    expect(sumRepoStars(null)).toBe(0);
+    expect(sumRepoStars(undefined)).toBe(0);
+    expect(sumRepoStars({} as unknown as Repo[])).toBe(0);
+  });
+
+  it("ignores non-numeric and negative star counts", () => {
+    const dirty = [
+      repo(5),
+      { ...repo(0), stars: undefined } as unknown as Repo,
+      { ...repo(0), stars: -3 } as unknown as Repo,
+      { ...repo(0), stars: Number.NaN } as unknown as Repo,
+    ];
+    expect(sumRepoStars(dirty)).toBe(5);
+  });
+});
+
+describe("normalizePair", () => {
+  it("gives the larger value the full scale", () => {
+    expect(normalizePair(200, 100)).toEqual({ a: 100, b: 50 });
+  });
+
+  it("is symmetric", () => {
+    expect(normalizePair(100, 200)).toEqual({ a: 50, b: 100 });
+  });
+
+  it("gives both full scale when equal", () => {
+    expect(normalizePair(42, 42)).toEqual({ a: 100, b: 100 });
+  });
+
+  it("returns zero for both when neither has any, rather than NaN", () => {
+    // Dividing by a zero maximum would produce NaN; treating "neither has any
+    // reviews" as a full score on both sides would be misleading.
+    expect(normalizePair(0, 0)).toEqual({ a: 0, b: 0 });
+  });
+
+  it("handles one side being zero", () => {
+    expect(normalizePair(50, 0)).toEqual({ a: 100, b: 0 });
+    expect(normalizePair(0, 50)).toEqual({ a: 0, b: 100 });
+  });
+
+  it("coerces negative and non-finite input to zero", () => {
+    expect(normalizePair(-10, 10)).toEqual({ a: 0, b: 100 });
+    expect(normalizePair(Number.NaN, 10)).toEqual({ a: 0, b: 100 });
+    expect(normalizePair(Number.POSITIVE_INFINITY, 10)).toEqual({ a: 0, b: 100 });
+  });
+
+  it("never exceeds 100", () => {
+    for (const [a, b] of [
+      [1, 999999],
+      [999999, 1],
+      [7, 7],
+    ]) {
+      const result = normalizePair(a, b);
+      expect(result.a).toBeLessThanOrEqual(100);
+      expect(result.b).toBeLessThanOrEqual(100);
+      expect(result.a).toBeGreaterThanOrEqual(0);
+      expect(result.b).toBeGreaterThanOrEqual(0);
+    }
+  });
+});
+
+describe("buildRadarData", () => {
+  const a = user("alice", {
+    totalCommits: 1000,
+    totalPRs: 50,
+    totalReviews: 200,
+    totalIssues: 10,
+  }, [repo(500)]);
+
+  const b = user("bob", {
+    totalCommits: 500,
+    totalPRs: 100,
+    totalReviews: 20,
+    totalIssues: 40,
+  }, [repo(100), repo(150)]);
+
+  it("returns the five axes the issue specifies, in order", () => {
+    expect(buildRadarData(a, b).map((d) => d.metric)).toEqual([
+      "Commits",
+      "Pull Requests",
+      "Code Reviews",
+      "Issues Opened",
+      "Repo Stars",
+    ]);
+  });
+
+  it("normalises each axis independently", () => {
+    const data = buildRadarData(a, b);
+    // Alice leads commits 1000 v 500; Bob leads PRs 100 v 50.
+    expect(data[0]).toMatchObject({ a: 100, b: 50 });
+    expect(data[1]).toMatchObject({ a: 50, b: 100 });
+  });
+
+  it("preserves raw values for the tooltip", () => {
+    const data = buildRadarData(a, b);
+    expect(data[0]).toMatchObject({ aRaw: 1000, bRaw: 500 });
+    expect(data[2]).toMatchObject({ aRaw: 200, bRaw: 20 });
+  });
+
+  it("derives the stars axis by summing repositories", () => {
+    const stars = buildRadarData(a, b)[4];
+    expect(stars).toMatchObject({ aRaw: 500, bRaw: 250 });
+    expect(stars.a).toBe(100);
+    expect(stars.b).toBe(50);
+  });
+
+  it("does not let a large axis flatten the others", () => {
+    // The whole point of normalising: commits dwarf reviews numerically, but
+    // the leader on each axis must still reach the outer edge.
+    const spike = user("spike", { totalCommits: 100000, totalReviews: 5 });
+    const even = user("even", { totalCommits: 1, totalReviews: 10 });
+    const data = buildRadarData(spike, even);
+    expect(data[0].a).toBe(100); // commits leader
+    expect(data[2].b).toBe(100); // reviews leader, despite tiny raw numbers
+  });
+
+  it("keeps all five axes even when both contributors score zero on some", () => {
+    const data = buildRadarData(user("x"), user("y"));
+    expect(data).toHaveLength(5);
+    expect(data.every((d) => d.a === 0 && d.b === 0)).toBe(true);
+  });
+
+  it("survives missing stats and repos without throwing", () => {
+    const broken = { username: "b", stats: undefined, repos: undefined } as unknown as RadarMetricInput;
+    expect(() => buildRadarData(broken, broken)).not.toThrow();
+    expect(buildRadarData(broken, broken)).toHaveLength(5);
+  });
+});
+
+describe("isRadarEmpty", () => {
+  it("is true when every axis is zero for both", () => {
+    expect(isRadarEmpty(buildRadarData(user("x"), user("y")))).toBe(true);
+  });
+
+  it("is false when any axis has data", () => {
+    const data = buildRadarData(user("x", { totalCommits: 1 }), user("y"));
+    expect(isRadarEmpty(data)).toBe(false);
+  });
+});

--- a/src/lib/radar-metrics.ts
+++ b/src/lib/radar-metrics.ts
@@ -1,0 +1,113 @@
+import type { ContributorStats, Repo } from "@/types";
+
+/**
+ * Normalisation for the contributor comparison radar chart.
+ *
+ * A radar plots every axis on one shared scale, so raw contribution counts do
+ * not work: commits routinely run into the thousands while code reviews sit in
+ * the dozens, and the polygon collapses into a spike on the commit axis with
+ * everything else pinned near the origin. That hides exactly the archetype
+ * differences the chart exists to show.
+ *
+ * Each axis is therefore scaled against the larger of the two contributors'
+ * values on that axis, so the leader on any metric reaches the outer edge and
+ * the other is drawn in proportion. Raw values are carried alongside so the
+ * tooltip can report real numbers rather than percentages.
+ */
+
+export interface RadarMetricInput {
+  username: string;
+  stats: ContributorStats;
+  repos: Repo[];
+}
+
+export interface RadarAxis {
+  /** Axis label shown on the chart. */
+  metric: string;
+  /** Normalised 0-100 value for contributor A. */
+  a: number;
+  /** Normalised 0-100 value for contributor B. */
+  b: number;
+  /** Unscaled value for contributor A, for the tooltip. */
+  aRaw: number;
+  /** Unscaled value for contributor B, for the tooltip. */
+  bRaw: number;
+}
+
+/**
+ * Sums stargazers across a contributor's repositories.
+ *
+ * Note this is not a contributor's total stars. The compare page fetches the
+ * six highest-starred repositories from a page of 100, so this is "stars across
+ * top repositories". Both contributors are measured the same way, which keeps
+ * the comparison fair, but the absolute figure is a floor rather than a total.
+ */
+export const sumRepoStars = (repos: Repo[] | null | undefined): number => {
+  if (!Array.isArray(repos)) return 0;
+  return repos.reduce((total, repo) => {
+    const stars = typeof repo?.stars === "number" && Number.isFinite(repo.stars)
+      ? repo.stars
+      : 0;
+    return total + Math.max(0, stars);
+  }, 0);
+};
+
+/** Guards against negatives and non-finite values arriving from the API. */
+const safeCount = (value: unknown): number => {
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) return 0;
+  return parsed;
+};
+
+/**
+ * Scales a pair of values against their own maximum.
+ *
+ * When both are zero the axis is drawn at zero for both rather than at the
+ * outer edge — dividing by a zero maximum would otherwise produce NaN, and
+ * treating "neither contributor has any reviews" as a full score on both sides
+ * would be actively misleading.
+ */
+export const normalizePair = (a: number, b: number): { a: number; b: number } => {
+  const safeA = safeCount(a);
+  const safeB = safeCount(b);
+  const max = Math.max(safeA, safeB);
+  if (max === 0) return { a: 0, b: 0 };
+  return {
+    a: Math.round((safeA / max) * 100),
+    b: Math.round((safeB / max) * 100),
+  };
+};
+
+/** The five axes, in the order the issue specifies. */
+const AXES: Array<{ metric: string; read: (_input: RadarMetricInput) => number }> = [
+  { metric: "Commits", read: (i) => safeCount(i.stats?.totalCommits) },
+  { metric: "Pull Requests", read: (i) => safeCount(i.stats?.totalPRs) },
+  { metric: "Code Reviews", read: (i) => safeCount(i.stats?.totalReviews) },
+  { metric: "Issues Opened", read: (i) => safeCount(i.stats?.totalIssues) },
+  { metric: "Repo Stars", read: (i) => sumRepoStars(i.repos) },
+];
+
+/**
+ * Builds the radar dataset for two contributors.
+ *
+ * Always returns all five axes, including ones where both contributors score
+ * zero — dropping empty axes would change the polygon's shape between profile
+ * pairs and make comparisons across pages incoherent.
+ */
+export const buildRadarData = (
+  userA: RadarMetricInput,
+  userB: RadarMetricInput,
+): RadarAxis[] =>
+  AXES.map(({ metric, read }) => {
+    const aRaw = read(userA);
+    const bRaw = read(userB);
+    const { a, b } = normalizePair(aRaw, bRaw);
+    return { metric, a, b, aRaw, bRaw };
+  });
+
+/**
+ * True when every axis is zero for both contributors, meaning the chart would
+ * render an empty polygon and is better replaced with a message.
+ */
+export const isRadarEmpty = (data: RadarAxis[]): boolean =>
+  data.every((axis) => axis.aRaw === 0 && axis.bRaw === 0);


### PR DESCRIPTION
## Summary

The `/compare` page already shows a stats table and a bar chart, but both rank
metrics one at a time. Neither tells you what kind of contributor someone is —
you can see that A has more commits and B has more reviews, but you have to
piece the picture together yourself.

A radar chart shows that shape directly. A review-heavy contributor and a
commit-heavy one produce visibly different polygons, which is the thing the
issue was actually asking for.

The interesting part was that raw numbers don't work on a radar. Commits run
into the thousands while code reviews sit in the dozens, so plotting the real
values collapses the whole shape into one spike on the commit axis and flattens
everything else against the middle — hiding exactly the difference the chart is
supposed to show. So each axis is scaled against whichever of the two
contributors is higher on that metric. Whoever leads an axis touches the outer
edge, the other is drawn in proportion, and the real numbers move into the
tooltip so nothing is lost.

Two things I had to work around. There's no stars field on `ContributorStats`,
so the Repo Stars axis is summed from the profile's repos — and since the
compare page only fetches the top six, that's stars across top repositories
rather than a true total. Both contributors are counted the same way so the
comparison is still fair, but I put a footnote on the chart rather than let it
imply something it isn't.

The other is colour. I used the emerald and grey the issue specifies, which is
what DESIGN.md asks for. The existing bar chart on the same page uses emerald
and purple for the same two people, so the page is now inconsistent with itself.
I left that file alone since it's outside this issue, but it's worth fixing one
way or the other.

## Related Issue

Closes #562

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Chore / dependency update

## Changes Made

- Added `src/lib/radar-metrics.ts` — normalisation logic kept out of the
  component so it can be unit tested without rendering. Each axis is scaled
  against the higher of the two contributors, so whoever leads a metric reaches
  the outer edge and the other is drawn in proportion.
- Added `src/components/profile/CompareRadarChart.tsx` — Recharts radar over
  Commits, Pull Requests, Code Reviews, Issues Opened and Repo Stars, with a
  custom tooltip reporting raw totals rather than the normalised percentages
  the chart plots.
- Added `src/lib/__tests__/radar-metrics.test.ts` — 20 tests covering
  normalisation, the stars derivation, and malformed API data.
- Wired the chart into `src/app/compare/page.tsx` above the existing bar chart.

Two decisions worth calling out:

- **Repo Stars is derived, not read.** `ContributorStats` has no stars field —
  it carries `totalCommits`, `totalPRs`, `totalIssues`, `totalReviews`,
  `totalContributions`. Stars live on `Repo`, and `fetchGitHubRepos` returns the
  six highest-starred repos from a page of 100. So this axis is *stars across
  top repositories*, not a contributor's total. Both contributors are measured
  identically so the comparison is fair, and the chart carries a footnote saying
  so rather than implying a total.

- **Palette.** I used `#3ecf8e` and `#707070` as the issue specifies, matching
  DESIGN.md — "single emerald primary as the only chromatic event; everything
  else is monochrome" (line 236), with `#707070` defined as Ink Mute (line 270).
  The existing `CompareCharts.tsx` on the same page uses `#3ecf8e` and `#6b01c2`
  (purple) for the same two contributors, so the page now colours the same people
  differently in two charts. I left that file alone since it's outside this
  issue — happy to align it in a follow-up, or here if you'd prefer one PR.

Edge cases handled: both-zero axes return 0 rather than NaN (dividing by a zero
maximum), all five axes always render so the polygon stays comparable between
profile pairs, malformed API data can't throw, and there's an empty state when
neither contributor has data.

## AI Usage

- [ ] I did not use AI for any part of the code in this PR
- [x] I used AI for coding (specify which tool below) and I fully understand
      every change I made, including which functions I changed, why I changed
      them, and what side effects they could create

Used Claude for coding.

## Screenshots (if UI change)

<img width="1918" height="786" alt="Screenshot 2026-07-26 012124" src="https://github.com/user-attachments/assets/7a7b2f30-fa2c-4230-b62a-862765394415" />
<img width="1919" height="776" alt="Screenshot 2026-07-26 012142" src="https://github.com/user-attachments/assets/e51158dd-5e9d-4dbf-9a32-ed9397265aa0" />
<img width="1914" height="977" alt="Screenshot 2026-07-26 012156" src="https://github.com/user-attachments/assets/8e076ef9-64b5-40e9-a53e-a404bb620332" />

## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with `main`
- [x] Code works locally and I have tested it
- [x] No `console.log` left in `src/`
- [x] If schema changed — both `schema.sql` and a new migration file are included
      (n/a — no schema change)
- [x] If this is a UI change — I read `DESIGN.md` and followed the design system
- [x] Docs updated if needed (n/a)
- [x] PR title follows Conventional Commits format
- [ ] This PR description is written in my own words

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added a radar chart for side-by-side contributor comparisons across commits, pull requests, reviews, open issues, and repository stars.
  - Axis values are normalized for clearer comparison, and hover tooltips show raw (non-normalized) totals.
  - Shows an empty state when both contributors have no contribution data.
- **Bug Fixes**
  - Improved resilience to missing, invalid, zero, and negative metric inputs during comparison.
- **Tests**
  - Added coverage for radar metrics calculations and the radar chart/tooltip UI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->