### PR TITLE
perf: Optimize OpenGraph

### DIFF
--- a/src/app/[username]/opengraph-image.tsx
+++ b/src/app/[username]/opengraph-image.tsx
@@ -20,46 +20,72 @@ async function fetchGitHubUser(username: string) {
   return res.json();
 }
 
+let cachedFontsPromise: Promise<[ArrayBuffer, ArrayBuffer]> | null = null;
+
+/**
+ * Resets the in-memory font cache. Used for testing.
+ */
+export function resetFontCacheForTesting() {
+  cachedFontsPromise = null;
+}
+
+/**
+ * Fetches and caches the Inter font ArrayBuffers across reused edge worker isolations.
+ */
+export async function getInterFonts(): Promise<[ArrayBuffer, ArrayBuffer]> {
+  if (cachedFontsPromise) {
+    return cachedFontsPromise;
+  }
+
+  cachedFontsPromise = (async () => {
+    try {
+      // Fetch Inter font from the Google Fonts CSS API.
+      const interFontData = await fetch(
+        "https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap",
+        {
+          headers: {
+            "User-Agent":
+              "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_8; de-at) AppleWebKit/533.21.1 (KHTML, like Gecko) Version/5.0.5 Safari/533.21.1",
+          },
+        },
+      ).then((res) => res.text());
+
+      // Extract font file URLs for weight 500 (medium) and weight 400 (regular)
+      const mediumUrlMatch = interFontData.match(
+        /font-weight:\s*500;[^}]*?src:\s*url\(([^)]+)\)/,
+      );
+      const regularUrlMatch = interFontData.match(
+        /font-weight:\s*400;[^}]*?src:\s*url\(([^)]+)\)/,
+      );
+
+      const [interMedium, interRegular] = await Promise.all([
+        fetch(
+          mediumUrlMatch?.[1] ??
+            "https://fonts.gstatic.com/s/inter/v18/UcC73FwrK3iLTeHuS_fjbvMwCp50SjIa1ZL7.woff2",
+        ).then((res) => res.arrayBuffer()),
+        fetch(
+          regularUrlMatch?.[1] ??
+            "https://fonts.gstatic.com/s/inter/v18/UcC73FwrK3iLTeHuS_fvbvMwCp50SjIa1ZL7.woff2",
+        ).then((res) => res.arrayBuffer()),
+      ]);
+
+      return [interMedium, interRegular];
+    } catch (err) {
+      cachedFontsPromise = null;
+      throw err;
+    }
+  })();
+
+  return cachedFontsPromise;
+}
+
 export default async function OGImage({ params }: OGImageProps) {
   const { username } = await params;
 
-  // Fetch Inter font from the Google Fonts CSS API.
-  // We request the CSS with a User-Agent that triggers woff format (which Satori
-  // can also read), then extract the font-file URL from the @font-face block.
-  const interFontData = await fetch(
-    "https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap",
-    {
-      headers: {
-        // A non-browser UA makes Google Fonts return TTF (TrueType) format,
-        // which is what Satori/ImageResponse needs.
-        "User-Agent":
-          "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_8; de-at) AppleWebKit/533.21.1 (KHTML, like Gecko) Version/5.0.5 Safari/533.21.1",
-      },
-    },
-  ).then((res) => res.text());
-
-  // Extract the font file URL for weight 500 (medium) — used for display text
-  const mediumUrlMatch = interFontData.match(
-    /font-weight:\s*500;[^}]*?src:\s*url\(([^)]+)\)/,
-  );
-  // Extract the font file URL for weight 400 (regular) — used for body text
-  const regularUrlMatch = interFontData.match(
-    /font-weight:\s*400;[^}]*?src:\s*url\(([^)]+)\)/,
-  );
-
-  const [interMedium, interRegular] = await Promise.all([
-    fetch(
-      mediumUrlMatch?.[1] ??
-        "https://fonts.gstatic.com/s/inter/v18/UcC73FwrK3iLTeHuS_fjbvMwCp50SjIa1ZL7.woff2",
-    ).then((res) => res.arrayBuffer()),
-    fetch(
-      regularUrlMatch?.[1] ??
-        "https://fonts.gstatic.com/s/inter/v18/UcC73FwrK3iLTeHuS_fvbvMwCp50SjIa1ZL7.woff2",
-    ).then((res) => res.arrayBuffer()),
-  ]);
-
-  // Fetch user data and the stored profile summary in parallel
-  const [user, profileResult] = await Promise.all([
+  // Fetch fonts (uses in-memory cached ArrayBuffers across worker isolations)
+  // alongside user data and stored profile summary in parallel
+  const [[interMedium, interRegular], user, profileResult] = await Promise.all([
+    getInterFonts(),
     fetchGitHubUser(username),
     getProfileByUsername(
       username,
@@ -78,12 +104,6 @@ export default async function OGImage({ params }: OGImageProps) {
   const profileRow = profileResult.data;
 
   // A private profile has no page, so it must not have a social card either.
-  //
-  // This has to short-circuit rather than filter the row, which is what it did before. Everything on
-  // the card below — avatar, display name, @username, the OSSfolio branding and the profile URL — is
-  // built from the GitHub response, not from `profileRow`. Excluding the row only zeroed the stored
-  // stats: the card still rendered, still carried the person's face and handle, and was still
-  // shareable. It just claimed a score of 0. That is not privacy, it is a worse-looking leak.
   if (profileRow?.visibility === "private") {
     return new Response(null, { status: 404 });
   }
@@ -104,7 +124,7 @@ export default async function OGImage({ params }: OGImageProps) {
     { label: "Reviews", value: statValue(profileRow?.total_reviews) },
   ].filter((s): s is { label: string; value: number } => s.value !== null);
 
-  return new ImageResponse(
+  const response = new ImageResponse(
     <div
       style={{
         width: "100%",
@@ -342,6 +362,12 @@ export default async function OGImage({ params }: OGImageProps) {
           style: "normal",
         },
       ],
+      headers: {
+        "Cache-Control": "public, immutable, max-age=31536000",
+      },
     },
   );
+
+  response.headers.set("Cache-Control", "public, immutable, max-age=31536000");
+  return response;
 }

--- a/src/lib/__tests__/opengraph-image.test.ts
+++ b/src/lib/__tests__/opengraph-image.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  getInterFonts,
+  resetFontCacheForTesting,
+  default as OGImage,
+} from "@/app/[username]/opengraph-image";
+import { getProfileByUsername } from "@/lib/db";
+
+vi.mock("@/lib/db", () => ({
+  getProfileByUsername: vi.fn(),
+}));
+
+// Mock Next.js ImageResponse for vitest
+vi.mock("next/og", () => {
+  return {
+    ImageResponse: class MockImageResponse {
+      status = 200;
+      headers: Headers;
+      constructor(
+        _element: unknown,
+        options?: { headers?: Record<string, string> },
+      ) {
+        this.headers = new Headers(options?.headers || {});
+      }
+    },
+  };
+});
+
+describe("OpenGraph Font ArrayBuffer Caching & Response Headers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetFontCacheForTesting();
+  });
+
+  describe("getInterFonts", () => {
+    it("should fetch font data once and return cached ArrayBuffer promise on subsequent calls", async () => {
+      const mockCssText = `
+        @font-face {
+          font-family: 'Inter';
+          font-style: normal;
+          font-weight: 400;
+          src: url(https://fonts.gstatic.com/inter-400.ttf) format('truetype');
+        }
+        @font-face {
+          font-family: 'Inter';
+          font-style: normal;
+          font-weight: 500;
+          src: url(https://fonts.gstatic.com/inter-500.ttf) format('truetype');
+        }
+      `;
+
+      const dummyBufferMedium = new ArrayBuffer(64);
+      const dummyBufferRegular = new ArrayBuffer(32);
+
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+        const urlStr = String(url);
+        if (urlStr.includes("fonts.googleapis.com")) {
+          return new Response(mockCssText, { status: 200 });
+        }
+        if (urlStr.includes("inter-500.ttf")) {
+          return new Response(dummyBufferMedium, { status: 200 });
+        }
+        if (urlStr.includes("inter-400.ttf")) {
+          return new Response(dummyBufferRegular, { status: 200 });
+        }
+        return new Response("", { status: 200 });
+      });
+
+      // First call -> triggers network fetch
+      const fonts1 = await getInterFonts();
+      expect(fonts1[0]).toBeDefined();
+      expect(fonts1[1]).toBeDefined();
+      const initialFetchCount = fetchSpy.mock.calls.length;
+      expect(initialFetchCount).toBe(3); // 1 CSS fetch + 2 font binary fetches
+
+      // Second call -> reuses in-memory cached promise without additional network calls
+      const fonts2 = await getInterFonts();
+      expect(fonts2).toBe(fonts1);
+      expect(fetchSpy.mock.calls.length).toBe(initialFetchCount);
+
+      fetchSpy.mockRestore();
+    });
+
+    it("should clear cache on error allowing subsequent retry", async () => {
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockRejectedValueOnce(new Error("Network Error"))
+        .mockImplementation(async (url) => {
+          const urlStr = String(url);
+          if (urlStr.includes("fonts.googleapis.com")) {
+            return new Response(
+              `
+              @font-face {
+                font-family: 'Inter';
+                font-style: normal;
+                font-weight: 400;
+                src: url(https://fonts.gstatic.com/inter-400.ttf) format('truetype');
+              }
+              @font-face {
+                font-family: 'Inter';
+                font-style: normal;
+                font-weight: 500;
+                src: url(https://fonts.gstatic.com/inter-500.ttf) format('truetype');
+              }
+              `,
+              { status: 200 },
+            );
+          }
+          return new Response(new ArrayBuffer(16), { status: 200 });
+        });
+
+      await expect(getInterFonts()).rejects.toThrow("Network Error");
+
+      // Should attempt fetch again rather than returning failed promise
+      await expect(getInterFonts()).resolves.toBeDefined();
+
+      fetchSpy.mockRestore();
+    });
+  });
+
+  describe("OGImage response headers", () => {
+    it("should include Cache-Control immutable header on rendered ImageResponse", async () => {
+      vi.mocked(getProfileByUsername).mockResolvedValue({
+        data: {
+          username: "octocat",
+          score: 95,
+          total_commits: 100,
+          total_prs: 20,
+          total_issues: 5,
+          total_reviews: 10,
+          visibility: "public",
+        },
+        error: null,
+      } as never);
+
+      const mockCssText = `
+        @font-face {
+          font-family: 'Inter';
+          font-style: normal;
+          font-weight: 400;
+          src: url(https://fonts.gstatic.com/inter-400.ttf) format('truetype');
+        }
+        @font-face {
+          font-family: 'Inter';
+          font-style: normal;
+          font-weight: 500;
+          src: url(https://fonts.gstatic.com/inter-500.ttf) format('truetype');
+        }
+      `;
+
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+        const urlStr = String(url);
+        if (urlStr.includes("api.github.com")) {
+          return new Response(
+            JSON.stringify({
+              name: "The Octocat",
+              avatar_url: "https://github.com/octocat.png",
+            }),
+            { status: 200 },
+          );
+        }
+        if (urlStr.includes("fonts.googleapis.com")) {
+          return new Response(mockCssText, { status: 200 });
+        }
+        return new Response(new ArrayBuffer(16), { status: 200 });
+      });
+
+      const res = await OGImage({
+        params: Promise.resolve({ username: "octocat" }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Cache-Control")).toBe(
+        "public, immutable, max-age=31536000",
+      );
+
+      fetchSpy.mockRestore();
+    });
+  });
+});

--- a/src/lib/__tests__/opengraph-image.test.ts
+++ b/src/lib/__tests__/opengraph-image.test.ts
@@ -54,7 +54,8 @@ describe("OpenGraph Font ArrayBuffer Caching & Response Headers", () => {
 
       const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
         const urlStr = String(url);
-        if (urlStr.includes("fonts.googleapis.com")) {
+        const parsedUrl = new URL(urlStr);
+        if (parsedUrl.hostname === "fonts.googleapis.com") {
           return new Response(mockCssText, { status: 200 });
         }
         if (urlStr.includes("inter-500.ttf")) {
@@ -87,7 +88,8 @@ describe("OpenGraph Font ArrayBuffer Caching & Response Headers", () => {
         .mockRejectedValueOnce(new Error("Network Error"))
         .mockImplementation(async (url) => {
           const urlStr = String(url);
-          if (urlStr.includes("fonts.googleapis.com")) {
+          const parsedUrl = new URL(urlStr);
+          if (parsedUrl.hostname === "fonts.googleapis.com") {
             return new Response(
               `
               @font-face {
@@ -150,7 +152,8 @@ describe("OpenGraph Font ArrayBuffer Caching & Response Headers", () => {
 
       const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
         const urlStr = String(url);
-        if (urlStr.includes("api.github.com")) {
+        const parsedUrl = new URL(urlStr);
+        if (parsedUrl.hostname === "api.github.com") {
           return new Response(
             JSON.stringify({
               name: "The Octocat",
@@ -159,7 +162,7 @@ describe("OpenGraph Font ArrayBuffer Caching & Response Headers", () => {
             { status: 200 },
           );
         }
-        if (urlStr.includes("fonts.googleapis.com")) {
+        if (parsedUrl.hostname === "fonts.googleapis.com") {
           return new Response(mockCssText, { status: 200 });
         }
         return new Response(new ArrayBuffer(16), { status: 200 });


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. Write this in your own words. Do not paste an AI-generated summary here. -->

## Related Issue

Closes #573

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Chore / dependency update

## Changes Made

<!-- Bullet points of what changed and why you made each change -->

- Extracted font loading into getInterFonts() in opengraph-image.tsx with an in-memory cachedFontsPromise cache. TrueType/WOFF font binaries are fetched at most once per edge worker isolate lifespan, avoiding redundant binary parsing and network fetches on social sharing spikes.
- Configured ImageResponse with Cache-Control: public, immutable, max-age=31536000 headers to ensure rendered PNG cards are cached immutably at Cloudflare CDN edges and by social crawlers.



## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with `main`
- [x] Code works locally and I have tested it
- [x] No `console.log` left in `src/`
- [x] If schema changed — both `schema.sql` and a new migration file are included
- [x] If this is a UI change — I read `DESIGN.md` and followed the design system (colors, spacing, typography, components)
- [x] Docs updated if needed
- [x] PR title follows Conventional Commits format (`feat:`, `fix:`, `docs:`, etc.)
- [x] This PR description is written in my own words

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved OpenGraph image generation by caching font resources and fetching required data in parallel.
  * Added long-term caching headers to generated OpenGraph images.

* **Bug Fixes**
  * Font download failures can now recover automatically through subsequent retries.

* **Tests**
  * Added coverage for font caching, retry behavior, and OpenGraph image cache headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->