### PR TITLE
ci(stale): exempt good first issue and pinned from auto-close (closes #553)

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -25,3 +25,12 @@ jobs:
           days-before-close: 7
           stale-issue-label: "stale"
           stale-pr-label: "stale"
+          # Newcomer-facing and deliberately-parked work must survive the sweep.
+          # A "good first issue" is meant to sit unclaimed until someone new picks
+          # it up, so the 30-day timer would close exactly the issues the repo
+          # wants to keep open. Comma-separated, per the action's input format.
+          exempt-issue-labels: "good first issue,pinned"
+          exempt-pr-labels: "pinned"
+          # Already the action's default; stated explicitly because closing a
+          # stale PR must never destroy the contributor's branch.
+          delete-branch: false


### PR DESCRIPTION
## Summary

The stale workflow has been running since mid-July and closes anything with no
activity for 37 days. That's fine for most things, but it also applies to
`good first issue` — and those are supposed to sit there waiting for someone new
to find them. Leaving it as-is means the bot would eventually close the exact
issues we want newcomers to see.

This adds the exemptions the issue asks for. It doesn't change the timings or
the messages, which were already right.

## Related Issue

Closes #553

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Chore / dependency update

## Changes Made

- `exempt-issue-labels: "good first issue,pinned"` — newcomer-facing and
  deliberately-parked issues no longer go stale. Note `good first issue` exists
  in this repo; `pinned` does not yet, so that half activates if the label is
  created later.
- `exempt-pr-labels: "pinned"` — same protection for pull requests.
- `delete-branch: false` — already the action's default. Stated explicitly so a
  future edit can't silently start deleting contributors' branches when a stale
  PR is closed.
- Comments explaining why each exemption exists.

Nothing else in the workflow was touched: `days-before-stale`, `days-before-close`,
the labels and all four messages are unchanged.

## AI Usage

- [ ] I did not use AI for any part of the code in this PR
- [x] I used AI for coding (specify which tool below) and I fully understand every change I made, including which functions I changed, why I changed them, and what side effects they could create

Used Claude for coding.

## Screenshots (if UI change)

n/a — workflow configuration only.

## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with `main`
- [x] Code works locally and I have tested it
- [x] No `console.log` left in `src/`
- [x] If schema changed — both `schema.sql` and a new migration file are included (n/a)
- [x] If this is a UI change — I read `DESIGN.md` and followed the design system (n/a)
- [x] Docs updated if needed (n/a)
- [x] PR title follows Conventional Commits format
- [ ] This PR description is written in my own words

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated inactivity management to preserve issues labeled “good first issue” or “pinned.”
  * Preserved pinned pull requests during stale-item processing.
  * Disabled automatic deletion of pull request branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->