### PR TITLE
ci: report client bundle size changes on pull requests (closes #551)

### DIFF
--- a/.github/workflows/bundle-size-comment.yml
+++ b/.github/workflows/bundle-size-comment.yml
@@ -1,0 +1,103 @@
+name: Bundle Size Comment
+
+# Posts the report produced by `bundle-size.yml`.
+#
+# Split from that workflow on purpose. This one needs `pull-requests: write`,
+# and `workflow_run` grants it even for pull requests from forks — but it never
+# checks out or executes repository code. It downloads an artifact and posts the
+# text inside it, so a fork cannot use it to run anything with a write token.
+#
+# The comment is updated in place rather than appended, so pushing ten commits
+# leaves one report rather than ten.
+
+on:
+  workflow_run:
+    workflows: ["Bundle Size"]
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  actions: read
+
+jobs:
+  comment:
+    name: comment
+    runs-on: ubuntu-latest
+    # Skip runs that were cancelled, and anything not triggered by a pull
+    # request, which would have no PR to comment on.
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+
+    steps:
+      - name: Download report
+        uses: actions/download-artifact@v4
+        with:
+          name: bundle-report
+          path: bundle-report
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Post or update comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("fs");
+
+            // Marker written into the report by scripts/bundle-size.mjs. Finding
+            // the previous comment by marker rather than by position means an
+            // unrelated comment can never be overwritten.
+            const MARKER = "<!-- ossfolio-bundle-size-report -->";
+
+            let body;
+            let prNumber;
+            try {
+              body = fs.readFileSync("bundle-report/report.md", "utf8");
+              prNumber = parseInt(
+                fs.readFileSync("bundle-report/pr-number.txt", "utf8").trim(),
+                10,
+              );
+            } catch (error) {
+              core.info(`No bundle report to post: ${error.message}`);
+              return;
+            }
+
+            if (!Number.isInteger(prNumber) || prNumber <= 0) {
+              core.info("Artifact did not contain a usable pull request number.");
+              return;
+            }
+
+            if (!body.includes(MARKER)) {
+              core.info("Report is missing its marker; refusing to post.");
+              return;
+            }
+
+            const { owner, repo } = context.repo;
+
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number: prNumber, per_page: 100 },
+            );
+
+            const existing = comments.find(
+              (comment) =>
+                comment.user?.type === "Bot" && comment.body?.includes(MARKER),
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+              core.info(`Updated bundle report comment ${existing.id}.`);
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: prNumber,
+                body,
+              });
+              core.info("Created bundle report comment.");
+            }

--- a/.github/workflows/bundle-size-comment.yml
+++ b/.github/workflows/bundle-size-comment.yml
@@ -15,6 +15,17 @@ on:
     workflows: ["Bundle Size"]
     types: [completed]
 
+# Serialised per pull request. Several Bundle Size runs can finish close
+# together on a busy branch, and without this two comment jobs could race to
+# update the same comment.
+concurrency:
+  group: >-
+    ${{ github.workflow }}-${{
+      github.event.workflow_run.pull_requests[0].number ||
+      github.event.workflow_run.head_branch
+    }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: write
   actions: read

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -55,8 +55,7 @@ jobs:
           npm run build
 
       - name: Measure pull request bundle
-        working-directory: head
-        run: node scripts/bundle-size.mjs measure .next/static ../head-bundle.json
+        run: node head/scripts/bundle-size.mjs measure head/.next/static head-bundle.json
 
       # A base branch that cannot build is not a reason to fail the PR check.
       # The report handles a missing baseline by reporting the current total
@@ -69,10 +68,16 @@ jobs:
           npm ci
           npm run build
 
+      # The script is run from the head checkout, not the base one: it is a new
+      # file on this branch, so the base checkout does not contain it. Only the
+      # directory being measured comes from base.
+      #
+      # continue-on-error because a base bundle that cannot be measured should
+      # produce the no-baseline report, not a failed check.
       - name: Measure base bundle
         if: steps.base-build.outcome == 'success'
-        working-directory: base
-        run: node scripts/bundle-size.mjs measure .next/static ../base-bundle.json
+        continue-on-error: true
+        run: node head/scripts/bundle-size.mjs measure base/.next/static base-bundle.json
 
       - name: Render report
         run: |

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -1,0 +1,96 @@
+name: Bundle Size
+
+# Builds the pull request and its base branch, measures the client JavaScript
+# each produces, and uploads the comparison as an artifact.
+#
+# This workflow deliberately does *not* post the comment. It checks out and
+# executes pull request code, and a `pull_request` run from a fork gets a
+# read-only token — which is the correct security boundary, not a limitation to
+# work around. Switching to `pull_request_target` to gain write access would
+# hand a privileged token to untrusted code.
+#
+# So the comment is posted by `bundle-size-comment.yml`, which runs on
+# `workflow_run` with write permission but never checks out or runs repository
+# code. It only publishes the Markdown this workflow produced.
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  measure:
+    name: measure
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out pull request
+        uses: actions/checkout@v4
+        with:
+          path: head
+
+      - name: Check out base branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.base_ref }}
+          path: base
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: head/package-lock.json
+
+      - name: Build pull request
+        working-directory: head
+        run: |
+          npm ci
+          npm run build
+
+      - name: Measure pull request bundle
+        working-directory: head
+        run: node scripts/bundle-size.mjs measure .next/static ../head-bundle.json
+
+      # A base branch that cannot build is not a reason to fail the PR check.
+      # The report handles a missing baseline by reporting the current total
+      # on its own.
+      - name: Build base branch
+        id: base-build
+        continue-on-error: true
+        working-directory: base
+        run: |
+          npm ci
+          npm run build
+
+      - name: Measure base bundle
+        if: steps.base-build.outcome == 'success'
+        working-directory: base
+        run: node scripts/bundle-size.mjs measure .next/static ../base-bundle.json
+
+      - name: Render report
+        run: |
+          mkdir -p bundle-report
+          # The base measurement is absent when the base build failed; the
+          # script treats an unreadable file as an empty bundle.
+          node head/scripts/bundle-size.mjs report \
+            base-bundle.json \
+            head-bundle.json \
+            bundle-report/report.md
+          # The commenting workflow cannot infer the pull request number from a
+          # workflow_run event, so it travels with the artifact.
+          echo "${{ github.event.pull_request.number }}" > bundle-report/pr-number.txt
+          cat bundle-report/report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload report
+        uses: actions/upload-artifact@v4
+        with:
+          name: bundle-report
+          path: bundle-report/
+          retention-days: 7

--- a/scripts/__tests__/bundle-size.test.ts
+++ b/scripts/__tests__/bundle-size.test.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+// The script is plain JavaScript because CI runs it directly with `node` —
+// there is no tsx or ts-node in this project, so a .ts entry point could not be
+// executed by a workflow.
+const {
+  measureBundle,
+  diffBundles,
+  stripContentHash,
+  formatBytes,
+  formatDelta,
+  renderMarkdownReport,
+  COMMENT_MARKER,
+} = await import("../bundle-size.mjs");
+
+let root: string;
+let staticDir: string;
+
+beforeAll(async () => {
+  root = await mkdtemp(path.join(tmpdir(), "bundle-size-test-"));
+  staticDir = path.join(root, "static");
+  await mkdir(path.join(staticDir, "chunks"), { recursive: true });
+  await mkdir(path.join(staticDir, "css"), { recursive: true });
+
+  // Repetitive content so gzip compresses meaningfully.
+  await writeFile(
+    path.join(staticDir, "chunks", "main-abc12345.js"),
+    "const a=1;".repeat(500),
+  );
+  await writeFile(
+    path.join(staticDir, "chunks", "framework-deadbeef.js"),
+    "const b=2;".repeat(1000),
+  );
+  await writeFile(path.join(staticDir, "css", "styles.css"), "body{margin:0}");
+  await writeFile(path.join(staticDir, "manifest.json"), "{}");
+});
+
+afterAll(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+const report = (
+  entries: Array<[string, number]>,
+): { files: Array<{ file: string; bytes: number; gzipBytes: number }>; totalBytes: number; totalGzipBytes: number } => {
+  const files = entries.map(([file, gzipBytes]) => ({
+    file,
+    bytes: gzipBytes * 3,
+    gzipBytes,
+  }));
+  return {
+    files,
+    totalBytes: files.reduce((s, f) => s + f.bytes, 0),
+    totalGzipBytes: files.reduce((s, f) => s + f.gzipBytes, 0),
+  };
+};
+
+describe("measureBundle", () => {
+  it("measures every JavaScript file", async () => {
+    const result = await measureBundle(staticDir);
+    expect(result.files).toHaveLength(2);
+  });
+
+  it("ignores non-JavaScript assets", async () => {
+    // CSS and JSON are not the client JS payload this report is about.
+    const result = await measureBundle(staticDir);
+    const names = result.files.map((f: { file: string }) => f.file);
+    expect(names.some((n: string) => n.endsWith(".css"))).toBe(false);
+    expect(names.some((n: string) => n.endsWith(".json"))).toBe(false);
+  });
+
+  it("reports paths relative to the measured root, with forward slashes", async () => {
+    const result = await measureBundle(staticDir);
+    for (const file of result.files) {
+      expect(file.file).not.toContain("\\");
+      expect(file.file.startsWith("chunks/")).toBe(true);
+    }
+  });
+
+  it("reports gzip smaller than raw for compressible content", async () => {
+    const result = await measureBundle(staticDir);
+    expect(result.totalGzipBytes).toBeGreaterThan(0);
+    expect(result.totalGzipBytes).toBeLessThan(result.totalBytes);
+  });
+
+  it("totals match the sum of the files", async () => {
+    const result = await measureBundle(staticDir);
+    const raw = result.files.reduce((s: number, f: { bytes: number }) => s + f.bytes, 0);
+    const gz = result.files.reduce((s: number, f: { gzipBytes: number }) => s + f.gzipBytes, 0);
+    expect(result.totalBytes).toBe(raw);
+    expect(result.totalGzipBytes).toBe(gz);
+  });
+
+  it("returns an empty report for a missing directory rather than throwing", async () => {
+    // A base branch that failed to build should mean "no baseline", not a
+    // crashed workflow.
+    const result = await measureBundle(path.join(root, "does-not-exist"));
+    expect(result.files).toEqual([]);
+    expect(result.totalGzipBytes).toBe(0);
+  });
+
+  it("returns files in a stable order", async () => {
+    const a = await measureBundle(staticDir);
+    const b = await measureBundle(staticDir);
+    expect(a.files.map((f: { file: string }) => f.file)).toEqual(
+      b.files.map((f: { file: string }) => f.file),
+    );
+  });
+});
+
+describe("stripContentHash", () => {
+  it("removes a hex content hash", () => {
+    expect(stripContentHash("chunks/main-abc12345.js")).toBe("chunks/main.js");
+  });
+
+  it("removes a dot-separated hash", () => {
+    expect(stripContentHash("chunks/page.9f8e7d6c.js")).toBe("chunks/page.js");
+  });
+
+  it("leaves an unhashed name alone", () => {
+    expect(stripContentHash("chunks/framework.js")).toBe("chunks/framework.js");
+    expect(stripContentHash("chunks/polyfills.js")).toBe("chunks/polyfills.js");
+  });
+
+  it("does not mistake a short suffix for a hash", () => {
+    // "page-1" is a name, not a content hash.
+    expect(stripContentHash("chunks/page-1.js")).toBe("chunks/page-1.js");
+  });
+
+  it("normalises the build id directory", () => {
+    expect(stripContentHash("abcdefghij0123456789X/_buildManifest.js")).toBe(
+      "abcdefghij0123456789X/_buildManifest.js",
+    );
+  });
+
+  it("lets two builds of the same chunk match", () => {
+    expect(stripContentHash("chunks/main-aaaaaaaa.js")).toBe(
+      stripContentHash("chunks/main-bbbbbbbb.js"),
+    );
+  });
+});
+
+describe("diffBundles", () => {
+  it("reports growth", () => {
+    const diff = diffBundles(report([["chunks/a-11111111.js", 100]]), report([["chunks/a-22222222.js", 150]]));
+    expect(diff.totalGzipDelta).toBe(50);
+    expect(diff.percentChange).toBeCloseTo(50);
+  });
+
+  it("reports shrinkage as a negative delta", () => {
+    const diff = diffBundles(report([["chunks/a-11111111.js", 200]]), report([["chunks/a-22222222.js", 150]]));
+    expect(diff.totalGzipDelta).toBe(-50);
+    expect(diff.percentChange).toBeCloseTo(-25);
+  });
+
+  it("matches chunks across builds despite differing hashes", () => {
+    const diff = diffBundles(report([["chunks/main-aaa11111.js", 100]]), report([["chunks/main-bbb22222.js", 120]]));
+    expect(diff.changes).toHaveLength(1);
+    expect(diff.changes[0].status).toBe("changed");
+    expect(diff.changes[0].file).toBe("chunks/main.js");
+  });
+
+  it("marks a genuinely new chunk as added", () => {
+    const diff = diffBundles(report([]), report([["chunks/new-11111111.js", 90]]));
+    expect(diff.changes[0].status).toBe("added");
+  });
+
+  it("marks a deleted chunk as removed", () => {
+    const diff = diffBundles(report([["chunks/old-11111111.js", 90]]), report([]));
+    expect(diff.changes[0].status).toBe("removed");
+  });
+
+  it("omits unchanged chunks from the change list", () => {
+    const diff = diffBundles(
+      report([["chunks/a-11111111.js", 100], ["chunks/b-11111111.js", 50]]),
+      report([["chunks/a-22222222.js", 100], ["chunks/b-22222222.js", 80]]),
+    );
+    expect(diff.changes).toHaveLength(1);
+    expect(diff.changes[0].file).toBe("chunks/b.js");
+  });
+
+  it("orders changes by magnitude regardless of direction", () => {
+    const diff = diffBundles(
+      report([["chunks/a-11111111.js", 100], ["chunks/b-11111111.js", 500]]),
+      report([["chunks/a-22222222.js", 110], ["chunks/b-22222222.js", 100]]),
+    );
+    // b shrank by 400, a grew by 10 — the larger movement comes first.
+    expect(diff.changes[0].file).toBe("chunks/b.js");
+  });
+
+  it("reports no percentage when there was no baseline", () => {
+    // Infinity or 100% would both mislead.
+    const diff = diffBundles(report([]), report([["chunks/a-11111111.js", 100]]));
+    expect(diff.percentChange).toBeNull();
+  });
+
+  it("handles two empty bundles without dividing by zero", () => {
+    const diff = diffBundles(report([]), report([]));
+    expect(diff.totalGzipDelta).toBe(0);
+    expect(diff.percentChange).toBeNull();
+    expect(diff.changes).toEqual([]);
+  });
+});
+
+describe("formatBytes / formatDelta", () => {
+  it("scales units", () => {
+    expect(formatBytes(512)).toBe("512 B");
+    expect(formatBytes(2048)).toBe("2.00 kB");
+    expect(formatBytes(5 * 1024 * 1024)).toBe("5.00 MB");
+  });
+
+  it("signs a delta so direction is unmistakable", () => {
+    expect(formatDelta(1024)).toBe("+1.00 kB");
+    expect(formatDelta(-1024)).toBe("-1.00 kB");
+    expect(formatDelta(0)).toBe("—");
+  });
+
+  it("scales negative values by magnitude, not sign", () => {
+    expect(formatBytes(-2048)).toBe("-2.00 kB");
+  });
+});
+
+describe("renderMarkdownReport", () => {
+  const grew = diffBundles(
+    report([["chunks/a-11111111.js", 1000]]),
+    report([["chunks/a-22222222.js", 1500]]),
+  );
+
+  it("includes the marker the comment workflow searches for", () => {
+    // Without this the workflow cannot find its previous comment and would
+    // append a new one on every push.
+    expect(renderMarkdownReport(grew)).toContain(COMMENT_MARKER);
+  });
+
+  it("leads with the headline verdict", () => {
+    expect(renderMarkdownReport(grew)).toContain("Client bundle grew by");
+  });
+
+  it("says so plainly when the bundle shrinks", () => {
+    const shrank = diffBundles(
+      report([["chunks/a-11111111.js", 1500]]),
+      report([["chunks/a-22222222.js", 1000]]),
+    );
+    expect(renderMarkdownReport(shrank)).toContain("Client bundle shrank by");
+  });
+
+  it("reports no change when totals match", () => {
+    const same = diffBundles(
+      report([["chunks/a-11111111.js", 1000]]),
+      report([["chunks/a-22222222.js", 1000]]),
+    );
+    expect(renderMarkdownReport(same)).toContain("No change to the client bundle.");
+  });
+
+  it("renders a totals table", () => {
+    const md = renderMarkdownReport(grew);
+    expect(md).toContain("| **Total (gzipped)** |");
+    expect(md).toContain("| --- | ---: | ---: | ---: |");
+  });
+
+  it("explains itself when there is no baseline", () => {
+    const noBase = diffBundles(report([]), report([["chunks/a-11111111.js", 100]]));
+    const md = renderMarkdownReport(noBase);
+    expect(md).toContain("No baseline bundle was available");
+    expect(md).not.toContain("NaN");
+    expect(md).not.toContain("Infinity");
+  });
+
+  it("collapses a long change list and says how many were hidden", () => {
+    const many = Array.from({ length: 30 }, (_, i) => [`chunks/c${i}-11111111.js`, 100] as [string, number]);
+    const after = Array.from({ length: 30 }, (_, i) => [`chunks/c${i}-22222222.js`, 100 + i + 1] as [string, number]);
+    const md = renderMarkdownReport(diffBundles(report(many), report(after)), {
+      maxRows: 5,
+    });
+    expect(md).toContain("…and 25 more.");
+  });
+
+  it("honours a noise threshold", () => {
+    const md = renderMarkdownReport(
+      diffBundles(report([["chunks/a-11111111.js", 1000]]), report([["chunks/a-22222222.js", 1005]])),
+      { thresholdBytes: 100 },
+    );
+    expect(md).toContain("No individual chunk changed size.");
+  });
+
+  it("never emits NaN or Infinity", () => {
+    for (const diff of [
+      diffBundles(report([]), report([])),
+      diffBundles(report([]), report([["chunks/a-11111111.js", 10]])),
+      diffBundles(report([["chunks/a-11111111.js", 10]]), report([])),
+    ]) {
+      const md = renderMarkdownReport(diff);
+      expect(md).not.toContain("NaN");
+      expect(md).not.toContain("Infinity");
+      expect(md).not.toContain("undefined");
+    }
+  });
+});

--- a/scripts/__tests__/bundle-size.test.ts
+++ b/scripts/__tests__/bundle-size.test.ts
@@ -363,6 +363,33 @@ describe("renderMarkdownReport", () => {
     expect(renderMarkdownReport(diff)).toContain("we\\|ird");
   });
 
+  it("escapes a backslash before the pipe it precedes", () => {
+    // Escaping the pipe first leaves "a\\|b" rendering as a literal backslash
+    // followed by an unescaped pipe, which breaks the cell. The backslash has
+    // to be doubled first.
+    const diff = diffBundles(
+      report([["chunks/keep-11111111.js", 500]]),
+      report([
+        ["chunks/keep-22222222.js", 500],
+        ["chunks/a\\|b-33333333.js", 60],
+      ]),
+    );
+    const md = renderMarkdownReport(diff);
+    expect(md).toContain("a\\\\\\|b");
+  });
+
+  it("replaces a backtick, which cannot be escaped inside a code span", () => {
+    const diff = diffBundles(
+      report([["chunks/keep-11111111.js", 500]]),
+      report([
+        ["chunks/keep-22222222.js", 500],
+        ["chunks/ti`ck-33333333.js", 60],
+      ]),
+    );
+    const md = renderMarkdownReport(diff);
+    expect(md).toContain("ti'ck");
+  });
+
   it("reports the raw total alongside the gzipped one", () => {
     const diff = diffBundles(
       report([["chunks/a-11111111.js", 100]]),

--- a/scripts/__tests__/bundle-size.test.ts
+++ b/scripts/__tests__/bundle-size.test.ts
@@ -101,12 +101,13 @@ describe("measureBundle", () => {
     expect(result.totalGzipBytes).toBe(0);
   });
 
-  it("returns files in a stable order", async () => {
-    const a = await measureBundle(staticDir);
-    const b = await measureBundle(staticDir);
-    expect(a.files.map((f: { file: string }) => f.file)).toEqual(
-      b.files.map((f: { file: string }) => f.file),
-    );
+  it("returns files sorted, so two builds line up", async () => {
+    // Comparing two invocations would pass even without the sort, since readdir
+    // is consistent on a static directory. Comparing against an explicitly
+    // sorted copy actually pins the behaviour.
+    const result = await measureBundle(staticDir);
+    const names = result.files.map((f: { file: string }) => f.file);
+    expect(names).toEqual([...names].sort());
   });
 });
 
@@ -129,9 +130,18 @@ describe("stripContentHash", () => {
     expect(stripContentHash("chunks/page-1.js")).toBe("chunks/page-1.js");
   });
 
-  it("normalises the build id directory", () => {
+  it("normalises a build id directory at the start of a relative path", () => {
+    // measureBundle emits paths relative to .next/static, so build ids have no
+    // leading slash. Without this, _buildManifest.js shows as removed-and-added
+    // on every single PR.
     expect(stripContentHash("abcdefghij0123456789X/_buildManifest.js")).toBe(
-      "abcdefghij0123456789X/_buildManifest.js",
+      "[buildId]/_buildManifest.js",
+    );
+  });
+
+  it("normalises a build id directory nested deeper in a path", () => {
+    expect(stripContentHash("chunks/abcdefghij0123456789X/page.js")).toBe(
+      "chunks/[buildId]/page.js",
     );
   });
 
@@ -188,6 +198,45 @@ describe("diffBundles", () => {
     );
     // b shrank by 400, a grew by 10 — the larger movement comes first.
     expect(diff.changes[0].file).toBe("chunks/b.js");
+  });
+
+  it("sums chunks that normalise to the same logical name", () => {
+    // Two differently-hashed files can collapse to one logical chunk; their
+    // sizes must be added before comparing, not silently overwrite each other.
+    const diff = diffBundles(
+      report([["chunks/main-aaaaaaaa.js", 100], ["chunks/main-bbbbbbbb.js", 40]]),
+      report([["chunks/main-cccccccc.js", 200]]),
+    );
+    expect(diff.changes).toHaveLength(1);
+    expect(diff.changes[0]).toMatchObject({
+      file: "chunks/main.js",
+      beforeGzip: 140,
+      afterGzip: 200,
+      deltaGzip: 60,
+      status: "changed",
+    });
+  });
+
+  it("reports concrete before, after and delta on a changed chunk", () => {
+    const diff = diffBundles(
+      report([["chunks/a-11111111.js", 120]]),
+      report([["chunks/a-22222222.js", 95]]),
+    );
+    expect(diff.changes[0]).toMatchObject({
+      beforeGzip: 120,
+      afterGzip: 95,
+      deltaGzip: -25,
+    });
+  });
+
+  it("carries raw byte totals alongside gzip", () => {
+    const diff = diffBundles(
+      report([["chunks/a-11111111.js", 100]]),
+      report([["chunks/a-22222222.js", 150]]),
+    );
+    expect(diff.totalBytesBefore).toBe(300);
+    expect(diff.totalBytesAfter).toBe(450);
+    expect(diff.totalBytesDelta).toBe(150);
   });
 
   it("reports no percentage when there was no baseline", () => {
@@ -283,6 +332,43 @@ describe("renderMarkdownReport", () => {
       { thresholdBytes: 100 },
     );
     expect(md).toContain("No individual chunk changed size.");
+  });
+
+  it("labels added and removed chunks in the table", () => {
+    const diff = diffBundles(
+      report([["chunks/keep-11111111.js", 500], ["chunks/gone-11111111.js", 80]]),
+      report([["chunks/keep-22222222.js", 500], ["chunks/fresh-33333333.js", 60]]),
+    );
+    const md = renderMarkdownReport(diff);
+    expect(md).toContain("_(new)_");
+    expect(md).toContain("_(removed)_");
+  });
+
+  it("keeps the added/removed label outside the code span", () => {
+    // Markdown does not interpret underscores inside backticks, so a label
+    // within the code span would render literally as "_(new)_".
+    const diff = diffBundles(
+      report([["chunks/keep-11111111.js", 500]]),
+      report([["chunks/keep-22222222.js", 500], ["chunks/fresh-33333333.js", 60]]),
+    );
+    expect(renderMarkdownReport(diff)).toContain("` _(new)_");
+  });
+
+  it("escapes a pipe in a chunk name so the table cannot be broken", () => {
+    // Chunk names come from the pull request branch, so they are untrusted.
+    const diff = diffBundles(
+      report([["chunks/keep-11111111.js", 500]]),
+      report([["chunks/keep-22222222.js", 500], ["chunks/we|ird-33333333.js", 60]]),
+    );
+    expect(renderMarkdownReport(diff)).toContain("we\\|ird");
+  });
+
+  it("reports the raw total alongside the gzipped one", () => {
+    const diff = diffBundles(
+      report([["chunks/a-11111111.js", 100]]),
+      report([["chunks/a-22222222.js", 150]]),
+    );
+    expect(renderMarkdownReport(diff)).toContain("| Total (raw) |");
   });
 
   it("never emits NaN or Infinity", () => {

--- a/scripts/bundle-size.mjs
+++ b/scripts/bundle-size.mjs
@@ -1,4 +1,4 @@
-import { readdir, readFile, stat } from "node:fs/promises";
+import { readdir, readFile, stat, writeFile } from "node:fs/promises";
 import { gzipSync } from "node:zlib";
 import path from "node:path";
 
@@ -32,7 +32,11 @@ export const stripContentHash = (file) =>
   file
     .replace(/[-.][a-f0-9]{8,}(?=\.[a-z]+$)/gi, "")
     .replace(/[-.][a-z0-9]{16,}(?=\.[a-z]+$)/gi, "")
-    .replace(/\/[a-zA-Z0-9_-]{21}\//g, "/[buildId]/");
+    // Build-id directories arrive without a leading slash, because paths are
+    // relative to .next/static. Anchoring at the start as well as after a
+    // slash is what makes _buildManifest.js match across builds instead of
+    // showing as removed-and-added on every PR.
+    .replace(/(^|\/)[a-zA-Z0-9_-]{21}\//g, "$1[buildId]/");
 
 /** Recursively lists every `.js` file beneath `root`. */
 const listJsFiles = async (root, prefix = "") => {
@@ -134,6 +138,9 @@ export const diffBundles = (before, after) => {
     totalGzipBefore,
     totalGzipAfter,
     totalGzipDelta: totalGzipAfter - totalGzipBefore,
+    totalBytesBefore: before.totalBytes,
+    totalBytesAfter: after.totalBytes,
+    totalBytesDelta: after.totalBytes - before.totalBytes,
     // No baseline means no meaningful percentage; reporting Infinity or 100%
     // would both be misleading.
     percentChange:
@@ -158,6 +165,16 @@ export const formatDelta = (bytes) => {
   const sign = bytes > 0 ? "+" : "";
   return `${sign}${formatBytes(bytes)}`;
 };
+
+/**
+ * Makes a filename safe inside a Markdown table cell and code span.
+ *
+ * Chunk names originate from files in the pull request branch, so they are
+ * untrusted input: a pipe would end the table cell early and a backtick would
+ * close the code span, either of which corrupts the rendered comment.
+ */
+const escapeTableCell = (value) =>
+  String(value).replace(/\|/g, "\\|").replace(/`/g, "'");
 
 /** Marker used to find and replace this workflow's previous comment. */
 export const COMMENT_MARKER = "<!-- ossfolio-bundle-size-report -->";
@@ -202,6 +219,7 @@ export const renderMarkdownReport = (diff, options = {}) => {
     "| | Base | This PR | Change |",
     "| --- | ---: | ---: | ---: |",
     `| **Total (gzipped)** | ${formatBytes(diff.totalGzipBefore)} | ${formatBytes(diff.totalGzipAfter)} | ${formatDelta(diff.totalGzipDelta)} (${percent}) |`,
+    `| Total (raw) | ${formatBytes(diff.totalBytesBefore)} | ${formatBytes(diff.totalBytesAfter)} | ${formatDelta(diff.totalBytesDelta)} |`,
     "",
   );
 
@@ -226,14 +244,17 @@ export const renderMarkdownReport = (diff, options = {}) => {
   );
 
   for (const change of shown) {
-    const label =
+    // The suffix sits outside the code span: Markdown does not interpret
+    // underscores inside backticks, so "_(new)_" would render literally.
+    const suffix =
       change.status === "added"
-        ? `${change.file} _(new)_`
+        ? " _(new)_"
         : change.status === "removed"
-          ? `${change.file} _(removed)_`
-          : change.file;
+          ? " _(removed)_"
+          : "";
     lines.push(
-      `| \`${label}\` | ${formatBytes(change.beforeGzip)} | ${formatBytes(change.afterGzip)} | ${formatDelta(change.deltaGzip)} |`,
+      `| \`${escapeTableCell(change.file)}\`${suffix} | ${formatBytes(change.beforeGzip)} | ` +
+        `${formatBytes(change.afterGzip)} | ${formatDelta(change.deltaGzip)} |`,
     );
   }
 
@@ -263,17 +284,16 @@ export const renderMarkdownReport = (diff, options = {}) => {
 // text it was handed.
 // ---------------------------------------------------------------------------
 
-import { writeFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import process from "node:process";
 
 const isDirectRun =
-  process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
 
 const readJson = async (file) => {
-  const { readFile: read } = await import("node:fs/promises");
   try {
-    return JSON.parse(await read(file, "utf-8"));
+    return JSON.parse(await readFile(file, "utf-8"));
   } catch {
     // A missing or unreadable baseline is normal — the base branch may have
     // failed to build. Treat it as "no bundle" rather than crashing.

--- a/scripts/bundle-size.mjs
+++ b/scripts/bundle-size.mjs
@@ -174,7 +174,15 @@ export const formatDelta = (bytes) => {
  * close the code span, either of which corrupts the rendered comment.
  */
 const escapeTableCell = (value) =>
-  String(value).replace(/\|/g, "\\|").replace(/`/g, "'");
+  String(value)
+    // Backslashes first: escaping the pipe before the backslash leaves
+    // "a\\|b" rendering as a literal backslash followed by an *unescaped*
+    // pipe, which breaks the cell the escaping was meant to protect.
+    .replace(/\\/g, "\\\\")
+    .replace(/\|/g, "\\|")
+    // A backtick cannot be escaped inside a code span — it can only be
+    // replaced — so this substitutes rather than escapes.
+    .replace(/`/g, "'");
 
 /** Marker used to find and replace this workflow's previous comment. */
 export const COMMENT_MARKER = "<!-- ossfolio-bundle-size-report -->";

--- a/scripts/bundle-size.mjs
+++ b/scripts/bundle-size.mjs
@@ -1,0 +1,324 @@
+import { readdir, readFile, stat } from "node:fs/promises";
+import { gzipSync } from "node:zlib";
+import path from "node:path";
+
+/**
+ * Bundle size measurement and comparison.
+ *
+ * Next.js emits the client JavaScript a browser actually downloads into
+ * `.next/static`. Measuring that directory after a build gives a truthful
+ * figure for what ships, without needing a bundler plugin: `@next/bundle-analyzer`
+ * is built for interactive exploration of a single build, not for diffing two
+ * of them in CI.
+ *
+ * Sizes are reported gzipped as well as raw, because gzip is what crosses the
+ * wire and raw bytes routinely overstate the real cost of a change.
+ *
+ * The logic here is deliberately free of any CI or filesystem-layout
+ * assumptions beyond the directory it is handed, so it can be unit tested
+ * without running a build.
+ */
+
+/**
+ * Next emits content-hashed filenames, so `main-abc123.js` and `main-def456.js`
+ * are the same logical chunk across two builds. Stripping the hash lets files
+ * be matched up instead of every build looking like a complete rewrite.
+ *
+ * Only hash-shaped segments are removed: at least eight characters of
+ * lowercase hex or base36, which is what Next's build IDs and chunk hashes
+ * look like. A chunk genuinely named `page` or `framework` is left alone.
+ */
+export const stripContentHash = (file) =>
+  file
+    .replace(/[-.][a-f0-9]{8,}(?=\.[a-z]+$)/gi, "")
+    .replace(/[-.][a-z0-9]{16,}(?=\.[a-z]+$)/gi, "")
+    .replace(/\/[a-zA-Z0-9_-]{21}\//g, "/[buildId]/");
+
+/** Recursively lists every `.js` file beneath `root`. */
+const listJsFiles = async (root, prefix = "") => {
+  let entries;
+  try {
+    entries = await readdir(root, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const found = [];
+  for (const entry of entries) {
+    const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+    const abs = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      found.push(...(await listJsFiles(abs, rel)));
+    } else if (entry.isFile() && entry.name.endsWith(".js")) {
+      found.push(rel);
+    }
+  }
+  return found;
+};
+
+/**
+ * Measures every JavaScript file beneath `staticDir`.
+ *
+ * A missing directory yields an empty report rather than throwing: a base
+ * branch that failed to build should produce "no baseline", not a crashed
+ * workflow.
+ */
+export const measureBundle = async (staticDir) => {
+  const relativePaths = await listJsFiles(staticDir);
+  const files = [];
+
+  for (const rel of relativePaths.sort()) {
+    const abs = path.join(staticDir, rel);
+    try {
+      const info = await stat(abs);
+      const contents = await readFile(abs);
+      files.push({
+        file: rel,
+        bytes: info.size,
+        gzipBytes: gzipSync(contents).length,
+      });
+    } catch {
+      // A file that vanished mid-measurement is not worth failing over.
+    }
+  }
+
+  return {
+    files,
+    totalBytes: files.reduce((sum, f) => sum + f.bytes, 0),
+    totalGzipBytes: files.reduce((sum, f) => sum + f.gzipBytes, 0),
+  };
+};
+
+/** Collapses a report to hash-stripped name → total gzip bytes. */
+const byLogicalName = (report) => {
+  const map = new Map();
+  for (const file of report.files) {
+    const key = stripContentHash(file.file);
+    map.set(key, (map.get(key) ?? 0) + file.gzipBytes);
+  }
+  return map;
+};
+
+/**
+ * Compares two reports.
+ *
+ * Changes are ordered by the absolute size of the change, so the entries that
+ * matter appear first regardless of direction.
+ */
+export const diffBundles = (before, after) => {
+  const beforeMap = byLogicalName(before);
+  const afterMap = byLogicalName(after);
+  const names = new Set([...beforeMap.keys(), ...afterMap.keys()]);
+
+  const changes = [];
+  for (const name of names) {
+    const beforeGzip = beforeMap.get(name) ?? 0;
+    const afterGzip = afterMap.get(name) ?? 0;
+    if (beforeGzip === afterGzip) continue;
+
+    changes.push({
+      file: name,
+      status: beforeGzip === 0 ? "added" : afterGzip === 0 ? "removed" : "changed",
+      beforeGzip,
+      afterGzip,
+      deltaGzip: afterGzip - beforeGzip,
+    });
+  }
+
+  changes.sort((a, b) => Math.abs(b.deltaGzip) - Math.abs(a.deltaGzip));
+
+  const totalGzipBefore = before.totalGzipBytes;
+  const totalGzipAfter = after.totalGzipBytes;
+
+  return {
+    totalGzipBefore,
+    totalGzipAfter,
+    totalGzipDelta: totalGzipAfter - totalGzipBefore,
+    // No baseline means no meaningful percentage; reporting Infinity or 100%
+    // would both be misleading.
+    percentChange:
+      totalGzipBefore === 0
+        ? null
+        : ((totalGzipAfter - totalGzipBefore) / totalGzipBefore) * 100,
+    changes,
+  };
+};
+
+/** Human-readable byte size. */
+export const formatBytes = (bytes) => {
+  const abs = Math.abs(bytes);
+  if (abs < 1024) return `${bytes} B`;
+  if (abs < 1024 * 1024) return `${(bytes / 1024).toFixed(2)} kB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+};
+
+/** Signed size, so a reader can tell growth from shrinkage at a glance. */
+export const formatDelta = (bytes) => {
+  if (bytes === 0) return "—";
+  const sign = bytes > 0 ? "+" : "";
+  return `${sign}${formatBytes(bytes)}`;
+};
+
+/** Marker used to find and replace this workflow's previous comment. */
+export const COMMENT_MARKER = "<!-- ossfolio-bundle-size-report -->";
+
+/**
+ * Renders the diff as the Markdown comment body.
+ *
+ * Leads with the headline total, because that is the number a reviewer
+ * actually needs; the per-file table is supporting detail.
+ */
+export const renderMarkdownReport = (diff, options = {}) => {
+  const maxRows = options.maxRows ?? 15;
+  const threshold = options.thresholdBytes ?? 0;
+
+  const lines = [COMMENT_MARKER, "## Bundle size report", ""];
+
+  if (diff.totalGzipBefore === 0) {
+    lines.push(
+      "No baseline bundle was available for the base branch, so only the current total is shown.",
+      "",
+      `**Total (gzipped):** ${formatBytes(diff.totalGzipAfter)}`,
+      "",
+    );
+    return lines.join("\n");
+  }
+
+  const percent =
+    diff.percentChange === null
+      ? "—"
+      : `${diff.percentChange >= 0 ? "+" : ""}${diff.percentChange.toFixed(2)}%`;
+
+  const verdict =
+    diff.totalGzipDelta === 0
+      ? "No change to the client bundle."
+      : diff.totalGzipDelta > 0
+        ? `Client bundle grew by **${formatBytes(diff.totalGzipDelta)}** gzipped.`
+        : `Client bundle shrank by **${formatBytes(Math.abs(diff.totalGzipDelta))}** gzipped.`;
+
+  lines.push(
+    verdict,
+    "",
+    "| | Base | This PR | Change |",
+    "| --- | ---: | ---: | ---: |",
+    `| **Total (gzipped)** | ${formatBytes(diff.totalGzipBefore)} | ${formatBytes(diff.totalGzipAfter)} | ${formatDelta(diff.totalGzipDelta)} (${percent}) |`,
+    "",
+  );
+
+  const notable = diff.changes.filter(
+    (change) => Math.abs(change.deltaGzip) >= threshold,
+  );
+
+  if (notable.length === 0) {
+    lines.push("No individual chunk changed size.", "");
+    return lines.join("\n");
+  }
+
+  const shown = notable.slice(0, maxRows);
+  const hidden = notable.length - shown.length;
+
+  lines.push(
+    "<details>",
+    `<summary>Per-chunk changes (${notable.length})</summary>`,
+    "",
+    "| Chunk | Base | This PR | Change |",
+    "| --- | ---: | ---: | ---: |",
+  );
+
+  for (const change of shown) {
+    const label =
+      change.status === "added"
+        ? `${change.file} _(new)_`
+        : change.status === "removed"
+          ? `${change.file} _(removed)_`
+          : change.file;
+    lines.push(
+      `| \`${label}\` | ${formatBytes(change.beforeGzip)} | ${formatBytes(change.afterGzip)} | ${formatDelta(change.deltaGzip)} |`,
+    );
+  }
+
+  if (hidden > 0) {
+    lines.push("", `_…and ${hidden} more._`);
+  }
+
+  lines.push("", "</details>", "");
+  lines.push(
+    "<sub>Measured from `.next/static`, gzipped. Content hashes are stripped so chunks match across builds.</sub>",
+  );
+
+  return lines.join("\n");
+};
+
+// ---------------------------------------------------------------------------
+// CLI
+//
+// Two subcommands, so the workflow that builds the code and the workflow that
+// posts the comment stay separate:
+//
+//   measure <staticDir> <outFile>          write a JSON report
+//   report  <baseJson> <headJson> <outFile> write the Markdown comment
+//
+// The rendering happens here rather than in the commenting workflow, so that
+// workflow never needs to check out or execute repository code — it only posts
+// text it was handed.
+// ---------------------------------------------------------------------------
+
+import { writeFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import process from "node:process";
+
+const isDirectRun =
+  process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+const readJson = async (file) => {
+  const { readFile: read } = await import("node:fs/promises");
+  try {
+    return JSON.parse(await read(file, "utf-8"));
+  } catch {
+    // A missing or unreadable baseline is normal — the base branch may have
+    // failed to build. Treat it as "no bundle" rather than crashing.
+    return { files: [], totalBytes: 0, totalGzipBytes: 0 };
+  }
+};
+
+const main = async () => {
+  const [command, ...args] = process.argv.slice(2);
+
+  if (command === "measure") {
+    const [staticDir, outFile] = args;
+    if (!staticDir || !outFile) {
+      throw new Error("usage: bundle-size.mjs measure <staticDir> <outFile>");
+    }
+    const report = await measureBundle(staticDir);
+    await writeFile(outFile, JSON.stringify(report, null, 2), "utf-8");
+    console.log(
+      `[bundle-size] ${report.files.length} JS files, ` +
+        `${formatBytes(report.totalGzipBytes)} gzipped -> ${outFile}`,
+    );
+    return;
+  }
+
+  if (command === "report") {
+    const [baseFile, headFile, outFile] = args;
+    if (!baseFile || !headFile || !outFile) {
+      throw new Error(
+        "usage: bundle-size.mjs report <baseJson> <headJson> <outFile>",
+      );
+    }
+    const diff = diffBundles(await readJson(baseFile), await readJson(headFile));
+    await writeFile(outFile, renderMarkdownReport(diff), "utf-8");
+    console.log(
+      `[bundle-size] delta ${formatDelta(diff.totalGzipDelta)} gzipped -> ${outFile}`,
+    );
+    return;
+  }
+
+  throw new Error(`Unknown command: ${command ?? "(none)"}`);
+};
+
+if (isDirectRun) {
+  main().catch((error) => {
+    console.error(`[bundle-size] ${error.message}`);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary

Every time someone adds a charting library or a new visual feature, the client
JavaScript payload creeps up a bit, and nobody notices until the site feels slow
on a phone. There's no way to see that happening at review time — you'd have to
build locally, remember what the number was before, and compare by hand, which
nobody does.

So this measures the bundle on every pull request and posts the difference
against the base branch as a comment.

The genuinely interesting part was that the obvious way to build it doesn't work
here. The natural approach is one workflow that builds the PR and posts the
comment — but a pull request from a fork gets a read-only token, so the comment
would fail for exactly the contributors it's meant to help. The usual workaround
is `pull_request_target`, which grants write access, and that's what
`pr-welcome.yml` already uses. That's fine there because it never checks out PR
code. A bundle build has to check out and run PR code, so doing the same thing
would hand a write token to code from a stranger's fork.

So it's split in two. The first workflow builds both branches and measures them,
with no write access at all. It renders the comment text and uploads it as an
artifact. The second workflow picks that artifact up, has permission to comment,
and never checks out or runs any repository code — it just posts text it was
handed.

I also didn't use `@next/bundle-analyzer`, even though the issue suggests it.
It's built for exploring one build interactively, not for diffing two in CI.
Measuring `.next/static` directly gives the number that actually matters — what a
browser downloads — with no plugin and no config change.

One detail that would have quietly broken it: Next puts a content hash in every
chunk filename, so `main-abc123.js` becomes `main-def456.js` on the next build.
Without stripping those, every single chunk looks brand new every time and the
diff is meaningless. The stripping is careful enough not to mangle a chunk
genuinely named something like `page-1`.

The report also updates itself in place rather than piling up — push ten commits
and you get one comment, not ten.

## Related Issue

Closes #551

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Chore / dependency update

## Changes Made

- `scripts/bundle-size.mjs` — measures `.next/static`, diffs two reports, renders
  the comment. Plain JavaScript, because CI runs it with `node` directly and
  there's no `tsx` or `ts-node` in the project.
- `scripts/__tests__/bundle-size.test.ts` — 34 tests.
- `.github/workflows/bundle-size.yml` — builds both branches and measures.
- `.github/workflows/bundle-size-comment.yml` — posts the report.

No new dependencies; gzip sizes come from Node's `zlib`.

### Why this is two workflows and not one

The obvious implementation posts the comment from the same workflow that builds
the PR. That doesn't work safely here.

A `pull_request` run from a fork gets a read-only token, which is the correct
security boundary. The usual workaround is `pull_request_target` — that's what
`pr-welcome.yml` uses, and it's safe there because that workflow never checks
out PR code. A bundle build *must* check out and execute PR code, so the same
approach would hand a write token to untrusted code.

So:

- **`bundle-size.yml`** runs on `pull_request` with `contents: read`. It builds
  both branches, measures, renders the Markdown, and uploads it as an artifact.
  Untrusted code runs here, with no write access.
- **`bundle-size-comment.yml`** runs on `workflow_run` with
  `pull-requests: write`. It downloads the artifact and posts the text. It never
  checks out or executes repository code.

Rendering happens in the first workflow on purpose, so the privileged one only
handles text it was handed.

### Why not @next/bundle-analyzer

The analyzer produces an interactive treemap of a single build — useful for
exploring, but not for diffing two builds in CI. Measuring `.next/static`
directly gives the number that matters (what a browser downloads) with no plugin
and no config change. Sizes are reported gzipped as well as raw, since gzip is
what crosses the wire.

### Details worth knowing

**Content hashes are stripped before matching.** Next emits `main-abc123.js`;
without normalising, every build looks like a complete rewrite. Only hash-shaped
segments are removed — a chunk genuinely called `page-1` is left alone, and
there's a test for that.

**Reports update in place.** The comment carries an HTML marker; the workflow
finds the previous one by marker and bot authorship and edits it, so ten pushes
leave one report. Matching by marker rather than position means an unrelated
comment can't be clobbered.

**A failing base build doesn't fail the PR.** The base build is
`continue-on-error`, and a missing baseline is reported as "no baseline
available" with the current total — no `NaN`, no `Infinity`. There's a test
asserting those strings never appear in any output.

**Unchanged chunks are omitted** and changes are sorted by magnitude, so the
entries that matter are at the top regardless of direction.

## Verification

Run against this repo's actual build:

    $ npm run build
    $ node scripts/bundle-size.mjs measure .next/static head.json
    [bundle-size] 76 JS files, 622.40 kB gzipped

Simulated diff output:

    | Chunk                       | Base  | This PR | Change |
    | `chunks/radar.js _(new)_`   | 0 B   | 65 B    | +65 B  |
    | `chunks/main.js`            | 89 B  | 101 B   | +12 B  |

`framework` was unchanged and correctly omitted; `main` matched across differing
content hashes.

- 34 tests, `type-check` clean, no new lint warnings
- both workflows validate as YAML; action versions match the rest of `.github/`

## Not verified

The comment posting itself. A `workflow_run` workflow only proves itself on a
real PR — the marker logic and both branches of the upsert are unit tested, but
"it posts, then edits on the next push" won't be confirmed until it runs.

Also worth flagging: two `npm ci` runs and two Next builds make this the slowest
check on the repo, roughly 4–6 minutes. Happy to restrict it to PRs touching
`src/**` and `package.json` if that's too heavy.

## AI Usage

- [ ] I did not use AI for any part of the code in this PR
- [x] I used AI for coding (specify which tool below) and I fully understand
      every change I made, including which functions I changed, why I changed
      them, and what side effects they could create

Used Claude for coding.

## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with `main`
- [x] Code works locally and I have tested it
- [x] No `console.log` left in `src/`
- [x] If schema changed — n/a
- [x] If this is a UI change — n/a
- [x] Docs updated if needed (n/a)
- [x] PR title follows Conventional Commits format
- [x] This PR description is written in my own words

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated bundle-size comparisons for pull requests targeting the main branch.
  * Reports now summarize bundle growth, reductions, changed chunks, and overall totals.
  * Bundle-size results are published or updated automatically in the pull request conversation.

* **Bug Fixes**
  * Handles missing baselines, empty bundles, and unavailable reports without producing invalid results.

* **Tests**
  * Added comprehensive coverage for bundle measurement, comparisons, formatting, and report generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->