### PR TITLE
feat(api): add ETag and 304 conditional caching to public users endpoint (closes #558)

### DIFF
--- a/src/app/api/v1/users/[username]/route.ts
+++ b/src/app/api/v1/users/[username]/route.ts
@@ -5,6 +5,7 @@ import {
   createApiResponse,
   createErrorResponse,
 } from "@/lib/validators/api";
+import { computeETag, isNotModified } from "@/lib/http-cache";
 
 // Runtime managed by @opennextjs/cloudflare
 
@@ -202,9 +203,30 @@ export async function GET(
     last_refreshed_at: profile.last_refreshed_at,
   };
 
-  return withCors(
-    createApiResponse(body, 200, {
-      "Cache-Control": "public, s-maxage=300, stale-while-revalidate=600",
-    }),
-  );
+  // The tag is derived from the exact bytes this endpoint would return.
+  // `NextResponse.json` serialises with `JSON.stringify`, so hashing the same
+  // value here yields a validator that genuinely matches the payload.
+  const etag = await computeETag(JSON.stringify(body));
+
+  const cacheHeaders: Record<string, string> = {
+    "Cache-Control": "public, s-maxage=300, stale-while-revalidate=600",
+    ETag: etag,
+  };
+
+  // The caller already holds this exact representation, so send no payload.
+  //
+  // Built with an explicit null body rather than `createApiResponse`: 304 is a
+  // null-body status, and the Response constructor rejects it outright if a body
+  // is supplied — `NextResponse.json(x, { status: 304 })` throws.
+  //
+  // Only the cache-relevant headers travel with a 304 (RFC 9110 §15.4.5). The
+  // security headers on the 200 guard how a body is interpreted, and there is no
+  // body here; the client merges these fields into the response it already has.
+  if (isNotModified(request.headers.get("if-none-match"), etag)) {
+    return withCors(
+      new NextResponse(null, { status: 304, headers: cacheHeaders }),
+    );
+  }
+
+  return withCors(createApiResponse(body, 200, cacheHeaders));
 }

--- a/src/lib/__tests__/http-cache.test.ts
+++ b/src/lib/__tests__/http-cache.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { computeETag, isNotModified } from "@/lib/http-cache";
+
+describe("computeETag", () => {
+  it("wraps the digest in double quotes, as the entity-tag grammar requires", async () => {
+    const tag = await computeETag("hello");
+    expect(tag.startsWith('"')).toBe(true);
+    expect(tag.endsWith('"')).toBe(true);
+  });
+
+  it("is a strong validator — no weak prefix", async () => {
+    const tag = await computeETag("hello");
+    expect(tag.startsWith("W/")).toBe(false);
+  });
+
+  it("is deterministic for identical input", async () => {
+    expect(await computeETag("same")).toBe(await computeETag("same"));
+  });
+
+  it("changes when the payload changes by a single character", async () => {
+    expect(await computeETag('{"score":100}')).not.toBe(
+      await computeETag('{"score":101}'),
+    );
+  });
+
+  it("matches the known SHA-256 of a fixed input, truncated to 32 hex chars", async () => {
+    // sha256("hello") = 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+    expect(await computeETag("hello")).toBe('"2cf24dba5fb0a30e26e83b2ac5b9e29e"');
+  });
+
+  it("handles an empty payload without throwing", async () => {
+    expect(await computeETag("")).toMatch(/^"[0-9a-f]{32}"$/);
+  });
+
+  it("handles non-ASCII payloads (UTF-8 encoded, not code units)", async () => {
+    expect(await computeETag('{"name":"José 日本"}')).toMatch(/^"[0-9a-f]{32}"$/);
+  });
+});
+
+describe("isNotModified", () => {
+  const ETAG = '"abc123"';
+
+  it("returns false when the header is absent", () => {
+    expect(isNotModified(null, ETAG)).toBe(false);
+    expect(isNotModified(undefined, ETAG)).toBe(false);
+  });
+
+  it("returns false for an empty or whitespace-only header", () => {
+    expect(isNotModified("", ETAG)).toBe(false);
+    expect(isNotModified("   ", ETAG)).toBe(false);
+  });
+
+  it("matches an identical strong tag", () => {
+    expect(isNotModified('"abc123"', ETAG)).toBe(true);
+  });
+
+  it("does not match a different tag", () => {
+    expect(isNotModified('"different"', ETAG)).toBe(false);
+  });
+
+  it("matches a weak tag against a strong one — If-None-Match uses weak comparison", () => {
+    expect(isNotModified('W/"abc123"', ETAG)).toBe(true);
+  });
+
+  it("matches when the current tag appears anywhere in a list", () => {
+    expect(isNotModified('"other", "abc123", "more"', ETAG)).toBe(true);
+    expect(isNotModified('"abc123","second"', ETAG)).toBe(true);
+    expect(isNotModified('"first","second"', ETAG)).toBe(false);
+  });
+
+  it("matches a weak tag inside a list", () => {
+    expect(isNotModified('"other", W/"abc123"', ETAG)).toBe(true);
+  });
+
+  it("tolerates irregular whitespace around list members", () => {
+    expect(isNotModified('   "other" ,    "abc123"   ', ETAG)).toBe(true);
+  });
+
+  it("treats * as a match, per RFC 9110", () => {
+    expect(isNotModified("*", ETAG)).toBe(true);
+    expect(isNotModified("  *  ", ETAG)).toBe(true);
+  });
+
+  it("does not treat a bare * inside a list as a wildcard", () => {
+    // `*` is only meaningful as the entire field value. As a list member it is
+    // not a valid entity-tag and must not silently match everything.
+    expect(isNotModified('"other", *', ETAG)).toBe(false);
+  });
+
+  it("is quote-sensitive — an unquoted value is not a valid entity-tag", () => {
+    expect(isNotModified("abc123", ETAG)).toBe(false);
+  });
+
+  it("does not match on empty list members produced by stray commas", () => {
+    expect(isNotModified(",,,", ETAG)).toBe(false);
+  });
+
+  it("round-trips against a real computed tag", async () => {
+    const tag = await computeETag('{"username":"octocat"}');
+    expect(isNotModified(tag, tag)).toBe(true);
+    expect(isNotModified(`W/${tag}`, tag)).toBe(true);
+    expect(isNotModified('"stale"', tag)).toBe(false);
+  });
+});

--- a/src/lib/__tests__/http-cache.test.ts
+++ b/src/lib/__tests__/http-cache.test.ts
@@ -95,6 +95,26 @@ describe("isNotModified", () => {
     expect(isNotModified(",,,", ETAG)).toBe(false);
   });
 
+  it("treats a comma inside a quoted tag as content, not a delimiter", () => {
+    // `etagc` admits %x23-7E and 0x2C sits in that range, so "a,b" is one
+    // entity-tag rather than two. RFC 9110 §8.8.3.
+    expect(isNotModified('"a,b"', '"a,b"')).toBe(true);
+  });
+
+  it("still splits on commas that sit between quoted tags", () => {
+    expect(isNotModified('"a,b", "abc123"', '"abc123"')).toBe(true);
+    expect(isNotModified('"a,b","c,d"', '"c,d"')).toBe(true);
+  });
+
+  it("does not let a quoted comma cause a false match", () => {
+    expect(isNotModified('"a,b"', '"a"')).toBe(false);
+    expect(isNotModified('"a,b"', '"b"')).toBe(false);
+  });
+
+  it("handles a quoted comma alongside a weak validator", () => {
+    expect(isNotModified('W/"a,b"', '"a,b"')).toBe(true);
+  });
+
   it("round-trips against a real computed tag", async () => {
     const tag = await computeETag('{"username":"octocat"}');
     expect(isNotModified(tag, tag)).toBe(true);

--- a/src/lib/__tests__/v1-users-caching.test.ts
+++ b/src/lib/__tests__/v1-users-caching.test.ts
@@ -80,11 +80,24 @@ describe("GET /api/v1/users/[username] — conditional caching", () => {
     expect((await call()).headers.get("etag")).toBe((await call()).headers.get("etag"));
   });
 
-  it("200 body shape is unchanged by this feature", async () => {
+  it("200 body matches the public contract exactly — no field added or dropped", async () => {
+    // Deep equality rather than a partial match: this endpoint is a versioned
+    // public contract, so a field appearing or disappearing should fail here and
+    // force a deliberate decision, not slip through unnoticed.
     const body = await (await call()).json();
-    expect(body).toMatchObject({
-      username: "octocat", score: 1234,
+    expect(body).toEqual({
+      username: "octocat",
+      name: "The Octocat",
+      avatar_url: "https://a",
+      github_url: "https://g",
+      bio: null,
+      headline: null,
+      score: 1234,
+      followers: 10,
+      top_languages: ["TypeScript"],
       stats: { commits: 1, prs: 2, issues: 3, reviews: 4 },
+      badges: [],
+      last_refreshed_at: "2026-07-26T00:00:00.000Z",
     });
   });
 });

--- a/src/lib/__tests__/v1-users-caching.test.ts
+++ b/src/lib/__tests__/v1-users-caching.test.ts
@@ -1,0 +1,90 @@
+/**
+ * End-to-end coverage of the conditional-caching path on
+ * `GET /api/v1/users/[username]`.
+ *
+ * Lives under `src/lib/__tests__/` rather than beside the route on purpose. The
+ * App Router treats directories under `src/app` as route segments, and putting a
+ * `__tests__` folder inside one puts test files into the routing tree's scan
+ * path. Keeping them here sidesteps that entirely, and matches where every other
+ * suite in this repo already lives.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Stub the DB so the handler runs without Supabase.
+const profile = {
+  username: "octocat", name: "The Octocat", avatar_url: "https://a", github_url: "https://g",
+  bio: null, headline: null, score: 1234, followers: 10, top_languages: ["TypeScript"],
+  total_commits: 1, total_prs: 2, total_issues: 3, total_reviews: 4,
+  badges: [], last_refreshed_at: "2026-07-26T00:00:00.000Z",
+};
+vi.mock("@/lib/db", () => ({
+  getPublicProfileByUsername: vi.fn(async () => ({ data: profile, error: null })),
+}));
+
+import { GET } from "@/app/api/v1/users/[username]/route";
+import { NextRequest } from "next/server";
+
+const call = (headers: Record<string, string> = {}) =>
+  GET(
+    new NextRequest("https://ossfolio.dev/api/v1/users/octocat", { headers }),
+    { params: Promise.resolve({ username: "octocat" }) },
+  );
+
+describe("GET /api/v1/users/[username] — conditional caching", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("200 carries a quoted ETag alongside the existing Cache-Control", async () => {
+    const res = await call();
+    expect(res.status).toBe(200);
+    expect(res.headers.get("etag")).toMatch(/^"[0-9a-f]{32}"$/);
+    expect(res.headers.get("cache-control")).toBe(
+      "public, s-maxage=300, stale-while-revalidate=600",
+    );
+  });
+
+  it("the ETag matches a hash of the exact body the client receives", async () => {
+    const res = await call();
+    const text = await res.text();
+    const { computeETag } = await import("@/lib/http-cache");
+    expect(res.headers.get("etag")).toBe(await computeETag(text));
+  });
+
+  it("replaying the ETag yields 304 with a genuinely empty body", async () => {
+    const first = await call();
+    const etag = first.headers.get("etag")!;
+    const second = await call({ "if-none-match": etag });
+    expect(second.status).toBe(304);
+    expect(await second.text()).toBe("");
+  });
+
+  it("304 still carries ETag, Cache-Control and CORS", async () => {
+    const etag = (await call()).headers.get("etag")!;
+    const res = await call({ "if-none-match": etag });
+    expect(res.headers.get("etag")).toBe(etag);
+    expect(res.headers.get("cache-control")).toContain("s-maxage=300");
+    expect(res.headers.get("access-control-allow-origin")).toBe("*");
+  });
+
+  it("a weak validator also yields 304", async () => {
+    const etag = (await call()).headers.get("etag")!;
+    expect((await call({ "if-none-match": `W/${etag}` })).status).toBe(304);
+  });
+
+  it("a stale ETag falls through to a full 200", async () => {
+    const res = await call({ "if-none-match": '"0000000000000000000000000000dead"' });
+    expect(res.status).toBe(200);
+    expect((await res.json()).username).toBe("octocat");
+  });
+
+  it("the ETag is stable across repeated identical requests", async () => {
+    expect((await call()).headers.get("etag")).toBe((await call()).headers.get("etag"));
+  });
+
+  it("200 body shape is unchanged by this feature", async () => {
+    const body = await (await call()).json();
+    expect(body).toMatchObject({
+      username: "octocat", score: 1234,
+      stats: { commits: 1, prs: 2, issues: 3, reviews: 4 },
+    });
+  });
+});

--- a/src/lib/http-cache.ts
+++ b/src/lib/http-cache.ts
@@ -51,6 +51,36 @@ function stripWeakPrefix(entityTag: string): string {
 }
 
 /**
+ * Split an `If-None-Match` field value into its entity-tags.
+ *
+ * A naive `split(",")` is wrong: a comma is a legal character *inside* an
+ * opaque-tag, because `etagc` admits %x23-7E and 0x2C falls in that range
+ * (RFC 9110 §8.8.3). So `"a,b"` is one tag, not two. Quoting has no escape
+ * mechanism — DQUOTE itself is excluded from `etagc` — so tracking whether we
+ * are inside quotes is sufficient to tokenise correctly.
+ */
+function splitEntityTags(header: string): string[] {
+  const tags: string[] = [];
+  let current = "";
+  let inQuotes = false;
+
+  for (const character of header) {
+    if (character === '"') {
+      inQuotes = !inQuotes;
+      current += character;
+    } else if (character === "," && !inQuotes) {
+      tags.push(current);
+      current = "";
+    } else {
+      current += character;
+    }
+  }
+  tags.push(current);
+
+  return tags;
+}
+
+/**
  * Decide whether a caller's `If-None-Match` header already covers `etag`.
  *
  * Returns true when the request should be answered `304 Not Modified`.
@@ -77,8 +107,7 @@ export function isNotModified(
 
   const current = stripWeakPrefix(etag);
 
-  return header
-    .split(",")
+  return splitEntityTags(header)
     .map((candidate) => stripWeakPrefix(candidate.trim()))
     .some((candidate) => candidate !== "" && candidate === current);
 }

--- a/src/lib/http-cache.ts
+++ b/src/lib/http-cache.ts
@@ -1,0 +1,84 @@
+/**
+ * Conditional-request helpers for public GET endpoints (RFC 9110 §8.8.3, §13.1.2).
+ *
+ * A public profile changes rarely — often not for hours — but every request
+ * currently ships the whole payload again. An `ETag` lets a caller say "I already
+ * have version X", and lets us answer `304 Not Modified` with no body at all.
+ *
+ * What this does and does not save, stated plainly: the 304 removes the response
+ * payload from the wire, not the database read. The tag is derived from the row,
+ * so the row still has to be fetched in order to know whether the caller's copy
+ * is current. The win is bandwidth and client parse time, not query count.
+ */
+
+/**
+ * Derive a strong ETag from the exact bytes the client would have received.
+ *
+ * Hashing the serialised body rather than a timestamp column is deliberate.
+ * `profiles.updated_at` is not part of this endpoint's public projection — the
+ * route excludes internal timestamps on purpose — and widening the projection to
+ * reach one would leak a field the API intentionally hides. The body is also the
+ * more truthful input: it changes exactly when what we send changes, so the tag
+ * can never claim "unchanged" while the payload has in fact moved.
+ *
+ * SHA-256 via Web Crypto matches `rate-limit.ts`, which is available in the edge
+ * runtime this route deploys to. 128 bits of the digest is far past the point
+ * where an accidental collision matters for cache validation.
+ *
+ * The result is a *strong* validator (no `W/` prefix) because it is computed from
+ * the exact response bytes, which is what strong comparison means.
+ */
+export async function computeETag(payload: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(payload),
+  );
+  const hex = Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+  return `"${hex.slice(0, 32)}"`;
+}
+
+/**
+ * Strip an optional weak-validator prefix from an entity-tag.
+ *
+ * `If-None-Match` is evaluated with the *weak* comparison function (RFC 9110
+ * §8.8.3.2), so `W/"abc"` and `"abc"` are a match. The prefix is case-sensitive
+ * and must be an uppercase `W` followed by a solidus, per the grammar.
+ */
+function stripWeakPrefix(entityTag: string): string {
+  return entityTag.startsWith("W/") ? entityTag.slice(2) : entityTag;
+}
+
+/**
+ * Decide whether a caller's `If-None-Match` header already covers `etag`.
+ *
+ * Returns true when the request should be answered `304 Not Modified`.
+ *
+ * Handles the three shapes the header actually takes in the wild:
+ *   - `*`, which matches whenever a representation exists at all
+ *   - a single entity-tag
+ *   - a comma-separated list, which is what a client sends after it has cached
+ *     several variants
+ *
+ * A malformed or absent header is treated as "no match", so the caller falls
+ * through to a normal 200. Being permissive in the wrong direction here would
+ * serve a stale 304, which is far worse than an unnecessary full response.
+ */
+export function isNotModified(
+  ifNoneMatch: string | null | undefined,
+  etag: string,
+): boolean {
+  if (!ifNoneMatch) return false;
+
+  const header = ifNoneMatch.trim();
+  if (header === "") return false;
+  if (header === "*") return true;
+
+  const current = stripWeakPrefix(etag);
+
+  return header
+    .split(",")
+    .map((candidate) => stripWeakPrefix(candidate.trim()))
+    .some((candidate) => candidate !== "" && candidate === current);
+}


### PR DESCRIPTION
## Summary

The public profile endpoint is polled by badges and third-party integrations, and
it sends the whole profile back every single time — even when nothing about that
contributor has changed in hours. There was already an `If-None-Match` entry in
the CORS allow-list, so the intent was there; the endpoint just never returned an
`ETag` for a client to send back.

This adds one. The tag is a SHA-256 of the exact response body, so it changes when
and only when the payload does. A caller that sends it back gets a `304` with an
empty body instead of the full profile.

One thing I want to be straight about, because the issue is inconsistent on it:
this saves bandwidth, not database reads. The Problem Statement says it cuts
Supabase IOPS, but the row still has to be fetched to know whether the caller's
copy is current — you can't answer the question without reading the thing. The
Proposed Solution's own wording, "eliminate data transmission overhead", is the
accurate one, and that's what this delivers.

I also didn't use `updated_at` as the issue suggested. It's excluded from this
endpoint's public projection deliberately — there's a comment in the route saying
internal timestamps are kept out on purpose — so reaching for it would have meant
widening the projection to expose a field the API intentionally hides. Hashing the
body avoids that and is more truthful anyway.

## Related Issue

Closes #558

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Chore / dependency update

## Changes Made

**`src/lib/http-cache.ts`** (new) — two pure functions:

- `computeETag(payload)` — SHA-256 via Web Crypto, truncated to 128 bits and
  quoted per the entity-tag grammar. Uses the same `crypto.subtle.digest` approach
  as `rate-limit.ts`, which is available in the edge runtime this route deploys to.
  It's a strong validator, since it's computed from the exact response bytes.
- `isNotModified(ifNoneMatch, etag)` — evaluates `If-None-Match` with the weak
  comparison the spec requires, so `W/"abc"` matches `"abc"`. Handles `*`, a
  single tag, and a comma-separated list. Anything malformed is treated as "no
  match" so the request falls through to a normal 200 — erring the other way
  would serve a stale 304, which is much worse than an unnecessary full response.

**`src/app/api/v1/users/[username]/route.ts`** — computes the tag, adds `ETag`
alongside the existing `Cache-Control`, and returns `304` when the validator
matches.

Worth flagging one detail: the 304 is built with `new NextResponse(null, ...)`
rather than `createApiResponse`. 304 is a null-body status and the Response
constructor rejects it outright — `NextResponse.json(x, { status: 304 })` throws
`TypeError: Invalid response status code 304`. The obvious implementation would
have crashed on every cache hit. There's a comment in the file so nobody
simplifies it back.

Only the cache-relevant headers travel with the 304, per RFC 9110 §15.4.5. The
security headers on the 200 govern how a body is interpreted and there is no body
here; the client merges these fields into the response it already holds. CORS
headers are still applied, or browsers would refuse to read the response.

**Not changed:** the 200 body shape, the existing `Cache-Control`, the 404 and
400 paths, and the rate limiter. Existing e2e assertions on the error shapes are
untouched.

## AI Usage

- [ ] I did not use AI for any part of the code in this PR
- [x] I used AI for coding (specify which tool below) and I fully understand every change I made, including which functions I changed, why I changed them, and what side effects they could create

Used Claude for coding.

## Screenshots (if UI change)

n/a — API only.

## Testing

28 new tests, all passing. Full suite: **202 passed across 18 files**.

`src/lib/__tests__/http-cache.test.ts` — 20 tests on the helpers: quoting and
grammar, determinism, a known SHA-256 vector, empty and non-ASCII payloads, weak
vs strong comparison, list handling, whitespace tolerance, `*`, and rejection of
unquoted values and stray commas.

`src/lib/__tests__/v1-users-caching.test.ts` — 8 tests driving the real route
handler with the DB stubbed:

1. 200 carries a quoted ETag alongside the existing Cache-Control
2. the ETag equals a hash of the exact body the client receives
3. replaying the ETag yields 304 with a genuinely empty body
4. the 304 still carries ETag, Cache-Control and CORS
5. a weak validator also yields 304
6. a stale ETag falls through to a full 200
7. the ETag is stable across repeated identical requests
8. the 200 body shape is unchanged

That suite lives in `src/lib/__tests__/` rather than beside the route on purpose:
the App Router treats directories under `src/app` as route segments, and a
`__tests__` folder inside one puts test files in the routing tree's scan path.

**On `npm run build`:** it currently fails on `main`, and on this branch, with
`.next/types/app/api/webhooks/github/route.ts` — `Property 'timingSafeEqualBuffer'
is incompatible with index signature`. I verified this is not from this PR by
stashing all four files and rebuilding a clean checkout: webpack reports
`✓ Compiled successfully` and the same type error follows. `src/app/api/webhooks/
github/route.ts` exports `timingSafeEqualBuffer` and `verifySignature` alongside
`POST`, and App Router route modules may only export HTTP methods and specific
config keys. I've raised it separately and have a fix ready if it's wanted.

`npm run type-check` and `npm run lint` report nothing attributable to these four
files.

## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with `main`
- [x] Code works locally and I have tested it
- [x] No `console.log` left in `src/`
- [x] If schema changed — both `schema.sql` and a new migration file are included (n/a)
- [x] If this is a UI change — I read `DESIGN.md` and followed the design system (n/a)
- [x] Docs updated if needed (n/a)
- [x] PR title follows Conventional Commits format
- [ ] This PR description is written in my own words

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ETag-based conditional caching for user profile API responses.
  * Matching cached requests now return `304 Not Modified` without a response body.
  * Responses include ETag and cache-control headers to improve caching efficiency.

* **Bug Fixes**
  * Added support for strong, weak, wildcard, and comma-separated ETag matching.
  * Preserved CORS headers on cached responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->