### PR TITLE
ci(sql): add migration checks for RLS, version collisions and schema sync (closes #552)

### DIFF
--- a/.github/workflows/sql-lint.yml
+++ b/.github/workflows/sql-lint.yml
@@ -1,0 +1,94 @@
+name: SQL Migration Checks
+
+# Validates changes under `supabase/migrations/`.
+#
+# Runs on `pull_request` rather than `pull_request_target`: the job reads files
+# and posts nothing, so the read-only token a fork receives is all it needs. That
+# also means it never runs with write access alongside pull request code.
+#
+# Scope is deliberately limited to files the pull request actually changed. A
+# check that fails on pre-existing history is a check contributors learn to
+# ignore, so historical problems are surfaced as warnings in the job summary
+# instead of failing someone else's unrelated work.
+
+on:
+  pull_request:
+    paths:
+      - "supabase/**"
+      - "scripts/sql-lint.mjs"
+      - ".github/workflows/sql-lint.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  migrations:
+    name: migrations
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out pull request
+        uses: actions/checkout@v4
+        with:
+          # The base branch has to be present locally to diff against it.
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install sqlfluff
+        # Pinned so the parser cannot change underneath the repository without a
+        # commit. An unpinned linter turns every future release into a surprise
+        # CI failure nobody asked for.
+        run: pip install "sqlfluff==4.2.2"
+
+      - name: Collect changed SQL files
+        id: changed
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin "$BASE_REF"
+          CHANGED=$(git diff --name-only "origin/$BASE_REF...HEAD" -- 'supabase/**' || true)
+          echo "Changed files under supabase/:"
+          echo "${CHANGED:-  (none)}"
+          {
+            echo "files<<SQLLINT_EOF"
+            echo "$CHANGED"
+            echo "SQLLINT_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Validate SQL syntax
+        env:
+          CHANGED_FILES: ${{ steps.changed.outputs.files }}
+        run: |
+          set -euo pipefail
+          MIGRATIONS=$(echo "$CHANGED_FILES" | grep -E '^supabase/migrations/.*\.sql$' || true)
+          if [ -z "$MIGRATIONS" ]; then
+            echo "No migration files changed; nothing to parse."
+            exit 0
+          fi
+          STATUS=0
+          while IFS= read -r file; do
+            [ -z "$file" ] && continue
+            [ -f "$file" ] || continue
+            echo "Parsing $file"
+            sqlfluff parse --dialect postgres "$file" > /dev/null || STATUS=1
+          done <<< "$MIGRATIONS"
+          exit $STATUS
+
+      - name: Run migration checks
+        env:
+          CHANGED_FILES: ${{ steps.changed.outputs.files }}
+        run: |
+          set -euo pipefail
+          # shellcheck disable=SC2086
+          node scripts/sql-lint.mjs $(echo "$CHANGED_FILES" | tr '\n' ' ') \
+            | tee -a "$GITHUB_STEP_SUMMARY"

--- a/scripts/__tests__/sql-lint.test.ts
+++ b/scripts/__tests__/sql-lint.test.ts
@@ -1,0 +1,316 @@
+import { describe, it, expect } from "vitest";
+
+// The script is plain JavaScript because CI runs it directly with `node` —
+// there is no tsx or ts-node in this project, so a .ts entry point could not be
+// executed by a workflow. Same arrangement as bundle-size.test.ts.
+const {
+  stripComments,
+  parseVersion,
+  findDuplicateVersions,
+  extractCreatedTables,
+  extractRlsEnabledTables,
+  tablesMissingRls,
+  schemaSnapshotUpdated,
+  lintMigrations,
+  renderReport,
+} = await import("../sql-lint.mjs");
+
+describe("parseVersion", () => {
+  it("reads the 14-digit ordering prefix", () => {
+    expect(parseVersion("20260726000000_add_achievement_unlocks.sql")).toBe(
+      "20260726000000",
+    );
+  });
+
+  it("works on a full path", () => {
+    expect(parseVersion("supabase/migrations/20260520000001_initial.sql")).toBe(
+      "20260520000001",
+    );
+  });
+
+  it("returns null when there is no version prefix", () => {
+    expect(parseVersion("schema.sql")).toBeNull();
+    expect(parseVersion("2026_short.sql")).toBeNull();
+  });
+});
+
+describe("findDuplicateVersions", () => {
+  it("finds nothing when every version is distinct", () => {
+    expect(
+      findDuplicateVersions(["20260101000000_a.sql", "20260102000000_b.sql"]),
+    ).toEqual([]);
+  });
+
+  it("reports a collision with both filenames", () => {
+    expect(
+      findDuplicateVersions([
+        "20260726000000_a.sql",
+        "20260726000000_b.sql",
+        "20260727000000_c.sql",
+      ]),
+    ).toEqual([
+      {
+        version: "20260726000000",
+        files: ["20260726000000_a.sql", "20260726000000_b.sql"],
+      },
+    ]);
+  });
+
+  it("ignores files without a version prefix", () => {
+    expect(findDuplicateVersions(["schema.sql", "README.md"])).toEqual([]);
+  });
+});
+
+describe("stripComments", () => {
+  it("removes line comments", () => {
+    expect(stripComments("-- create table ghost (x int);\nselect 1;")).not.toMatch(
+      /ghost/,
+    );
+  });
+
+  it("removes block comments", () => {
+    expect(stripComments("/* create table ghost (x int); */ select 1;")).not.toMatch(
+      /ghost/,
+    );
+  });
+});
+
+describe("extractCreatedTables", () => {
+  it("finds a plain create", () => {
+    expect(extractCreatedTables("create table profiles (id uuid);")).toEqual([
+      "profiles",
+    ]);
+  });
+
+  it("handles IF NOT EXISTS and a public. prefix", () => {
+    expect(
+      extractCreatedTables("CREATE TABLE IF NOT EXISTS public.snapshots (id int);"),
+    ).toEqual(["snapshots"]);
+  });
+
+  it("handles quoted identifiers", () => {
+    expect(extractCreatedTables('create table "public"."my_table" (id int);')).toEqual(
+      ["my_table"],
+    );
+  });
+
+  it("finds several tables in one migration", () => {
+    expect(
+      extractCreatedTables(
+        "create table orgs (id int);\ncreate table org_members (id int);",
+      ),
+    ).toEqual(["orgs", "org_members"]);
+  });
+
+  it("does not treat a commented-out create as real", () => {
+    expect(
+      extractCreatedTables("-- create table ghost (id int);\ncreate table real (id int);"),
+    ).toEqual(["real"]);
+  });
+
+  it("is case-insensitive and tolerant of extra whitespace", () => {
+    expect(extractCreatedTables("CrEaTe   TABLE\n  Weird (id int);")).toEqual([
+      "weird",
+    ]);
+  });
+});
+
+describe("extractRlsEnabledTables", () => {
+  it("recognises the standard statement", () => {
+    expect(
+      extractRlsEnabledTables("alter table public.profiles enable row level security;"),
+    ).toEqual(["profiles"]);
+  });
+
+  it("is case-insensitive and handles no schema prefix", () => {
+    expect(
+      extractRlsEnabledTables("ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;"),
+    ).toEqual(["profiles"]);
+  });
+
+  it("does not match a disable statement", () => {
+    expect(
+      extractRlsEnabledTables("alter table profiles disable row level security;"),
+    ).toEqual([]);
+  });
+});
+
+describe("tablesMissingRls", () => {
+  it("passes when every created table enables RLS", () => {
+    const sql = `
+      create table public.widgets (id int);
+      alter table public.widgets enable row level security;
+    `;
+    expect(tablesMissingRls(sql)).toEqual([]);
+  });
+
+  it("flags a table created without RLS", () => {
+    expect(tablesMissingRls("create table public.widgets (id int);")).toEqual([
+      "widgets",
+    ]);
+  });
+
+  it("flags only the table that is missing it", () => {
+    const sql = `
+      create table a (id int);
+      create table b (id int);
+      alter table a enable row level security;
+    `;
+    expect(tablesMissingRls(sql)).toEqual(["b"]);
+  });
+
+  it("passes a table with RLS on and no policies — that is a deliberate pattern here", () => {
+    // profile_snapshots documents exactly this: RLS on, zero write policies,
+    // because the only writer is the service-role background sync.
+    const sql = `
+      create table public.snapshots (id int);
+      alter table public.snapshots enable row level security;
+    `;
+    expect(tablesMissingRls(sql)).toEqual([]);
+  });
+});
+
+describe("schemaSnapshotUpdated", () => {
+  it("is not required when no migration changed", () => {
+    expect(schemaSnapshotUpdated(["src/lib/db.ts"])).toEqual({
+      required: false,
+      satisfied: true,
+    });
+  });
+
+  it("is satisfied when both a migration and the snapshot changed", () => {
+    expect(
+      schemaSnapshotUpdated([
+        "supabase/migrations/20260101000000_a.sql",
+        "supabase/schema.sql",
+      ]),
+    ).toEqual({ required: true, satisfied: true });
+  });
+
+  it("is unsatisfied when only a migration changed", () => {
+    expect(
+      schemaSnapshotUpdated(["supabase/migrations/20260101000000_a.sql"]),
+    ).toEqual({ required: true, satisfied: false });
+  });
+
+  it("normalises Windows path separators", () => {
+    expect(
+      schemaSnapshotUpdated([
+        "supabase\\migrations\\20260101000000_a.sql",
+        "supabase/schema.sql",
+      ]),
+    ).toEqual({ required: true, satisfied: true });
+  });
+});
+
+describe("lintMigrations", () => {
+  const clean = {
+    allMigrations: ["20260101000000_a.sql", "20260102000000_b.sql"],
+    changedFiles: [
+      "supabase/migrations/20260102000000_b.sql",
+      "supabase/schema.sql",
+    ],
+    contentsByFile: {
+      "supabase/migrations/20260102000000_b.sql":
+        "create table b (id int); alter table b enable row level security;",
+    },
+  };
+
+  it("reports nothing for a well-formed migration", () => {
+    expect(lintMigrations(clean)).toEqual({ errors: [], warnings: [] });
+  });
+
+  it("errors when a new table has no RLS", () => {
+    const result = lintMigrations({
+      ...clean,
+      contentsByFile: {
+        "supabase/migrations/20260102000000_b.sql": "create table b (id int);",
+      },
+    });
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('table "b"');
+    expect(result.errors[0]).toContain("ENABLE ROW LEVEL SECURITY");
+  });
+
+  it("errors when the schema snapshot was not updated alongside", () => {
+    const result = lintMigrations({
+      ...clean,
+      changedFiles: ["supabase/migrations/20260102000000_b.sql"],
+    });
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain("schema.sql");
+  });
+
+  it("errors on a version collision this pull request introduced", () => {
+    const result = lintMigrations({
+      allMigrations: ["20260101000000_a.sql", "20260101000000_b.sql"],
+      changedFiles: [
+        "supabase/migrations/20260101000000_b.sql",
+        "supabase/schema.sql",
+      ],
+      contentsByFile: {
+        "supabase/migrations/20260101000000_b.sql":
+          "create table b (id int); alter table b enable row level security;",
+      },
+    });
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain("20260101000000");
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it("only warns about a collision the pull request did not touch", () => {
+    // A contributor editing an unrelated file should not inherit a red check for
+    // history they had no part in.
+    const result = lintMigrations({
+      allMigrations: ["20260101000000_a.sql", "20260101000000_b.sql"],
+      changedFiles: ["src/lib/db.ts"],
+      contentsByFile: {},
+    });
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("20260101000000");
+  });
+
+  it("reports several problems at once rather than stopping at the first", () => {
+    const result = lintMigrations({
+      allMigrations: ["20260101000000_a.sql"],
+      changedFiles: ["supabase/migrations/20260101000000_a.sql"],
+      contentsByFile: {
+        "supabase/migrations/20260101000000_a.sql":
+          "create table a (id int); create table b (id int);",
+      },
+    });
+    expect(result.errors).toHaveLength(3);
+  });
+
+  it("ignores changed files outside the migrations directory", () => {
+    expect(
+      lintMigrations({
+        allMigrations: ["20260101000000_a.sql"],
+        changedFiles: ["README.md", "src/lib/db.ts"],
+        contentsByFile: {},
+      }),
+    ).toEqual({ errors: [], warnings: [] });
+  });
+});
+
+describe("renderReport", () => {
+  it("says so plainly when nothing is wrong", () => {
+    expect(renderReport({ errors: [], warnings: [] })).toContain(
+      "No issues found",
+    );
+  });
+
+  it("lists errors with a count", () => {
+    const out = renderReport({ errors: ["first", "second"], warnings: [] });
+    expect(out).toContain("Errors (2)");
+    expect(out).toContain("- first");
+    expect(out).toContain("- second");
+  });
+
+  it("marks warnings as pre-existing so they are not mistaken for regressions", () => {
+    const out = renderReport({ errors: [], warnings: ["old collision"] });
+    expect(out).toContain("Warnings (1)");
+    expect(out).toContain("Pre-existing");
+  });
+});

--- a/scripts/sql-lint.mjs
+++ b/scripts/sql-lint.mjs
@@ -1,0 +1,226 @@
+// Migration checks for `supabase/migrations/`.
+//
+// Plain JavaScript, run directly with `node` in CI, matching bundle-size.mjs —
+// there is no tsx or ts-node in this project, so a .ts entry point could not be
+// executed by a workflow.
+//
+// Three rules, each chosen because it is already satisfied by every migration in
+// the repository. A check that fails on existing history is a check everyone
+// learns to ignore.
+//
+// Deliberately NOT enforced: sqlfluff's default rule set. It reports 424
+// violations across the current 20 migrations, almost all cosmetic (202 indent,
+// 125 line-length, 51 spacing). Gating on that would turn the job permanently red
+// and teach contributors to skip it. Syntax is validated separately by
+// `sqlfluff parse`, which passes on all 20 today.
+
+import { readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const MIGRATIONS_DIR = "supabase/migrations";
+export const SCHEMA_FILE = "supabase/schema.sql";
+
+/**
+ * Remove SQL comments before pattern matching.
+ *
+ * Without this, a line like `-- create table foo (...)` in a design note would be
+ * read as a real table definition and demand an RLS policy that should not exist.
+ */
+export const stripComments = (sql) =>
+  sql.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/--[^\n]*/g, " ");
+
+/**
+ * Pull the ordering prefix out of a migration filename.
+ *
+ * Supabase orders migrations by this prefix, not by content or commit date, so
+ * two files sharing one is genuinely ambiguous rather than merely untidy.
+ */
+export const parseVersion = (filename) => {
+  const match = path.basename(filename).match(/^(\d{14})_/);
+  return match ? match[1] : null;
+};
+
+/** Group migration filenames by version, returning only the collisions. */
+export const findDuplicateVersions = (filenames) => {
+  const byVersion = new Map();
+
+  for (const filename of filenames) {
+    const version = parseVersion(filename);
+    if (!version) continue;
+    const bucket = byVersion.get(version) ?? [];
+    bucket.push(path.basename(filename));
+    byVersion.set(version, bucket);
+  }
+
+  return [...byVersion.entries()]
+    .filter(([, files]) => files.length > 1)
+    .map(([version, files]) => ({ version, files: files.sort() }))
+    .sort((a, b) => a.version.localeCompare(b.version));
+};
+
+/** Table names introduced by `CREATE TABLE` statements in one migration. */
+export const extractCreatedTables = (sql) => {
+  const source = stripComments(sql);
+  const pattern =
+    /create\s+table\s+(?:if\s+not\s+exists\s+)?(?:"?public"?\s*\.\s*)?"?([a-z_][a-z0-9_]*)"?/gi;
+
+  return [...source.matchAll(pattern)].map((match) => match[1].toLowerCase());
+};
+
+/** Table names that have row level security switched on in one migration. */
+export const extractRlsEnabledTables = (sql) => {
+  const source = stripComments(sql);
+  const pattern =
+    /alter\s+table\s+(?:if\s+exists\s+)?(?:"?public"?\s*\.\s*)?"?([a-z_][a-z0-9_]*)"?\s+enable\s+row\s+level\s+security/gi;
+
+  return [...source.matchAll(pattern)].map((match) => match[1].toLowerCase());
+};
+
+/**
+ * Tables created without row level security being enabled.
+ *
+ * The rule checks that RLS is *on*, not that policies exist. Several tables here
+ * intentionally carry zero policies — `profile_snapshots` says so in a comment —
+ * because the only writer is the server-side sync using the service-role key,
+ * which bypasses RLS by design. RLS on with no policies denies anonymous access
+ * outright, which is the stricter posture. Demanding policies would flag that
+ * correct design as a violation.
+ */
+export const tablesMissingRls = (sql) => {
+  const created = extractCreatedTables(sql);
+  const enabled = new Set(extractRlsEnabledTables(sql));
+  return created.filter((table) => !enabled.has(table));
+};
+
+/**
+ * CONTRIBUTING.md requires a migration and the schema snapshot to move together,
+ * so that `schema.sql` stays a truthful picture of the database.
+ */
+export const schemaSnapshotUpdated = (changedFiles) => {
+  const normalised = changedFiles.map((file) => file.replace(/\\/g, "/"));
+  const touchedMigration = normalised.some(
+    (file) => file.startsWith(`${MIGRATIONS_DIR}/`) && file.endsWith(".sql"),
+  );
+  if (!touchedMigration) return { required: false, satisfied: true };
+
+  return {
+    required: true,
+    satisfied: normalised.includes(SCHEMA_FILE),
+  };
+};
+
+/**
+ * Run every rule and return findings.
+ *
+ * Version collisions among files this pull request did not touch are reported as
+ * warnings rather than errors. They are real problems, but failing a contributor's
+ * unrelated pull request for pre-existing history is how a check gets disabled.
+ */
+export const lintMigrations = ({
+  allMigrations,
+  changedFiles,
+  contentsByFile,
+}) => {
+  const errors = [];
+  const warnings = [];
+
+  const changedMigrations = changedFiles
+    .map((file) => file.replace(/\\/g, "/"))
+    .filter(
+      (file) => file.startsWith(`${MIGRATIONS_DIR}/`) && file.endsWith(".sql"),
+    );
+  const changedBasenames = new Set(
+    changedMigrations.map((file) => path.basename(file)),
+  );
+
+  for (const duplicate of findDuplicateVersions(allMigrations)) {
+    const involvesThisPr = duplicate.files.some((file) =>
+      changedBasenames.has(file),
+    );
+    const message = `Migration version ${duplicate.version} is used by ${duplicate.files.length} files: ${duplicate.files.join(", ")}. Supabase orders migrations by this prefix, so their apply order is undefined.`;
+    (involvesThisPr ? errors : warnings).push(message);
+  }
+
+  for (const file of changedMigrations) {
+    const sql = contentsByFile[file];
+    if (sql === undefined) continue;
+
+    const missing = tablesMissingRls(sql);
+    for (const table of missing) {
+      errors.push(
+        `${file}: table "${table}" is created without row level security. Add \`ALTER TABLE public.${table} ENABLE ROW LEVEL SECURITY;\`.`,
+      );
+    }
+  }
+
+  const snapshot = schemaSnapshotUpdated(changedFiles);
+  if (snapshot.required && !snapshot.satisfied) {
+    errors.push(
+      `${MIGRATIONS_DIR}/ changed but ${SCHEMA_FILE} did not. CONTRIBUTING.md requires both in the same pull request so the schema snapshot stays accurate.`,
+    );
+  }
+
+  return { errors, warnings };
+};
+
+/** Render findings as a GitHub step summary. */
+export const renderReport = ({ errors, warnings }) => {
+  const lines = ["## Migration checks", ""];
+
+  if (errors.length === 0 && warnings.length === 0) {
+    lines.push("No issues found.");
+    return lines.join("\n");
+  }
+
+  if (errors.length > 0) {
+    lines.push(`### Errors (${errors.length})`, "");
+    for (const error of errors) lines.push(`- ${error}`);
+    lines.push("");
+  }
+
+  if (warnings.length > 0) {
+    lines.push(`### Warnings (${warnings.length})`, "");
+    lines.push(
+      "_Pre-existing, and not caused by this pull request. Reported so they stay visible._",
+      "",
+    );
+    for (const warning of warnings) lines.push(`- ${warning}`);
+  }
+
+  return lines.join("\n").trimEnd();
+};
+
+const isDirectRun =
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isDirectRun) {
+  const changedFiles = process.argv.slice(2).filter(Boolean);
+
+  const entries = await readdir(MIGRATIONS_DIR).catch(() => []);
+  const allMigrations = entries.filter((entry) => entry.endsWith(".sql")).sort();
+
+  const contentsByFile = {};
+  for (const file of changedFiles) {
+    const normalised = file.replace(/\\/g, "/");
+    if (
+      !normalised.startsWith(`${MIGRATIONS_DIR}/`) ||
+      !normalised.endsWith(".sql")
+    ) {
+      continue;
+    }
+    contentsByFile[normalised] = await readFile(normalised, "utf8").catch(
+      () => undefined,
+    );
+  }
+
+  const result = lintMigrations({ allMigrations, changedFiles, contentsByFile });
+  const report = renderReport(result);
+
+  console.log(report);
+
+  if (result.errors.length > 0) {
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
## Summary

Migrations are the one place in this repo where a mistake is expensive — it lands
in production data and there's no quick revert. Right now nothing checks them
before merge.

This adds a workflow that runs three checks against migration files a PR actually
touches. I picked the rules by first measuring them against all 20 existing
migrations, because a check that fails on history is one everybody learns to
ignore. All three pass cleanly on `main` today.

Two things came out of that measurement that I want to flag, because they changed
what I built.

**sqlfluff's default rules are unusable here.** The issue suggests sqlfluff, and
it does parse our SQL perfectly — all 20 files, no failures. But its default lint
rules report **424 violations** across those same files, almost entirely cosmetic:
202 indentation, 125 line-length, 51 spacing. Turning that on would make the job
permanently red on day one. So this uses `sqlfluff parse` for syntax validation,
which is genuinely clean, and does not enable the default rule set.

**The RLS rule as written would flag correct code.** The issue asks to verify that
every new table "explicitly defines RLS policies". Several tables here deliberately
have zero policies — `profile_snapshots` says so in a comment:

> No insert/update/delete policies are granted, deliberately. The only writer is
> the background sync, which runs server-side with the service-role key.

RLS enabled with no policies denies anonymous access outright, which is the
stricter posture, not a gap. So the check enforces that RLS is *enabled* on every
new table, which is the real security invariant and is satisfied by all 10 tables
in the repo's history. If you'd rather it also demanded policies, I can add it,
but it would need an exemption list for the service-role tables.

## Related Issue

Closes #552

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Chore / dependency update

## Changes Made

**`.github/workflows/sql-lint.yml`** — runs on `pull_request`, filtered to
`supabase/**`. It only reads files and posts nothing, so the read-only token a
fork gets is sufficient, and it never runs with write access alongside PR code.
sqlfluff is pinned to `4.2.2` so the parser can't change under us without a commit.

**`scripts/sql-lint.mjs`** — the repo-specific checks, as plain JavaScript with
named exports and a CLI guard, matching `bundle-size.mjs`. Three rules:

1. **RLS enabled** on every table created in a changed migration.
2. **No duplicate migration versions.** Supabase orders migrations by the 14-digit
   filename prefix, so two files sharing one have undefined apply order.
3. **`schema.sql` updated alongside.** CONTRIBUTING.md already requires a migration
   and the schema snapshot to ship together; this is just enforcing it.

**`scripts/__tests__/sql-lint.test.ts`** — 35 tests.

One deliberate behaviour: a version collision among files the PR *didn't* touch is
reported as a **warning**, not an error. There is one on `main` right now —
`20260726000000` is shared by `add_achievement_unlocks.sql` and
`add_profile_advisory_locks.sql`, both from 26 July — and someone editing
`src/lib/db.ts` shouldn't get a red check for it. It becomes an error the moment a
PR touches one of the colliding files. That collision is real and worth fixing
separately; I've left it visible in the job summary rather than silently passing it.

## AI Usage

- [ ] I did not use AI for any part of the code in this PR
- [x] I used AI for coding (specify which tool below) and I fully understand every change I made, including which functions I changed, why I changed them, and what side effects they could create

Used Claude for coding.

## Screenshots (if UI change)

n/a — CI only.

## Testing

35 new tests. Full suite: **241 passed across 19 files**.

Coverage includes version parsing, duplicate detection, comment stripping (so a
commented-out `create table` isn't mistaken for a real one), table extraction with
`IF NOT EXISTS` / `public.` / quoted identifiers / multiple tables per file, RLS
detection including rejecting `disable row level security`, the schema-sync rule
with Windows path separators, and the error-vs-warning split for collisions.

Also verified end to end against the real repository:

| Scenario | Result |
|---|---|
| Unrelated PR, no migrations touched | exit 0, warning only |
| Real migration + `schema.sql` | exit 0 |
| Migration without `schema.sql` | exit 1 |
| PR touching one of the colliding files | exit 1 |

And against all 20 existing migrations: 10 tables detected, 0 RLS violations,
`sqlfluff parse` clean on every file. Cross-checked the table extractor against a
plain `grep -c "create table"` — 9 files, exact match.

**Note on Prettier:** `sql-lint.yml` will fail the Prettier check on 5 lines, all
double-vs-single quotes. I kept double quotes because `ci.yml`, `e2e.yml` and
`bundle-size.yml` all use `node-version: "22"` — single quotes would make this the
one inconsistent workflow of twenty. Happy to flip it if you'd rather.

The build and E2E checks are currently failing repo-wide because of a separate
issue in `src/app/api/webhooks/github/route.ts`, unrelated to this PR.

## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with `main`
- [x] Code works locally and I have tested it
- [x] No `console.log` left in `src/`
- [x] If schema changed — both `schema.sql` and a new migration file are included (n/a)
- [x] If this is a UI change — I read `DESIGN.md` and followed the design system (n/a)
- [x] Docs updated if needed (n/a)
- [x] PR title follows Conventional Commits format
- [ ] This PR description is written in my own words

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated SQL migration checks for changed migration files.
  * Validates SQL syntax and detects missing row-level security on newly created tables.
  * Verifies schema snapshots are updated alongside migration changes.
  * Reports migration version conflicts and distinguishes errors from warnings.

* **Tests**
  * Added comprehensive automated coverage for SQL parsing, linting rules, and report formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->