### PR TITLE
fix(ci): make PR issue-link check fork-safe and upsert its notice (closes #548)

### DIFF
--- a/.github/workflows/check-issue-link.yml
+++ b/.github/workflows/check-issue-link.yml
@@ -1,8 +1,33 @@
 name: Verify PR Issue Link
 
+# Runs on `pull_request_target` rather than `pull_request`.
+#
+# A `pull_request` run triggered from a fork receives a read-only GITHUB_TOKEN
+# regardless of the repository's default workflow permissions, so
+# `issues.createComment` answered 403 and the unhandled rejection aborted the
+# script before it could report the actual validation verdict. Contributors on
+# forks therefore saw an opaque "Resource not accessible by integration" error
+# instead of the guidance this check exists to give them.
+#
+# `pull_request_target` is safe in this workflow for the same reason it is in
+# pr-welcome.yml, pr-merged-thanks.yml and auto-label.yml: the job never checks
+# out, builds, installs or executes anything from the pull request. It reads one
+# inert string — the PR description — through the `context` object.
+#
+# Two rules keep it that way, and both must hold for any future edit:
+#   1. Never add a checkout, build or install step here.
+#   2. Never interpolate PR-controlled text into the script through a workflow
+#      expression. Values reached through `context.payload` are handed to the
+#      script as data at runtime; an expression is instead pasted into the
+#      script source before it runs, which is a script-injection vector.
+
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   verify-link:
@@ -12,23 +37,90 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            // Identifies this workflow's own comment so repeated runs update one
+            // notice instead of stacking a new warning on every `synchronize`.
+            // Same upsert convention as bundle-size-comment.yml.
+            const MARKER = "<!-- ossfolio:issue-link-check -->";
+
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.pull_request.number;
             const prBody = context.payload.pull_request.body || "";
 
-            // Regex to look for GitHub linking keywords followed by an issue number (e.g., Closes #123, Fixes #45)
+            // Unchanged from the previous revision. This PR fixes how the result
+            // is delivered, not what counts as a valid link, so no PR that passes
+            // today can start failing because of it.
             const regex = /(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s+#\d+/i;
             const hasLink = regex.test(prBody);
 
-            if (!hasLink) {
-              // Leave an educational comment on the PR
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                body: "⚠️ **Action Required:** Please update your PR description to link the issue you are solving (e.g., write `Closes #issue-number` or `Fixes #issue-number`). This is required to pass automated validation status checks."
-              });
+            const warning = [
+              MARKER,
+              "",
+              "⚠️ **Action Required:** Please update your PR description to link the issue you are solving (e.g., write `Closes #issue-number` or `Fixes #issue-number`). This is required to pass automated validation status checks.",
+            ].join("\n");
 
-              // Fail the workflow check explicitly
-              core.setFailed("PR description does not contain an issue linking keyword expression.");
+            const resolved = [
+              MARKER,
+              "",
+              "✅ **Issue link found.** Thanks — this PR now references the issue it resolves.",
+            ].join("\n");
+
+            const desired = hasLink ? resolved : warning;
+
+            // Paginate: a long review thread can exceed one page, and missing an
+            // earlier notice would recreate the duplicate-comment bug.
+            let existing = null;
+            try {
+              const comments = await github.paginate(
+                github.rest.issues.listComments,
+                { owner, repo, issue_number: prNumber, per_page: 100 },
+              );
+              existing = comments.find(
+                (comment) =>
+                  comment.user?.type === "Bot" && comment.body?.includes(MARKER),
+              );
+            } catch (error) {
+              core.warning(`Could not read existing comments: ${error.message}`);
+            }
+
+            // Commenting is best-effort. The status check must reflect the
+            // description, never the comment API's outcome — that coupling was
+            // the original bug.
+            try {
+              if (existing) {
+                // Skip a no-op write so pushing ten commits to an unlinked PR
+                // does not mark the same comment "edited" ten times.
+                if (existing.body !== desired) {
+                  await github.rest.issues.updateComment({
+                    owner,
+                    repo,
+                    comment_id: existing.id,
+                    body: desired,
+                  });
+                  core.info(`Updated issue-link notice ${existing.id}.`);
+                }
+              } else if (!hasLink) {
+                // Only warn. A compliant PR that never triggered a warning does
+                // not need a comment congratulating it.
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: prNumber,
+                  body: desired,
+                });
+                core.info("Posted issue-link warning.");
+              }
+            } catch (error) {
+              core.warning(
+                `Could not post the issue-link notice: ${error.message}`,
+              );
+            }
+
+            if (!hasLink) {
+              core.setFailed(
+                "PR description does not contain an issue linking keyword expression.",
+              );
             } else {
-              console.log("Validation Passed: Found a qualifying issue link keyword.");
+              core.info(
+                "Validation Passed: Found a qualifying issue link keyword.",
+              );
             }


### PR DESCRIPTION
## Summary

The check that makes sure a PR links its issue is the first thing a new
contributor from a fork runs into, and for them it's been broken in a way that's
easy to miss.

It only comments when the link is *missing*. So if your PR says `Closes #123`,
nothing happens and the check goes green — which is why this looks fine on most
PRs. But a fork PR gets a read-only token, so the moment someone forgets the
link, the comment call comes back 403 and the script dies right there. It never
reaches the line that reports the actual problem. The contributor sees
"Resource not accessible by integration" and no explanation of what to fix.

The second problem is quieter: the check re-runs on every push, and there was
nothing stopping it posting the same warning again each time. Push five commits
while sorting out your description and you get five identical warnings.

So this switches the trigger to `pull_request_target`, which is how the other
commenting workflows here already work, and makes the comment update itself
instead of piling up. The important change is that the pass/fail result no
longer depends on whether the comment succeeded — it just reads the description
and reports on that.

I left the matching rule exactly as it was. Nothing that passes today will start
failing.

## Related Issue

Closes #548

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Chore / dependency update

## Changes Made

- Switched `on: pull_request` to `on: pull_request_target` with explicit
  `permissions: contents: read` and `pull-requests: write`, so fork PRs get a
  token that can actually comment. Trigger types are unchanged
  (`opened, edited, synchronize`).
- Moved `core.setFailed` out of the commenting path. The status check now
  reflects the PR description and never the comment API's outcome — that
  coupling was the underlying bug.
- Added a marker-based upsert (`<!-- ossfolio:issue-link-check -->`) using the
  same convention as `bundle-size-comment.yml`: find this workflow's own
  previous comment and update it rather than posting a new one.
- Paginated `listComments`, so a long review thread can't hide an earlier notice
  past the first page and reintroduce duplicates.
- Added a no-op guard — repeated pushes to an unlinked PR don't repeatedly mark
  the same comment as edited.
- When a link is added later, the warning updates to a resolved notice instead
  of lingering. A compliant PR that never triggered a warning gets no comment.
- Wrapped both API paths in try/catch and log with `core.warning`, so a
  permission problem degrades to a logged warning instead of masking the verdict.
- Documented in the file header why `pull_request_target` is safe here and the
  two invariants that keep it safe.

**Not changed:** the matching regex and the warning text are byte-identical to
the previous version.

## AI Usage

- [ ] I did not use AI for any part of the code in this PR
- [x] I used AI for coding (specify which tool below) and I fully understand every change I made, including which functions I changed, why I changed them, and what side effects they could create

Used Claude for coding.

## Screenshots (if UI change)

n/a — workflow configuration only.

## Testing

Ran the script through a harness that reproduces `actions/github-script`'s
wrapper, with the GitHub client mocked, covering:

1. No link, no prior comment → one warning posted, check fails
2. No link, identical warning already present → no duplicate, no redundant edit
3. Link added later → warning updated to resolved, check passes
4. Link present, no prior comment → nothing posted
5. **No link + `createComment` returns 403 → check still fails with the correct message** (the reported bug)
6. `listComments` fails → logged warning, verdict unaffected
7. Non-bot comment containing the marker → ignored, not edited
8. Marker beyond comment #100 → found via pagination
9. Null PR body → no throw
10. `Closes #548` inside longer prose → still matches

10/10 pass. YAML parses; the extracted script passes `node --check`; Prettier
passes on this file both before and after.

**What I could not verify:** `pull_request_target` workflows run from the base
branch, so the check on this PR will use `main`'s current version. The new
behaviour can only be observed after merge.

## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with `main`
- [x] Code works locally and I have tested it
- [x] No `console.log` left in `src/`
- [x] If schema changed — both `schema.sql` and a new migration file are included (n/a)
- [x] If this is a UI change — I read `DESIGN.md` and followed the design system (n/a)
- [x] Docs updated if needed (n/a)
- [x] PR title follows Conventional Commits format
- [ ] This PR description is written in my own words