### PR TITLE
feat(explore): add language and score-tier filters with URL persistence (closes #564)

### DIFF
--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -632,7 +632,10 @@ export default async function ExplorePage({ searchParams }: ExplorePageProps) {
             hasNext={hasNext}
             hasPrev={hasPrev}
             baseUrl="/explore"
-            searchParams={{ q: searchQuery, type, sortBy }}
+            // Built from the same helper as the filter pills, so paging keeps
+            // the active language and score tier. Passing the raw params here
+            // would drop them and silently widen the results on page 2.
+            searchParams={buildExploreQuery(activeFilters)}
           />
         </div>
       </main>

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -9,6 +9,16 @@ import {
   type ExploreProfileSort,
 } from "@/lib/db";
 import { DiscoverPagination } from "@/components/discover/DiscoverPagination";
+import { POPULAR_LANGUAGES } from "@/lib/languages";
+import {
+  SCORE_TIERS,
+  normalizeLanguage,
+  normalizeScoreTier,
+  buildExploreQuery,
+  hasActiveFilters,
+  describeFilters,
+  type ExploreFilters,
+} from "@/lib/explore-filters";
 
 // Runtime managed by @opennextjs/cloudflare
 
@@ -19,6 +29,31 @@ export const metadata: Metadata = {
 };
 
 const PAGE_SIZE = 50;
+
+/**
+ * Filter pill styling. DESIGN.md treats the emerald primary as the only
+ * chromatic event, so an inactive pill is monochrome and the active one is the
+ * single point of colour.
+ */
+const pillStyle: React.CSSProperties = {
+  fontSize: "13px",
+  fontWeight: 500,
+  padding: "6px 12px",
+  borderRadius: "999px",
+  border: "1px solid var(--color-hairline)",
+  color: "var(--color-ink-mute)",
+  backgroundColor: "var(--color-canvas)",
+  textDecoration: "none",
+  lineHeight: 1.4,
+};
+
+const activePillStyle: React.CSSProperties = {
+  ...pillStyle,
+  fontWeight: 600,
+  color: "var(--color-on-primary)",
+  backgroundColor: "var(--color-primary)",
+  borderColor: "var(--color-primary)",
+};
 
 interface LeaderboardRow {
   username: string;
@@ -46,6 +81,8 @@ interface ExplorePageProps {
     q?: string;
     sortBy?: string;
     type?: string;
+    lang?: string;
+    minScore?: string;
   }>;
 }
 
@@ -54,6 +91,8 @@ async function fetchPage(
   searchQuery: string,
   sortBy: string,
   type: string,
+  lang: string | null,
+  minScore: number,
 ): Promise<{ rows: LeaderboardData[]; hasNext: boolean }> {
   const from = (page - 1) * PAGE_SIZE;
   const to = from + PAGE_SIZE;
@@ -67,6 +106,8 @@ async function fetchPage(
           sortBy: sortBy as ExploreProfileSort,
           from,
           to,
+          lang,
+          minScore,
         });
     if (error || !Array.isArray(data)) return { rows: [], hasNext: false };
     const hasNext = data.length > PAGE_SIZE;
@@ -82,6 +123,8 @@ export default async function ExplorePage({ searchParams }: ExplorePageProps) {
     q: qParam,
     sortBy: sortByParam,
     type: typeParam,
+    lang: langParam,
+    minScore: minScoreParam,
   } = await searchParams;
   const page = Math.max(1, Math.floor(Number(pageParam)) || 1);
   const searchQuery = typeof qParam === "string" ? qParam.trim() : "";
@@ -102,7 +145,28 @@ export default async function ExplorePage({ searchParams }: ExplorePageProps) {
       ? typeParam
       : "users";
 
-  const { rows, hasNext } = await fetchPage(page, searchQuery, sortBy, type);
+  // Organisations have no language or score-tier data, so those filters only
+  // apply to the contributor listing.
+  const lang = type === "users" ? normalizeLanguage(langParam) : null;
+  const minScore = type === "users" ? normalizeScoreTier(minScoreParam) : 0;
+
+  const activeFilters: ExploreFilters = {
+    type,
+    q: searchQuery,
+    sortBy,
+    lang,
+    minScore,
+    page,
+  };
+
+  const { rows, hasNext } = await fetchPage(
+    page,
+    searchQuery,
+    sortBy,
+    type,
+    lang,
+    minScore,
+  );
   const hasPrev = page > 1;
   const rankOffset = (page - 1) * PAGE_SIZE;
 
@@ -181,6 +245,12 @@ export default async function ExplorePage({ searchParams }: ExplorePageProps) {
             }}
           >
             <input type="hidden" name="type" value={type} />
+            {/* Without these, submitting a search would drop the active filter
+                pills and quietly widen the result set. */}
+            {lang && <input type="hidden" name="lang" value={lang} />}
+            {minScore > 0 && (
+              <input type="hidden" name="minScore" value={String(minScore)} />
+            )}
             <input
               type="text"
               name="q"
@@ -228,6 +298,122 @@ export default async function ExplorePage({ searchParams }: ExplorePageProps) {
             </button>
           </form>
 
+          {/* Filter pills — server-rendered links so every filtered view has a
+              shareable URL, rather than client state that vanishes on reload. */}
+          {type === "users" && (
+            <div style={{ marginBottom: "24px" }}>
+              <div
+                style={{
+                  display: "flex",
+                  flexWrap: "wrap",
+                  gap: "8px",
+                  alignItems: "center",
+                  marginBottom: "12px",
+                }}
+              >
+                <span
+                  style={{
+                    fontSize: "12px",
+                    fontWeight: 600,
+                    color: "var(--color-ink-mute)",
+                    textTransform: "uppercase",
+                    letterSpacing: "0.04em",
+                    marginRight: "4px",
+                  }}
+                >
+                  Language
+                </span>
+                <Link
+                  href={{
+                    pathname: "/explore",
+                    query: buildExploreQuery(activeFilters, { lang: null }),
+                  }}
+                  style={lang === null ? activePillStyle : pillStyle}
+                  aria-current={lang === null ? "true" : undefined}
+                >
+                  All
+                </Link>
+                {POPULAR_LANGUAGES.map((option) => (
+                  <Link
+                    key={option}
+                    href={{
+                      pathname: "/explore",
+                      query: buildExploreQuery(activeFilters, {
+                        // Clicking the active pill clears it, so a filter can
+                        // always be undone without hunting for a reset button.
+                        lang: lang === option ? null : option,
+                      }),
+                    }}
+                    style={lang === option ? activePillStyle : pillStyle}
+                    aria-current={lang === option ? "true" : undefined}
+                  >
+                    {option}
+                  </Link>
+                ))}
+              </div>
+
+              <div
+                style={{
+                  display: "flex",
+                  flexWrap: "wrap",
+                  gap: "8px",
+                  alignItems: "center",
+                }}
+              >
+                <span
+                  style={{
+                    fontSize: "12px",
+                    fontWeight: 600,
+                    color: "var(--color-ink-mute)",
+                    textTransform: "uppercase",
+                    letterSpacing: "0.04em",
+                    marginRight: "4px",
+                  }}
+                >
+                  Score
+                </span>
+                {SCORE_TIERS.map((tier) => (
+                  <Link
+                    key={tier.value}
+                    href={{
+                      pathname: "/explore",
+                      query: buildExploreQuery(activeFilters, {
+                        minScore: tier.value,
+                      }),
+                    }}
+                    style={
+                      minScore === tier.value ? activePillStyle : pillStyle
+                    }
+                    aria-current={minScore === tier.value ? "true" : undefined}
+                  >
+                    {tier.label}
+                  </Link>
+                ))}
+              </div>
+
+              {hasActiveFilters(activeFilters) && (
+                <p
+                  style={{
+                    fontSize: "13px",
+                    color: "var(--color-ink-mute)",
+                    margin: "16px 0 0 0",
+                  }}
+                >
+                  Showing {describeFilters(activeFilters)}.{" "}
+                  <Link
+                    href={{ pathname: "/explore", query: { type } }}
+                    style={{
+                      color: "var(--color-primary)",
+                      textDecoration: "none",
+                    }}
+                  >
+                    Clear all
+                  </Link>
+                </p>
+              )}
+            </div>
+          )}
+
           {rows.length === 0 ? (
             <div
               style={{
@@ -237,7 +423,11 @@ export default async function ExplorePage({ searchParams }: ExplorePageProps) {
                 textAlign: "center",
               }}
             >
-              <p>No results found.</p>
+              <p>
+                {hasActiveFilters(activeFilters)
+                  ? `No contributors match ${describeFilters(activeFilters)}.`
+                  : "No results found."}
+              </p>
             </div>
           ) : (
             <ol

--- a/src/components/discover/SearchFilters.tsx
+++ b/src/components/discover/SearchFilters.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useDebounce } from "@/hooks/useDebounce";
+import { POPULAR_LANGUAGES } from "@/lib/languages";
 
 const SORT_OPTIONS = [
   { value: "score", label: "Score" },
@@ -10,19 +11,6 @@ const SORT_OPTIONS = [
   { value: "contributions", label: "Contributions" },
   { value: "followers", label: "Followers" },
 ] as const;
-
-const POPULAR_LANGUAGES = [
-  "TypeScript",
-  "JavaScript",
-  "Python",
-  "Go",
-  "Rust",
-  "Java",
-  "C++",
-  "Ruby",
-  "PHP",
-  "Swift",
-];
 
 export function SearchFilters() {
   const router = useRouter();

--- a/src/lib/__tests__/explore-filters.test.ts
+++ b/src/lib/__tests__/explore-filters.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizeLanguage,
+  normalizeScoreTier,
+  buildExploreQuery,
+  hasActiveFilters,
+  describeFilters,
+  SCORE_TIERS,
+  type ExploreFilters,
+} from "../explore-filters";
+import { POPULAR_LANGUAGES } from "../languages";
+
+const filters = (over: Partial<ExploreFilters> = {}): ExploreFilters => ({
+  type: "users",
+  q: "",
+  sortBy: "score",
+  lang: null,
+  minScore: 0,
+  page: 1,
+  ...over,
+});
+
+describe("normalizeLanguage", () => {
+  it("accepts an offered language", () => {
+    expect(normalizeLanguage("TypeScript")).toBe("TypeScript");
+  });
+
+  it("accepts every offered language", () => {
+    for (const lang of POPULAR_LANGUAGES) {
+      expect(normalizeLanguage(lang), lang).toBe(lang);
+    }
+  });
+
+  it("returns canonical casing for a lowercased URL", () => {
+    // `top_languages @> array[lang]` is case-sensitive, so a bookmarked
+    // ?lang=typescript must still resolve to the stored "TypeScript".
+    expect(normalizeLanguage("typescript")).toBe("TypeScript");
+    expect(normalizeLanguage("RUST")).toBe("Rust");
+  });
+
+  it("handles languages with punctuation", () => {
+    expect(normalizeLanguage("c++")).toBe("C++");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(normalizeLanguage("  Go  ")).toBe("Go");
+  });
+
+  it("rejects a language that is not offered", () => {
+    expect(normalizeLanguage("COBOL")).toBeNull();
+    expect(normalizeLanguage("Brainfuck")).toBeNull();
+  });
+
+  it("rejects empty, whitespace and non-string input", () => {
+    expect(normalizeLanguage("")).toBeNull();
+    expect(normalizeLanguage("   ")).toBeNull();
+    expect(normalizeLanguage(null)).toBeNull();
+    expect(normalizeLanguage(undefined)).toBeNull();
+    expect(normalizeLanguage(42)).toBeNull();
+    expect(normalizeLanguage(["Go"])).toBeNull();
+  });
+
+  it("does not pass through injection-shaped input", () => {
+    expect(normalizeLanguage("Go'); drop table profiles;--")).toBeNull();
+    expect(normalizeLanguage("%")).toBeNull();
+  });
+});
+
+describe("normalizeScoreTier", () => {
+  it("accepts every offered tier", () => {
+    for (const tier of SCORE_TIERS) {
+      expect(normalizeScoreTier(String(tier.value)), tier.label).toBe(tier.value);
+    }
+  });
+
+  it("falls back to no filter for an unoffered number", () => {
+    expect(normalizeScoreTier("750")).toBe(0);
+    expect(normalizeScoreTier("999999")).toBe(0);
+  });
+
+  it("falls back to no filter for nonsense rather than erroring", () => {
+    expect(normalizeScoreTier("abc")).toBe(0);
+    expect(normalizeScoreTier("")).toBe(0);
+    expect(normalizeScoreTier(null)).toBe(0);
+    expect(normalizeScoreTier(undefined)).toBe(0);
+    expect(normalizeScoreTier(500)).toBe(0);
+  });
+
+  it("rejects negative values", () => {
+    expect(normalizeScoreTier("-100")).toBe(0);
+  });
+
+  it("trims whitespace", () => {
+    expect(normalizeScoreTier(" 500 ")).toBe(500);
+  });
+});
+
+describe("buildExploreQuery", () => {
+  it("omits defaults so shared URLs stay readable", () => {
+    expect(buildExploreQuery(filters())).toEqual({});
+  });
+
+  it("includes an active language", () => {
+    expect(buildExploreQuery(filters({ lang: "Rust" }))).toEqual({
+      lang: "Rust",
+    });
+  });
+
+  it("includes an active score tier as a string", () => {
+    expect(buildExploreQuery(filters({ minScore: 500 }))).toEqual({
+      minScore: "500",
+    });
+  });
+
+  it("omits a zero score tier", () => {
+    expect(buildExploreQuery(filters({ minScore: 0 }))).toEqual({});
+  });
+
+  it("preserves the search query when changing language", () => {
+    const result = buildExploreQuery(filters({ q: "alice" }), { lang: "Go" });
+    expect(result).toEqual({ q: "alice", lang: "Go" });
+  });
+
+  it("preserves a non-default sort when changing language", () => {
+    const result = buildExploreQuery(filters({ sortBy: "prs" }), {
+      lang: "Python",
+    });
+    expect(result).toEqual({ sortBy: "prs", lang: "Python" });
+  });
+
+  it("preserves a non-default type when changing language", () => {
+    const result = buildExploreQuery(filters({ type: "organizations" }), {
+      lang: "Java",
+    });
+    expect(result.type).toBe("organizations");
+  });
+
+  it("preserves language when changing score tier, and vice versa", () => {
+    expect(
+      buildExploreQuery(filters({ lang: "Rust" }), { minScore: 1000 }),
+    ).toEqual({ lang: "Rust", minScore: "1000" });
+    expect(
+      buildExploreQuery(filters({ minScore: 1000 }), { lang: "Rust" }),
+    ).toEqual({ lang: "Rust", minScore: "1000" });
+  });
+
+  it("clears a filter when the patch sets it empty", () => {
+    expect(buildExploreQuery(filters({ lang: "Rust" }), { lang: null })).toEqual(
+      {},
+    );
+    expect(
+      buildExploreQuery(filters({ minScore: 500 }), { minScore: 0 }),
+    ).toEqual({});
+  });
+
+  it("never carries pagination into a filter link", () => {
+    // Staying on page 4 while narrowing to two pages would look like a broken
+    // filter rather than the end of the list.
+    const result = buildExploreQuery(filters({ page: 4, lang: "Go" }), {
+      lang: "Rust",
+    });
+    expect(result).not.toHaveProperty("page");
+  });
+
+  it("carries every active filter together", () => {
+    const result = buildExploreQuery(
+      filters({
+        type: "organizations",
+        q: "alice",
+        sortBy: "prs",
+        lang: "Rust",
+        minScore: 500,
+      }),
+    );
+    expect(result).toEqual({
+      type: "organizations",
+      q: "alice",
+      sortBy: "prs",
+      lang: "Rust",
+      minScore: "500",
+    });
+  });
+});
+
+describe("hasActiveFilters", () => {
+  it("is false for the default view", () => {
+    expect(hasActiveFilters(filters())).toBe(false);
+  });
+
+  it("is true for any active filter", () => {
+    expect(hasActiveFilters(filters({ lang: "Go" }))).toBe(true);
+    expect(hasActiveFilters(filters({ minScore: 100 }))).toBe(true);
+    expect(hasActiveFilters(filters({ q: "alice" }))).toBe(true);
+  });
+
+  it("ignores sort and type, which are views rather than filters", () => {
+    expect(hasActiveFilters(filters({ sortBy: "prs" }))).toBe(false);
+    expect(hasActiveFilters(filters({ type: "organizations" }))).toBe(false);
+  });
+});
+
+describe("describeFilters", () => {
+  it("is empty when nothing is filtered", () => {
+    expect(describeFilters(filters())).toBe("");
+  });
+
+  it("names the language", () => {
+    expect(describeFilters(filters({ lang: "Rust" }))).toBe("Rust");
+  });
+
+  it("describes the score tier", () => {
+    expect(describeFilters(filters({ minScore: 500 }))).toBe("score 500+");
+  });
+
+  it("joins multiple filters", () => {
+    expect(
+      describeFilters(filters({ lang: "Go", minScore: 100, q: "alice" })),
+    ).toBe("Go · score 100+ · matching “alice”");
+  });
+});

--- a/src/lib/__tests__/explore-filters.test.ts
+++ b/src/lib/__tests__/explore-filters.test.ts
@@ -182,6 +182,40 @@ describe("buildExploreQuery", () => {
   });
 });
 
+describe("buildExploreQuery — pagination", () => {
+  // DiscoverPagination takes this object and adds `page` itself. If the object
+  // omitted the active filters, paging to page 2 would silently widen the
+  // results back to everything.
+  it("supplies every active filter for pagination links", () => {
+    const params = buildExploreQuery(
+      filters({ lang: "Rust", minScore: 500, q: "alice", sortBy: "prs" }),
+    );
+    expect(params.lang).toBe("Rust");
+    expect(params.minScore).toBe("500");
+    expect(params.q).toBe("alice");
+    expect(params.sortBy).toBe("prs");
+  });
+
+  it("leaves page out, since pagination sets it", () => {
+    expect(buildExploreQuery(filters({ lang: "Go", page: 3 }))).not.toHaveProperty(
+      "page",
+    );
+  });
+
+  it("round-trips through URLSearchParams the way pagination builds links", () => {
+    const params = new URLSearchParams(
+      buildExploreQuery(filters({ lang: "C++", minScore: 100 })),
+    );
+    params.set("page", "2");
+    const url = `/explore?${params.toString()}`;
+    // "C++" has to survive encoding or the filter breaks on the next page.
+    expect(url).toContain("lang=C%2B%2B");
+    expect(url).toContain("minScore=100");
+    expect(url).toContain("page=2");
+    expect(new URLSearchParams(url.split("?")[1]).get("lang")).toBe("C++");
+  });
+});
+
 describe("hasActiveFilters", () => {
   it("is false for the default view", () => {
     expect(hasActiveFilters(filters())).toBe(false);

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -139,11 +139,15 @@ export async function fetchExploreProfiles(opts: {
   sortBy: ExploreProfileSort;
   from: number;
   to: number;
+  /** Canonical language name, or null for no language filter. */
+  lang?: string | null;
+  /** Minimum score, or 0 for no score filter. */
+  minScore?: number;
 }): Promise<QueryResult<unknown[]>> {
   let query = supabase
     .from("profiles")
     .select(
-      "username, name, avatar_url, score, total_prs, total_issues, total_commits, score_delta_30_days",
+      "username, name, avatar_url, score, total_prs, total_issues, total_commits, score_delta_30_days, top_languages",
     )
     // Explore is a listing, so only public profiles belong in it. `unlisted` and `private` have
     // both opted out of being found.
@@ -153,6 +157,18 @@ export async function fetchExploreProfiles(opts: {
     query = query.or(
       `username.ilike.%${opts.searchQuery}%,name.ilike.%${opts.searchQuery}%`,
     );
+  }
+
+  if (opts.lang) {
+    // Array containment, matching the `top_languages @> array[lang]` predicate
+    // the `search_profiles` RPC uses for Discover, so both listings filter
+    // identically. The comparison is case-sensitive, which is why the caller
+    // normalises to GitHub's capitalisation first.
+    query = query.contains("top_languages", [opts.lang]);
+  }
+
+  if (opts.minScore && opts.minScore > 0) {
+    query = query.gte("score", opts.minScore);
   }
 
   let orderColumn = "score";

--- a/src/lib/explore-filters.ts
+++ b/src/lib/explore-filters.ts
@@ -1,0 +1,121 @@
+import { POPULAR_LANGUAGES } from "./languages";
+
+/**
+ * Filter parsing and URL construction for the Explore leaderboard.
+ *
+ * Explore is a server component, so its filters are plain links rather than
+ * client state. That has two consequences this module exists to handle:
+ *
+ *  - every filter value arrives as an untrusted query string and has to be
+ *    validated before it reaches a database query;
+ *  - every filter link has to carry the *other* active filters with it, or
+ *    picking a language would silently discard the current search and sort.
+ *
+ * Keeping both here means the rules can be unit tested without rendering a
+ * page or touching Supabase.
+ */
+
+/** Minimum-score buckets offered alongside the language filter. */
+export const SCORE_TIERS = [
+  { label: "Any score", value: 0 },
+  { label: "100+", value: 100 },
+  { label: "500+", value: 500 },
+  { label: "1000+", value: 1000 },
+  { label: "2500+", value: 2500 },
+] as const;
+
+const VALID_SCORES = new Set<number>(SCORE_TIERS.map((tier) => tier.value));
+
+/**
+ * Validates a language from the query string.
+ *
+ * Only the offered options are accepted. The value reaches an array
+ * containment predicate, so an allowlist is both the correct validation and
+ * the simplest: anything not on the list could not match a row anyway.
+ *
+ * Matching is case-insensitive on the way in but always returns the canonical
+ * capitalisation, because `profiles.top_languages` stores GitHub's casing and
+ * the containment operator is case-sensitive — a bookmarked
+ * `?lang=typescript` should still work.
+ */
+export const normalizeLanguage = (raw: unknown): string | null => {
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  if (trimmed === "") return null;
+  const match = POPULAR_LANGUAGES.find(
+    (lang) => lang.toLowerCase() === trimmed.toLowerCase(),
+  );
+  return match ?? null;
+};
+
+/**
+ * Validates a minimum-score tier from the query string.
+ *
+ * Returns 0 for anything unrecognised, which reads as "no score filter" and
+ * keeps an invalid URL showing the full leaderboard rather than an error.
+ */
+export const normalizeScoreTier = (raw: unknown): number => {
+  if (typeof raw !== "string") return 0;
+  const parsed = Number.parseInt(raw.trim(), 10);
+  if (!Number.isFinite(parsed)) return 0;
+  return VALID_SCORES.has(parsed) ? parsed : 0;
+};
+
+export interface ExploreFilters {
+  type: string;
+  q: string;
+  sortBy: string;
+  lang: string | null;
+  minScore: number;
+  page: number;
+}
+
+/** A query object suitable for passing to next/link's `href`. */
+export type ExploreQuery = Record<string, string>;
+
+/**
+ * Builds the query object for a filter link.
+ *
+ * Empty values are omitted so URLs stay readable and shareable — `?lang=Rust`
+ * rather than `?type=users&q=&sortBy=score&lang=Rust&minScore=0&page=1`.
+ *
+ * Any change to a filter resets pagination. Staying on page 4 while narrowing
+ * the result set to two pages would land the reader on an empty screen, which
+ * looks like a broken filter rather than the end of the list.
+ */
+export const buildExploreQuery = (
+  current: ExploreFilters,
+  patch: Partial<Pick<ExploreFilters, "lang" | "minScore" | "type" | "sortBy" | "q">> = {},
+): ExploreQuery => {
+  const merged = { ...current, ...patch };
+  const query: ExploreQuery = {};
+
+  // `users` is the default view, so it does not need to appear in the URL.
+  if (merged.type && merged.type !== "users") query.type = merged.type;
+  if (merged.q) query.q = merged.q;
+  if (merged.sortBy && merged.sortBy !== "score") query.sortBy = merged.sortBy;
+  if (merged.lang) query.lang = merged.lang;
+  if (merged.minScore > 0) query.minScore = String(merged.minScore);
+
+  // Pagination is deliberately not carried over: `patch` is only ever a filter
+  // change, and any filter change invalidates the current page number.
+  return query;
+};
+
+/** True when any filter beyond the default view is active. */
+export const hasActiveFilters = (filters: ExploreFilters): boolean =>
+  Boolean(filters.lang) || filters.minScore > 0 || Boolean(filters.q);
+
+/**
+ * Describes the active filters for the results heading, so a reader landing on
+ * a shared URL can see what they are looking at without decoding the query
+ * string.
+ */
+export const describeFilters = (filters: ExploreFilters): string => {
+  const parts: string[] = [];
+  if (filters.lang) parts.push(filters.lang);
+  if (filters.minScore > 0) parts.push(`score ${filters.minScore}+`);
+  if (filters.q) parts.push(`matching “${filters.q}”`);
+  if (parts.length === 0) return "";
+  return parts.join(" · ");
+};

--- a/src/lib/languages.ts
+++ b/src/lib/languages.ts
@@ -21,3 +21,27 @@ export const LANG_COLORS: Record<string, string> = {
   "Jupyter Notebook": "#DA5B0B",
   Dockerfile: "#384d54",
 };
+
+/**
+ * Languages offered as filter options in the UI.
+ *
+ * Kept here beside LANG_COLORS so Explore and Discover filter on the same set
+ * rather than maintaining separate lists that drift apart. Values are
+ * capitalised to match what GitHub reports and what `profiles.top_languages`
+ * stores — the filter is an exact array-containment match, so "typescript"
+ * would find nothing.
+ */
+export const POPULAR_LANGUAGES = [
+  "TypeScript",
+  "JavaScript",
+  "Python",
+  "Go",
+  "Rust",
+  "Java",
+  "C++",
+  "Ruby",
+  "PHP",
+  "Swift",
+] as const;
+
+export type PopularLanguage = (typeof POPULAR_LANGUAGES)[number];


### PR DESCRIPTION
## Summary

`/explore` could only sort, not filter. If you wanted to find Rust contributors
you had to scroll the whole leaderboard and read languages off each row — and
the page's own metadata already claimed you could "filter by language", which
you couldn't.

So this adds language and score-tier pills. They're server-rendered links rather
than client state, which means every filtered view has a real URL you can
bookmark or paste to someone — `/explore?lang=Rust` — instead of a filter that
vanishes the moment you reload.

The interesting part was that `/discover` already filters by language, so rather
than writing my own query I went and read how it does it. It goes through a
Postgres function using `top_languages @> array[lang]` — array containment. I
used the Supabase equivalent so both listings filter the same way instead of
quietly diverging.

That operator is case-sensitive, which turned out to matter more than it sounds.
If someone bookmarks `?lang=typescript` in lowercase, an exact match against the
stored "TypeScript" finds nothing — and the page wouldn't error, it would just
show an empty leaderboard, which reads as "nobody writes TypeScript" rather than
"your URL is slightly wrong". So the language is normalised back to GitHub's
capitalisation before it ever reaches the query.

Two things would have broken that the issue doesn't mention. The search box is a
GET form, so submitting a search would have wiped the active pills unless the
filters were carried through as hidden inputs. And pagination built its own URL
from a fixed set of params — so filtering to Rust and clicking page 2 dropped
the filter and silently showed everyone again. Both are fixed, and pagination now
uses the same URL helper the pills do so the two can't drift apart.

One thing outside the strict scope: the language list was sitting private inside
the Discover filter component. I moved it to `src/lib/languages.ts` next to the
colour map and pointed Discover at it, since two copies of the same list will
eventually disagree. Happy to put it back if you'd rather keep this PR to
Explore only.

## Related Issue

Closes #564

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Chore / dependency update

## Changes Made

`/explore` previously read only `page`, `q`, `sortBy` and `type` — there was no
language filtering at all, despite the page's own metadata advertising it.

- Added `src/lib/explore-filters.ts` — param validation and URL construction,
  kept out of the page so the rules are unit testable.
- Added `src/lib/__tests__/explore-filters.test.ts` — 34 tests.
- Extended `fetchExploreProfiles` in `src/lib/db.ts` with optional `lang` and
  `minScore`.
- Added language and score-tier pills to `/explore`, server-rendered as links.
- Lifted `POPULAR_LANGUAGES` from `SearchFilters.tsx` into `src/lib/languages.ts`.

### Matching how Discover already filters

Rather than invent a query, I followed the `search_profiles` RPC that Discover
uses (`supabase/schema.sql:186`):

    and (lang = '' or p.top_languages @> array[lang])

So `fetchExploreProfiles` uses `.contains("top_languages", [lang])`, which
generates the same `@>` predicate. Both listings now filter identically.

That operator is **case-sensitive**, which drove a real decision:
`normalizeLanguage` accepts input case-insensitively but always returns GitHub's
canonical capitalisation. A bookmarked `?lang=typescript` resolves to
`"TypeScript"` and matches. Without it the page would return zero results and
look like "nobody uses TypeScript" rather than a bug.

Only offered languages are accepted — an allowlist is both the right validation
and the simplest, since anything else couldn't match a row anyway.

### Things the issue didn't mention but that would have broken

**The search form would have eaten the filters.** It's a `<form method="GET">`
with a hidden `type` input; without hidden `lang`/`minScore` inputs, hitting
Apply would silently drop the active pills.

**Pagination would have dropped them too.** `DiscoverPagination` built its URL
from `{ q, type, sortBy }`, so paging past page 1 widened the results back to
everything. It now takes `buildExploreQuery(activeFilters)` — the same helper
the pills use, so the two can't drift apart. Three tests pin this, including a
`URLSearchParams` round-trip confirming `C++` survives as `C%2B%2B` and decodes
correctly on the next page.

**Pagination resets on filter change.** Staying on page 4 while narrowing to two
pages lands on an empty screen that looks like a broken filter.

Also: clicking an active pill clears it; defaults are omitted so URLs stay
readable (`?lang=Rust`, not `?type=users&q=&sortBy=score&lang=Rust&minScore=0`);
organisations skip both filters since they have no language or score data; and
the empty state names what was filtered rather than a bare "No results found."

### One scope call

`POPULAR_LANGUAGES` was private to `SearchFilters.tsx`. I moved it to
`src/lib/languages.ts` beside `LANG_COLORS` and pointed Discover at it — one
shared list beats two that drift. That's the 14-line deletion in a Discover
file. Happy to revert to a duplicate if you'd rather keep this PR to Explore.

## AI Usage

- [ ] I did not use AI for any part of the code in this PR
- [x] I used AI for coding (specify which tool below) and I fully understand
      every change I made, including which functions I changed, why I changed
      them, and what side effects they could create

Used Claude for coding.

## Screenshots (if UI change)

<img width="1907" height="812" alt="image" src="https://github.com/user-attachments/assets/8498ff5b-4bfe-42fa-94fd-eee75e9de818" />
<img width="1916" height="923" alt="image" src="https://github.com/user-attachments/assets/3a553941-53a9-481d-8f75-014847c32120" />
<img width="1915" height="928" alt="image" src="https://github.com/user-attachments/assets/91ffd978-40bd-444e-9ebe-27c2bfad05ec" />


## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with `main`
- [x] Code works locally and I have tested it
- [x] No `console.log` left in `src/`
- [x] If schema changed — n/a, `top_languages` already exists
- [x] If this is a UI change — I read `DESIGN.md` and followed the design system
- [x] Docs updated if needed (n/a)
- [x] PR title follows Conventional Commits format
- [ ] This PR description is written in my own words