### PR TITLE
feat(db): archive dormant unclaimed profile snapshots on a nightly schedule (closes #560)

### DIFF
--- a/supabase/migrations/20260727000000_archive_dormant_snapshots.sql
+++ b/supabase/migrations/20260727000000_archive_dormant_snapshots.sql
@@ -1,0 +1,255 @@
+-- Archive dormant profile snapshots.
+--
+-- `profile_snapshots` holds one row per username the site has ever rendered, and
+-- it is not tied to auth.users — a row exists for anyone whose profile page was
+-- opened once, including people who never signed up. The `snapshot` column holds
+-- the raw GitHub payload: user object, every repository, merged pull requests,
+-- organisations and a full contribution calendar. That is the large part.
+--
+-- Most of those rows are never looked at again. This adds a scheduled job that,
+-- for snapshots untouched for 90 days and belonging to nobody with an account,
+-- keeps a small numeric summary and drops the bulky JSON.
+--
+-- The row itself is kept, not deleted. `sync_started_at` on that row is the claim
+-- marker that stops concurrent renders stampeding the GitHub API, and the username
+-- is the primary key the sync path expects to find. Deleting the row would throw
+-- both away to save a few bytes.
+--
+-- Clearing `snapshot` is safe against the read path. `src/app/[username]/page.tsx`
+-- branches on `if (!stored?.snapshot)` and renders the syncing state, then
+-- refreshes in the background — the same path a profile that was never synced
+-- takes. So an archived profile that someone does visit again simply behaves like
+-- a cold one, which after ninety unvisited days it effectively is.
+
+-- ---------------------------------------------------------------------------
+-- 1. The compact archive
+-- ---------------------------------------------------------------------------
+
+create table if not exists public.profile_snapshot_archive (
+  username text primary key,
+  archived_at timestamptz not null default now(),
+  -- The `synced_at` the snapshot carried when it was archived, so the summary can
+  -- be read as "this is what the account looked like on this date".
+  last_synced_at timestamptz,
+  followers integer,
+  public_repos integer,
+  repo_count integer,
+  total_stars bigint,
+  total_commits integer,
+  total_prs integer,
+  total_issues integer,
+  total_reviews integer,
+  total_contributions integer,
+  merged_pr_count integer,
+  org_count integer,
+  -- `profile_snapshots` enforces the same invariant. Without it the archive could
+  -- hold "Octocat" and "octocat" as separate rows and neither would join back.
+  constraint profile_snapshot_archive_username_lowercase
+    check (username = lower(username))
+);
+
+comment on table public.profile_snapshot_archive is
+  'Small numeric summary of a profile snapshot whose bulky JSON payload has been dropped after a period of dormancy.';
+comment on column public.profile_snapshot_archive.last_synced_at is
+  'Value of profile_snapshots.synced_at at the moment of archiving, so the summary has a meaningful date attached.';
+comment on column public.profile_snapshot_archive.total_stars is
+  'Sum of stargazers across the stored repositories. bigint because this is a sum, not a per-repository count.';
+
+create index if not exists idx_profile_snapshot_archive_archived_at
+  on public.profile_snapshot_archive (archived_at);
+
+alter table public.profile_snapshot_archive enable row level security;
+
+-- Readable by anyone, matching profile_snapshots: these are public profiles and
+-- the summary is strictly less information than the payload it replaces.
+create policy "profile_snapshot_archive_select"
+  on public.profile_snapshot_archive
+  for select using (true);
+
+-- No insert/update/delete policies, deliberately, exactly as on profile_snapshots.
+-- The only writer is the scheduled job below, which runs as the function owner and
+-- bypasses RLS. An anonymous client can read a summary but never forge one.
+
+-- ---------------------------------------------------------------------------
+-- 2. Helper: tolerant integer extraction
+-- ---------------------------------------------------------------------------
+
+-- Snapshots are written by the application from GitHub's API, so these fields are
+-- numeric in practice. "In practice" is not good enough for an unattended job: one
+-- malformed row would abort the whole nightly run and it would keep aborting. This
+-- yields NULL for anything non-numeric instead of raising.
+create or replace function public.safe_jsonb_int(p_value text)
+returns integer
+language sql
+immutable
+as $$
+  select case when p_value ~ '^-?[0-9]+$' then p_value::integer end;
+$$;
+
+comment on function public.safe_jsonb_int(text) is
+  'Parse a JSON text value as an integer, returning NULL rather than raising when it is not one.';
+
+-- ---------------------------------------------------------------------------
+-- 3. The archival routine
+-- ---------------------------------------------------------------------------
+
+create or replace function public.archive_dormant_profile_snapshots(
+  p_retention_days integer default 90
+)
+returns integer
+language plpgsql
+security definer
+-- Pinned so the function cannot be redirected by a caller's search_path.
+set search_path = public
+as $$
+declare
+  v_cutoff timestamptz;
+  v_archived integer := 0;
+begin
+  if p_retention_days is null or p_retention_days < 1 then
+    raise exception 'p_retention_days must be a positive integer, got %',
+      p_retention_days;
+  end if;
+
+  v_cutoff := now() - make_interval(days => p_retention_days);
+
+  -- One statement on purpose. The archive insert and the payload clearing see the
+  -- same set of rows, so a snapshot cannot be cleared without its summary having
+  -- been written, and a sync landing mid-run cannot cause the two to disagree.
+  with dormant as (
+    select
+      ps.username,
+      ps.synced_at,
+      ps.snapshot -> 'user' as gh_user,
+      ps.snapshot -> 'liveStats' as live_stats,
+      case
+        when jsonb_typeof(ps.snapshot -> 'repos') = 'array'
+        then ps.snapshot -> 'repos'
+        else '[]'::jsonb
+      end as repos,
+      case
+        when jsonb_typeof(ps.snapshot -> 'mergedPRs') = 'array'
+        then ps.snapshot -> 'mergedPRs'
+        else '[]'::jsonb
+      end as merged_prs,
+      case
+        when jsonb_typeof(ps.snapshot -> 'orgs') = 'array'
+        then ps.snapshot -> 'orgs'
+        else '[]'::jsonb
+      end as orgs
+    from public.profile_snapshots ps
+    where ps.snapshot is not null
+      and ps.synced_at is not null
+      and ps.synced_at < v_cutoff
+      -- Only unclaimed usernames. Somebody who signed up owns their data, and
+      -- silently degrading a registered account's profile is not this job's call.
+      and not exists (
+        select 1
+        from public.profiles p
+        where lower(p.username) = ps.username
+      )
+  ),
+  archived as (
+    insert into public.profile_snapshot_archive as a (
+      username,
+      archived_at,
+      last_synced_at,
+      followers,
+      public_repos,
+      repo_count,
+      total_stars,
+      total_commits,
+      total_prs,
+      total_issues,
+      total_reviews,
+      total_contributions,
+      merged_pr_count,
+      org_count
+    )
+    select
+      d.username,
+      now(),
+      d.synced_at,
+      public.safe_jsonb_int(d.gh_user ->> 'followers'),
+      public.safe_jsonb_int(d.gh_user ->> 'public_repos'),
+      jsonb_array_length(d.repos),
+      (
+        select coalesce(sum(public.safe_jsonb_int(r ->> 'stargazers_count')), 0)
+        from jsonb_array_elements(d.repos) as r
+      ),
+      public.safe_jsonb_int(d.live_stats ->> 'totalCommits'),
+      public.safe_jsonb_int(d.live_stats ->> 'totalPRs'),
+      public.safe_jsonb_int(d.live_stats ->> 'totalIssues'),
+      public.safe_jsonb_int(d.live_stats ->> 'totalReviews'),
+      public.safe_jsonb_int(d.live_stats ->> 'totalContributions'),
+      jsonb_array_length(d.merged_prs),
+      jsonb_array_length(d.orgs)
+    from dormant d
+    -- A username can be archived, revived by a visit, then fall dormant again.
+    -- The newest summary wins rather than the insert failing.
+    on conflict (username) do update set
+      archived_at = excluded.archived_at,
+      last_synced_at = excluded.last_synced_at,
+      followers = excluded.followers,
+      public_repos = excluded.public_repos,
+      repo_count = excluded.repo_count,
+      total_stars = excluded.total_stars,
+      total_commits = excluded.total_commits,
+      total_prs = excluded.total_prs,
+      total_issues = excluded.total_issues,
+      total_reviews = excluded.total_reviews,
+      total_contributions = excluded.total_contributions,
+      merged_pr_count = excluded.merged_pr_count,
+      org_count = excluded.org_count
+    returning a.username
+  )
+  update public.profile_snapshots ps
+     set snapshot = null
+   where ps.username in (select username from archived);
+
+  get diagnostics v_archived = row_count;
+  return v_archived;
+end;
+$$;
+
+comment on function public.archive_dormant_profile_snapshots(integer) is
+  'Summarise and drop the JSON payload of unclaimed profile snapshots untouched for p_retention_days. Returns how many rows were archived.';
+
+-- The function is the scheduled job's entry point and writes with the owner's
+-- rights; it is not something an anonymous or signed-in client should be able to
+-- invoke. Postgres grants EXECUTE to PUBLIC by default, so revoke it.
+revoke execute on function public.archive_dormant_profile_snapshots(integer)
+  from public;
+
+-- Supabase's `anon` and `authenticated` roles may also hold an explicit grant.
+-- Guarded by a role-existence check so this migration still applies against a
+-- plain Postgres instance, where those roles do not exist.
+do $$
+begin
+  if exists (select 1 from pg_roles where rolname = 'anon') then
+    execute 'revoke execute on function public.archive_dormant_profile_snapshots(integer) from anon';
+  end if;
+  if exists (select 1 from pg_roles where rolname = 'authenticated') then
+    execute 'revoke execute on function public.archive_dormant_profile_snapshots(integer) from authenticated';
+  end if;
+end
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 4. Schedule
+-- ---------------------------------------------------------------------------
+
+create extension if not exists pg_cron;
+
+-- 03:00 UTC, an hour clear of the midnight score-snapshot job so the two do not
+-- contend. Unscheduled first so re-running this migration cannot stack duplicates.
+select cron.unschedule('archive-dormant-profile-snapshots')
+where exists (
+  select 1 from cron.job where jobname = 'archive-dormant-profile-snapshots'
+);
+
+select cron.schedule(
+  'archive-dormant-profile-snapshots',
+  '0 3 * * *',
+  'select public.archive_dormant_profile_snapshots();'
+);

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -341,3 +341,244 @@ comment on table public.scheduler_locks is
 -- expose the locks to every client role, including anon. RLS on with zero policies
 -- denies all client roles by default, which is exactly what we want here.
 alter table public.scheduler_locks enable row level security;
+
+-- ============================================================
+-- DORMANT SNAPSHOT ARCHIVE
+-- Summarise and drop the JSON payload of unclaimed profile snapshots that have
+-- gone untouched for 90 days. The profile_snapshots row itself is kept: it holds
+-- the sync claim marker, and the read path treats a null payload as a cold
+-- profile and re-syncs on the next visit.
+-- ============================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. The compact archive
+-- ---------------------------------------------------------------------------
+
+create table if not exists public.profile_snapshot_archive (
+  username text primary key,
+  archived_at timestamptz not null default now(),
+  -- The `synced_at` the snapshot carried when it was archived, so the summary can
+  -- be read as "this is what the account looked like on this date".
+  last_synced_at timestamptz,
+  followers integer,
+  public_repos integer,
+  repo_count integer,
+  total_stars bigint,
+  total_commits integer,
+  total_prs integer,
+  total_issues integer,
+  total_reviews integer,
+  total_contributions integer,
+  merged_pr_count integer,
+  org_count integer,
+  -- `profile_snapshots` enforces the same invariant. Without it the archive could
+  -- hold "Octocat" and "octocat" as separate rows and neither would join back.
+  constraint profile_snapshot_archive_username_lowercase
+    check (username = lower(username))
+);
+
+comment on table public.profile_snapshot_archive is
+  'Small numeric summary of a profile snapshot whose bulky JSON payload has been dropped after a period of dormancy.';
+comment on column public.profile_snapshot_archive.last_synced_at is
+  'Value of profile_snapshots.synced_at at the moment of archiving, so the summary has a meaningful date attached.';
+comment on column public.profile_snapshot_archive.total_stars is
+  'Sum of stargazers across the stored repositories. bigint because this is a sum, not a per-repository count.';
+
+create index if not exists idx_profile_snapshot_archive_archived_at
+  on public.profile_snapshot_archive (archived_at);
+
+alter table public.profile_snapshot_archive enable row level security;
+
+-- Readable by anyone, matching profile_snapshots: these are public profiles and
+-- the summary is strictly less information than the payload it replaces.
+create policy "profile_snapshot_archive_select"
+  on public.profile_snapshot_archive
+  for select using (true);
+
+-- No insert/update/delete policies, deliberately, exactly as on profile_snapshots.
+-- The only writer is the scheduled job below, which runs as the function owner and
+-- bypasses RLS. An anonymous client can read a summary but never forge one.
+
+-- ---------------------------------------------------------------------------
+-- 2. Helper: tolerant integer extraction
+-- ---------------------------------------------------------------------------
+
+-- Snapshots are written by the application from GitHub's API, so these fields are
+-- numeric in practice. "In practice" is not good enough for an unattended job: one
+-- malformed row would abort the whole nightly run and it would keep aborting. This
+-- yields NULL for anything non-numeric instead of raising.
+create or replace function public.safe_jsonb_int(p_value text)
+returns integer
+language sql
+immutable
+as $$
+  select case when p_value ~ '^-?[0-9]+$' then p_value::integer end;
+$$;
+
+comment on function public.safe_jsonb_int(text) is
+  'Parse a JSON text value as an integer, returning NULL rather than raising when it is not one.';
+
+-- ---------------------------------------------------------------------------
+-- 3. The archival routine
+-- ---------------------------------------------------------------------------
+
+create or replace function public.archive_dormant_profile_snapshots(
+  p_retention_days integer default 90
+)
+returns integer
+language plpgsql
+security definer
+-- Pinned so the function cannot be redirected by a caller's search_path.
+set search_path = public
+as $$
+declare
+  v_cutoff timestamptz;
+  v_archived integer := 0;
+begin
+  if p_retention_days is null or p_retention_days < 1 then
+    raise exception 'p_retention_days must be a positive integer, got %',
+      p_retention_days;
+  end if;
+
+  v_cutoff := now() - make_interval(days => p_retention_days);
+
+  -- One statement on purpose. The archive insert and the payload clearing see the
+  -- same set of rows, so a snapshot cannot be cleared without its summary having
+  -- been written, and a sync landing mid-run cannot cause the two to disagree.
+  with dormant as (
+    select
+      ps.username,
+      ps.synced_at,
+      ps.snapshot -> 'user' as gh_user,
+      ps.snapshot -> 'liveStats' as live_stats,
+      case
+        when jsonb_typeof(ps.snapshot -> 'repos') = 'array'
+        then ps.snapshot -> 'repos'
+        else '[]'::jsonb
+      end as repos,
+      case
+        when jsonb_typeof(ps.snapshot -> 'mergedPRs') = 'array'
+        then ps.snapshot -> 'mergedPRs'
+        else '[]'::jsonb
+      end as merged_prs,
+      case
+        when jsonb_typeof(ps.snapshot -> 'orgs') = 'array'
+        then ps.snapshot -> 'orgs'
+        else '[]'::jsonb
+      end as orgs
+    from public.profile_snapshots ps
+    where ps.snapshot is not null
+      and ps.synced_at is not null
+      and ps.synced_at < v_cutoff
+      -- Only unclaimed usernames. Somebody who signed up owns their data, and
+      -- silently degrading a registered account's profile is not this job's call.
+      and not exists (
+        select 1
+        from public.profiles p
+        where lower(p.username) = ps.username
+      )
+  ),
+  archived as (
+    insert into public.profile_snapshot_archive as a (
+      username,
+      archived_at,
+      last_synced_at,
+      followers,
+      public_repos,
+      repo_count,
+      total_stars,
+      total_commits,
+      total_prs,
+      total_issues,
+      total_reviews,
+      total_contributions,
+      merged_pr_count,
+      org_count
+    )
+    select
+      d.username,
+      now(),
+      d.synced_at,
+      public.safe_jsonb_int(d.gh_user ->> 'followers'),
+      public.safe_jsonb_int(d.gh_user ->> 'public_repos'),
+      jsonb_array_length(d.repos),
+      (
+        select coalesce(sum(public.safe_jsonb_int(r ->> 'stargazers_count')), 0)
+        from jsonb_array_elements(d.repos) as r
+      ),
+      public.safe_jsonb_int(d.live_stats ->> 'totalCommits'),
+      public.safe_jsonb_int(d.live_stats ->> 'totalPRs'),
+      public.safe_jsonb_int(d.live_stats ->> 'totalIssues'),
+      public.safe_jsonb_int(d.live_stats ->> 'totalReviews'),
+      public.safe_jsonb_int(d.live_stats ->> 'totalContributions'),
+      jsonb_array_length(d.merged_prs),
+      jsonb_array_length(d.orgs)
+    from dormant d
+    -- A username can be archived, revived by a visit, then fall dormant again.
+    -- The newest summary wins rather than the insert failing.
+    on conflict (username) do update set
+      archived_at = excluded.archived_at,
+      last_synced_at = excluded.last_synced_at,
+      followers = excluded.followers,
+      public_repos = excluded.public_repos,
+      repo_count = excluded.repo_count,
+      total_stars = excluded.total_stars,
+      total_commits = excluded.total_commits,
+      total_prs = excluded.total_prs,
+      total_issues = excluded.total_issues,
+      total_reviews = excluded.total_reviews,
+      total_contributions = excluded.total_contributions,
+      merged_pr_count = excluded.merged_pr_count,
+      org_count = excluded.org_count
+    returning a.username
+  )
+  update public.profile_snapshots ps
+     set snapshot = null
+   where ps.username in (select username from archived);
+
+  get diagnostics v_archived = row_count;
+  return v_archived;
+end;
+$$;
+
+comment on function public.archive_dormant_profile_snapshots(integer) is
+  'Summarise and drop the JSON payload of unclaimed profile snapshots untouched for p_retention_days. Returns how many rows were archived.';
+
+-- The function is the scheduled job's entry point and writes with the owner's
+-- rights; it is not something an anonymous or signed-in client should be able to
+-- invoke. Postgres grants EXECUTE to PUBLIC by default, so revoke it.
+revoke execute on function public.archive_dormant_profile_snapshots(integer)
+  from public;
+
+-- Supabase's `anon` and `authenticated` roles may also hold an explicit grant.
+-- Guarded by a role-existence check so this migration still applies against a
+-- plain Postgres instance, where those roles do not exist.
+do $$
+begin
+  if exists (select 1 from pg_roles where rolname = 'anon') then
+    execute 'revoke execute on function public.archive_dormant_profile_snapshots(integer) from anon';
+  end if;
+  if exists (select 1 from pg_roles where rolname = 'authenticated') then
+    execute 'revoke execute on function public.archive_dormant_profile_snapshots(integer) from authenticated';
+  end if;
+end
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 4. Schedule
+-- ---------------------------------------------------------------------------
+
+create extension if not exists pg_cron;
+
+-- 03:00 UTC, an hour clear of the midnight score-snapshot job so the two do not
+-- contend. Unscheduled first so re-running this migration cannot stack duplicates.
+select cron.unschedule('archive-dormant-profile-snapshots')
+where exists (
+  select 1 from cron.job where jobname = 'archive-dormant-profile-snapshots'
+);
+
+select cron.schedule(
+  'archive-dormant-profile-snapshots',
+  '0 3 * * *',
+  'select public.archive_dormant_profile_snapshots();'
+);


### PR DESCRIPTION
## Summary

`profile_snapshots` gets a row for every username whose profile page has ever been
opened, whether or not that person has an OSSfolio account. The `snapshot` column
holds the whole raw GitHub payload — user object, every repository, merged PRs,
organisations, a full contribution calendar. Most of those rows are never looked at
again, and the payload is the expensive part.

This adds a nightly job that finds snapshots untouched for 90 days belonging to
nobody with an account, keeps a small numeric summary, and drops the JSON.

Three decisions worth explaining, since the issue leaves them open.

**Which table.** There are two snapshot tables. `profile_score_snapshots` is keyed
on `profile_id` with a foreign key to `profiles` and `ON DELETE CASCADE`, so it
structurally cannot hold anything for a user who never signed in — it was never a
candidate for "unclaimed" records. `profile_snapshots` is the username-keyed one
holding the bulky JSON, so that's the target.

**"Unclaimed" means no account.** The table's own comment says it exists so profile
pages work "for a user who has never logged in", so the job skips any username with
a `profiles` row. Somebody who signed up owns their data, and quietly degrading a
registered account's profile isn't this job's decision to make.

**The row is kept, not deleted.** `sync_started_at` on that row is the claim marker
that stops concurrent page loads stampeding the GitHub API, and `username` is the
primary key the sync path expects. Deleting the row to save a few bytes would throw
both away.

Clearing `snapshot` is safe against the read path, which I checked before writing
anything. `src/app/[username]/page.tsx` branches on `if (!stored?.snapshot)` and
renders the syncing state, then refreshes in the background — the same path a
never-synced profile takes. And `isSnapshotStale()` keys off `synced_at`, not
`snapshot`, so nothing else gets confused. An archived profile someone does visit
simply behaves like a cold one, which after ninety unvisited days it effectively is.

## Related Issue

Closes #560

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Chore / dependency update

## Changes Made

**`supabase/migrations/20260727000000_archive_dormant_snapshots.sql`** (new)

- `profile_snapshot_archive` — username primary key, `archived_at`, the
  `last_synced_at` the row carried when archived, and the numeric summary:
  followers, public repos, repo count, summed stars, the five `liveStats` totals,
  merged PR count, org count. Same lowercase-username constraint as
  `profile_snapshots`, so the two always join.
- RLS enabled with a public select policy and no write policies, matching
  `profile_snapshots` exactly. The only writer is the job below, which runs with
  the owner's rights and bypasses RLS. A client can read a summary, never forge one.
- `safe_jsonb_int(text)` — parses a JSON value as an integer, returning NULL rather
  than raising when it isn't one.
- `archive_dormant_profile_snapshots(p_retention_days integer default 90)` —
  `security definer` with a pinned `search_path`, returns the number of rows
  archived. `EXECUTE` revoked from PUBLIC, and from `anon`/`authenticated` behind a
  role-existence check so the migration still applies on a plain Postgres.
- Scheduled at 03:00 UTC via pg_cron, an hour clear of the existing midnight
  score-snapshot job. Unscheduled first, so re-running the migration can't stack
  duplicate jobs.

The archive insert and the payload clearing are a single statement sharing one CTE.
That way a snapshot can never be cleared without its summary having been written,
and a sync landing mid-run can't make the two disagree.

**`supabase/schema.sql`** — same objects added to the snapshot, per CONTRIBUTING.md.

## AI Usage

- [ ] I did not use AI for any part of the code in this PR
- [x] I used AI for coding (specify which tool below) and I fully understand every change I made, including which functions I changed, why I changed them, and what side effects they could create

Used Claude for coding.

## Screenshots (if UI change)

n/a — database only.

## Testing

I ran the migration against a real PostgreSQL 18.3 instance rather than only
reading it, using PGlite with `profiles` and `profile_snapshots` set up from their
actual definitions. 22 assertions, all passing:

- The migration applies cleanly.
- A 200-day-old unclaimed snapshot is archived and its payload cleared.
- A 200-day-old snapshot belonging to a signed-up user is left alone.
- A 10-day-old snapshot is left alone; a 91-day-old one is archived.
- The `profile_snapshots` row survives — only `snapshot` becomes NULL.
- Every summary field extracts correctly, including stars summed across repos.
- `last_synced_at` is preserved.
- A second run archives nothing.
- A custom retention window is honoured; `0` and `NULL` are rejected.
- A row that is archived, revived by a visit, then falls dormant again re-archives
  through the `ON CONFLICT` upsert with fresh numbers.

Two of those came directly out of running it rather than reading it:

1. `revoke ... from anon` **fails outright** where those roles don't exist. It's now
   guarded by a `pg_roles` check.
2. A malformed payload would abort the whole nightly run — and keep aborting every
   night after. Tested with a deliberately garbage row: non-numeric fields become
   NULL, a non-array `repos` degrades to `0`, and the job completes.

`sqlfluff parse --dialect postgres` is clean on both files, and the migration checks
added in #552 pass — exit 0, with only the pre-existing `20260726000000` version
collision reported as a warning. Full JS suite unchanged at 241 passing.

The pg_cron block itself isn't covered by that harness, since PGlite has no cron
extension; it follows the same shape as the existing `daily-score-snapshot`
schedule in `20260710000000_add_most_improved_sorting.sql`.

I didn't add the PGlite harness to the repo — it would mean a new devDependency for
a single SQL test, and there's no SQL test infrastructure here today. Happy to add
it if you'd like migrations covered going forward.

## Two things I noticed while doing this

Both pre-existing and out of scope here, but worth flagging:

1. **`schema.sql` is missing four tables** that exist in migrations —
   `profile_views`, `profile_digests`, `achievement_unlocks` and
   `webhook_dead_letter_queue`. The #552 check would have caught each one. I only
   added my own table rather than expand this diff; happy to do a separate
   catch-up PR.
2. **`schema.sql` doesn't execute against a fresh Postgres** — it fails on
   `generation expression is not immutable`, identically with and without my
   section. That's consistent with it being a documentation snapshot rather than
   something that gets run, since production is built from migrations.

## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with `main`
- [x] Code works locally and I have tested it
- [x] No `console.log` left in `src/`
- [x] If schema changed — both `schema.sql` and a new migration file are included
- [x] If this is a UI change — I read `DESIGN.md` and followed the design system (n/a)
- [x] Docs updated if needed (n/a)
- [x] PR title follows Conventional Commits format
- [ ] This PR description is written in my own words

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added archival for dormant, unclaimed profile snapshots after 90 days.
  - Preserves key profile metrics and timestamps in a compact archive.
  - Archived summaries remain available for viewing while bulky snapshot data is removed.
  - Archival runs automatically each day at 03:00 UTC.

- **Bug Fixes**
  - Invalid or missing numeric snapshot values are handled safely without interrupting archival processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->