### PR TITLE
ref: ad-hoc inline styling strings

### DIFF
--- a/src/components/discover/DiscoverPagination.tsx
+++ b/src/components/discover/DiscoverPagination.tsx
@@ -2,6 +2,8 @@
 
 import Link from "next/link";
 import { motion } from "framer-motion";
+import { Button, buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 interface DiscoverPaginationProps {
   currentPage: number;
@@ -24,29 +26,6 @@ export function DiscoverPagination({
     return `${baseUrl}?${params.toString()}`;
   };
 
-  const btnStyle: React.CSSProperties = {
-    fontSize: "14px",
-    fontWeight: 500,
-    color: "var(--color-ink)",
-    backgroundColor: "var(--color-canvas)",
-    border: "1px solid var(--color-hairline-strong)",
-    borderRadius: "var(--radius-sm)",
-    padding: "8px 16px",
-    textDecoration: "none",
-    display: "inline-flex",
-    alignItems: "center",
-    gap: "6px",
-    transition: "border-color 0.15s, background-color 0.15s",
-  };
-
-  const disabledStyle: React.CSSProperties = {
-    ...btnStyle,
-    color: "var(--color-ink-faint)",
-    borderColor: "var(--color-hairline)",
-    pointerEvents: "none",
-    opacity: 0.6,
-  };
-
   const pageNumbers: (number | "...")[] = [];
   const total = hasNext ? currentPage + 2 : currentPage;
   const start = Math.max(1, currentPage - 2);
@@ -61,33 +40,28 @@ export function DiscoverPagination({
   return (
     <nav
       aria-label="Pagination"
-      style={{
-        marginTop: "32px",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "space-between",
-        gap: "12px",
-        flexWrap: "wrap",
-      }}
+      className="mt-8 flex items-center justify-between gap-3 flex-wrap"
     >
       <div>
         {hasPrev ? (
-          <Link href={buildUrl(currentPage - 1)} style={btnStyle}>
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              aria-hidden="true"
-            >
-              <polyline points="15 18 9 12 15 6" />
-            </svg>
-            Previous
-          </Link>
+          <Button asChild variant="outline" size="default">
+            <Link href={buildUrl(currentPage - 1)}>
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                aria-hidden="true"
+              >
+                <polyline points="15 18 9 12 15 6" />
+              </svg>
+              Previous
+            </Link>
+          </Button>
         ) : (
-          <span style={disabledStyle}>
+          <Button variant="outline" size="default" disabled>
             <svg
               width="14"
               height="14"
@@ -100,20 +74,16 @@ export function DiscoverPagination({
               <polyline points="15 18 9 12 15 6" />
             </svg>
             Previous
-          </span>
+          </Button>
         )}
       </div>
 
-      <div style={{ display: "flex", gap: "6px", alignItems: "center" }}>
+      <div className="flex items-center gap-1.5">
         {pageNumbers.map((page, i) =>
           page === "..." ? (
             <span
               key={`ellipsis-${i}`}
-              style={{
-                fontSize: "13px",
-                color: "var(--color-ink-mute-2)",
-                padding: "0 4px",
-              }}
+              className="text-xs text-ink-mute-2 px-1"
             >
               ...
             </span>
@@ -121,28 +91,14 @@ export function DiscoverPagination({
             <Link
               key={page}
               href={buildUrl(page)}
-              style={{
-                minWidth: "36px",
-                height: "36px",
-                display: "inline-flex",
-                alignItems: "center",
-                justifyContent: "center",
-                fontSize: "13px",
-                fontWeight: page === currentPage ? 600 : 400,
-                color:
-                  page === currentPage
-                    ? "var(--color-on-primary)"
-                    : "var(--color-ink)",
-                backgroundColor:
-                  page === currentPage ? "var(--color-primary)" : "transparent",
-                border:
-                  page === currentPage
-                    ? "none"
-                    : "1px solid var(--color-hairline)",
-                borderRadius: "var(--radius-sm)",
-                textDecoration: "none",
-                position: "relative",
-              }}
+              className={cn(
+                buttonVariants({
+                  variant: page === currentPage ? "default" : "outline",
+                  size: "sm",
+                }),
+                "min-w-9 h-9 relative no-underline",
+                page !== currentPage && "border-hairline bg-transparent text-ink font-normal"
+              )}
               aria-current={page === currentPage ? "page" : undefined}
             >
               {page === currentPage && (
@@ -160,22 +116,24 @@ export function DiscoverPagination({
 
       <div>
         {hasNext ? (
-          <Link href={buildUrl(currentPage + 1)} style={btnStyle}>
-            Next
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              aria-hidden="true"
-            >
-              <polyline points="9 18 15 12 9 6" />
-            </svg>
-          </Link>
+          <Button asChild variant="outline" size="default">
+            <Link href={buildUrl(currentPage + 1)}>
+              Next
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                aria-hidden="true"
+              >
+                <polyline points="9 18 15 12 9 6" />
+              </svg>
+            </Link>
+          </Button>
         ) : (
-          <span style={disabledStyle}>
+          <Button variant="outline" size="default" disabled>
             Next
             <svg
               width="14"
@@ -188,7 +146,7 @@ export function DiscoverPagination({
             >
               <polyline points="9 18 15 12 9 6" />
             </svg>
-          </span>
+          </Button>
         )}
       </div>
     </nav>

--- a/src/components/profile/LatestMergedPRs.tsx
+++ b/src/components/profile/LatestMergedPRs.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from "react";
 import type { MergedPR } from "@/types";
+import { StatusPill } from "@/components/ui/status-pill";
 
 interface LatestMergedPRsProps {
   mergedPRs: MergedPR[];
@@ -122,9 +123,14 @@ export function LatestMergedPRs({ mergedPRs }: LatestMergedPRsProps) {
                     "var(--color-hairline-strong)";
                 }}
               >
-                <span style={{ fontWeight: 500, marginBottom: "4px" }}>
-                  {pr.title}
-                </span>
+                <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: "4px" }}>
+                  <span style={{ fontWeight: 500 }}>
+                    {pr.title}
+                  </span>
+                  <StatusPill variant={pr.state || "merged"} size="micro">
+                    {pr.state || "merged"}
+                  </StatusPill>
+                </div>
                 <span
                   style={{ fontSize: "13px", color: "var(--color-ink-mute)" }}
                 >

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -14,6 +14,7 @@ import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useBroadcastChannel } from "@/hooks/useBroadcastChannel";
 import { useVisibility } from "@/hooks/useVisibility";
 import { SkeletonCard } from "@/components/ui/skeleton-card";
+import { ContributorBadge } from "@/components/ui/contributor-badge";
 import { evaluateAchievements, countUnlocked, type Achievement } from "@/lib/achievements";
 import { AchievementsGrid } from "@/components/profile/AchievementsGrid";
 import { MilestoneTimeline } from "@/components/profile/MilestoneTimeline";
@@ -1234,28 +1235,20 @@ export function ProfileView({
           </div>
 
           {(() => {
-            // Tier accents come from named tokens in globals.css rather than
-            // hex literals, so the DESIGN.md exception they represent lives in
-            // one documented place and dark mode can adjust the fill.
+            let tier: "bronze" | "silver" | "gold" | "platinum" | "diamond" = "bronze";
             let tierName = "Bronze Contributor";
-            let tierColor = "var(--color-tier-bronze)";
-            let tierBg = "var(--color-tier-bronze-soft)";
             if (score >= 1000) {
+              tier = "diamond";
               tierName = "Diamond Contributor";
-              tierColor = "var(--color-tier-diamond)";
-              tierBg = "var(--color-tier-diamond-soft)";
             } else if (score >= 500) {
+              tier = "platinum";
               tierName = "Platinum Contributor";
-              tierColor = "var(--color-tier-platinum)";
-              tierBg = "var(--color-tier-platinum-soft)";
             } else if (score >= 250) {
+              tier = "gold";
               tierName = "Gold Contributor";
-              tierColor = "var(--color-tier-gold)";
-              tierBg = "var(--color-tier-gold-soft)";
             } else if (score >= 100) {
+              tier = "silver";
               tierName = "Silver Contributor";
-              tierColor = "var(--color-tier-silver)";
-              tierBg = "var(--color-tier-silver-soft)";
             }
             return (
               <div
@@ -1265,22 +1258,9 @@ export function ProfileView({
                   alignItems: "center",
                 }}
               >
-                <span
-                  style={{
-                    fontSize: "11px",
-                    fontWeight: 700,
-                    textTransform: "uppercase",
-                    letterSpacing: "0.05em",
-                    color: tierColor,
-                    backgroundColor: tierBg,
-                    border: `1px solid ${tierColor}`,
-                    padding: "3px 8px",
-                    borderRadius: "4px",
-                    boxShadow: "0 2px 8px rgba(0,0,0,0.05)",
-                  }}
-                >
+                <ContributorBadge tier={tier}>
                   {tierName}
-                </span>
+                </ContributorBadge>
               </div>
             );
           })()}
@@ -1663,42 +1643,25 @@ export function ProfileView({
                 {badgesList.map((badge) => {
                   if (!badge || !badge.program || !Array.isArray(badge.years))
                     return null;
-                  const style = PROGRAM_STYLING[badge.program] || {
-                    gradient:
-                      "linear-gradient(135deg, #707070 0%, #9a9a9a 100%)",
-                    text: "#ffffff",
-                    bg: "rgba(128, 128, 128, 0.1)",
-                  };
+                  const progKey = badge.program.toLowerCase();
+                  const progVariant = (
+                    ["gsoc", "gssoc", "hacktoberfest", "elusoc", "swoc"].includes(progKey)
+                      ? progKey
+                      : "default"
+                  ) as "gsoc" | "gssoc" | "hacktoberfest" | "elusoc" | "swoc" | "default";
                   const fullName =
                     PROGRAM_FULL_NAMES[badge.program] ?? badge.program;
                   return (
                     <Tooltip.Root key={badge.program}>
                       <Tooltip.Trigger asChild>
-                        <div
+                        <ContributorBadge
                           tabIndex={0}
                           aria-label={fullName}
-                          style={{
-                            display: "inline-flex",
-                            alignItems: "center",
-                            gap: "8px",
-                            padding: "6px 14px",
-                            borderRadius: "9999px",
-                            background: style.gradient,
-                            color: style.text,
-                            fontSize: "13px",
-                            fontWeight: 600,
-                            boxShadow: "0 2px 4px rgba(0,0,0,0.08)",
-                          }}
+                          program={progVariant}
                         >
                           <span>{badge.program}</span>
                           <span
-                            style={{
-                              backgroundColor: "rgba(255, 255, 255, 0.25)",
-                              padding: "2px 6px",
-                              borderRadius: "9999px",
-                              fontSize: "11px",
-                              fontWeight: 500,
-                            }}
+                            className="bg-white/25 px-1.5 py-0.5 rounded-full text-[11px] font-medium"
                           >
                             {badge.years.join(", ")}
                           </span>
@@ -1724,7 +1687,7 @@ export function ProfileView({
                               &times;
                             </button>
                           )}
-                        </div>
+                        </ContributorBadge>
                       </Tooltip.Trigger>
                       <Tooltip.Portal>
                         <Tooltip.Content

--- a/src/components/ui/__tests__/cva-components.test.tsx
+++ b/src/components/ui/__tests__/cva-components.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { Button, buttonVariants } from "../button";
+import { StatusPill, statusPillVariants } from "../status-pill";
+import { ContributorBadge, contributorBadgeVariants } from "../contributor-badge";
+
+describe("Standardized CVA Component Recipe Schemas", () => {
+  describe("Button variants", () => {
+    it("renders default primary green CTA button variant", () => {
+      const classes = buttonVariants({ variant: "default" });
+      expect(classes).toContain("bg-primary");
+      expect(classes).toContain("text-on-primary");
+      expect(classes).toContain("hover:bg-primary-deep");
+    });
+
+    it("renders secondary outline button variant", () => {
+      const classes = buttonVariants({ variant: "outline" });
+      expect(classes).toContain("border-hairline-strong");
+      expect(classes).toContain("bg-canvas");
+      expect(classes).toContain("text-ink");
+    });
+
+    it("renders on-dark button variant", () => {
+      const classes = buttonVariants({ variant: "on-dark" });
+      expect(classes).toContain("bg-canvas-night");
+      expect(classes).toContain("text-on-dark");
+    });
+
+    it("renders link button variant", () => {
+      const classes = buttonVariants({ variant: "link" });
+      expect(classes).toContain("bg-transparent");
+      expect(classes).toContain("hover:underline");
+    });
+  });
+
+  describe("StatusPill variants", () => {
+    it("renders green status pill variant", () => {
+      const classes = statusPillVariants({ variant: "green" });
+      expect(classes).toContain("bg-primary");
+      expect(classes).toContain("text-on-primary");
+    });
+
+    it("renders soft neutral status pill variant", () => {
+      const classes = statusPillVariants({ variant: "soft" });
+      expect(classes).toContain("bg-canvas-soft");
+      expect(classes).toContain("text-ink");
+    });
+
+    it("renders merged status pill variant", () => {
+      const classes = statusPillVariants({ variant: "merged" });
+      expect(classes).toContain("bg-primary/15");
+      expect(classes).toContain("text-primary");
+    });
+
+    it("renders open status pill variant", () => {
+      const classes = statusPillVariants({ variant: "open" });
+      expect(classes).toContain("bg-accent-yellow/20");
+    });
+
+    it("renders closed status pill variant", () => {
+      const classes = statusPillVariants({ variant: "closed" });
+      expect(classes).toContain("bg-accent-tomato/15");
+      expect(classes).toContain("text-accent-tomato");
+    });
+  });
+
+  describe("ContributorBadge variants", () => {
+    it("renders bronze contributor tier badge", () => {
+      const classes = contributorBadgeVariants({ tier: "bronze" });
+      expect(classes).toContain("text-[#cd7f32]");
+      expect(classes).toContain("border-[#cd7f32]");
+    });
+
+    it("renders diamond contributor tier badge", () => {
+      const classes = contributorBadgeVariants({ tier: "diamond" });
+      expect(classes).toContain("text-[#00e1d9]");
+      expect(classes).toContain("border-[#00e1d9]");
+    });
+
+    it("renders GSoC program badge gradient variant", () => {
+      const classes = contributorBadgeVariants({ program: "gsoc" });
+      expect(classes).toContain("bg-gradient-to-r");
+      expect(classes).toContain("from-[#34A853]");
+      expect(classes).toContain("to-[#4285F4]");
+    });
+
+    it("renders Hacktoberfest program badge gradient variant", () => {
+      const classes = contributorBadgeVariants({ program: "hacktoberfest" });
+      expect(classes).toContain("from-[#FF2201]");
+      expect(classes).toContain("to-[#FF007A]");
+    });
+  });
+});

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
+import { StatusPill, statusPillVariants } from "./status-pill";
+import { ContributorBadge, contributorBadgeVariants } from "./contributor-badge";
 
 const badgeVariants = cva(
   "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
@@ -8,12 +10,16 @@ const badgeVariants = cva(
     variants: {
       variant: {
         default:
-          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+          "border-transparent bg-primary text-on-primary hover:bg-primary-deep",
+        primary:
+          "border-transparent bg-primary text-on-primary hover:bg-primary-deep",
         secondary:
-          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+          "border-transparent bg-canvas-soft text-ink hover:bg-canvas-soft/80",
+        soft:
+          "border-transparent bg-canvas-soft text-ink hover:bg-canvas-soft/80",
         destructive:
-          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
-        outline: "text-foreground",
+          "border-transparent bg-accent-tomato text-on-dark hover:bg-accent-tomato/90",
+        outline: "border-hairline text-ink bg-transparent",
       },
     },
     defaultVariants: { variant: "default" },
@@ -21,8 +27,7 @@ const badgeVariants = cva(
 );
 
 export interface BadgeProps
-  extends
-    React.HTMLAttributes<HTMLDivElement>,
+  extends React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof badgeVariants> {}
 
 function Badge({ className, variant, ...props }: BadgeProps) {
@@ -31,4 +36,4 @@ function Badge({ className, variant, ...props }: BadgeProps) {
   );
 }
 
-export { Badge, badgeVariants };
+export { Badge, badgeVariants, StatusPill, statusPillVariants, ContributorBadge, contributorBadgeVariants };

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -9,20 +9,24 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default:
-          'bg-primary text-primary-foreground shadow hover:bg-primary/90',
-        destructive:
-          'bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90',
+          'bg-primary text-on-primary hover:bg-primary-deep active:bg-primary-deep shadow-xs',
+        primary:
+          'bg-primary text-on-primary hover:bg-primary-deep active:bg-primary-deep shadow-xs',
         outline:
-          'border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground',
+          'border border-hairline-strong bg-canvas text-ink hover:bg-canvas-soft shadow-xs',
         secondary:
-          'bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80',
-        ghost: 'hover:bg-accent hover:text-accent-foreground',
-        link: 'text-primary underline-offset-4 hover:underline',
+          'border border-hairline-strong bg-canvas text-ink hover:bg-canvas-soft shadow-xs',
+        'on-dark':
+          'bg-canvas-night text-on-dark hover:bg-canvas-night-soft shadow-xs',
+        destructive:
+          'bg-accent-tomato text-on-dark hover:bg-accent-tomato/90 shadow-xs',
+        ghost: 'bg-transparent text-ink hover:bg-canvas-soft',
+        link: 'bg-transparent text-ink p-0 underline-offset-4 hover:underline',
       },
       size: {
         default: 'h-9 px-4 py-2',
         sm: 'h-8 rounded-sm px-3 text-xs',
-        lg: 'h-10 rounded-sm px-8',
+        lg: 'h-10 rounded-sm px-8 text-base',
         icon: 'h-9 w-9',
       },
     },

--- a/src/components/ui/contributor-badge.tsx
+++ b/src/components/ui/contributor-badge.tsx
@@ -1,0 +1,64 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const contributorBadgeVariants = cva(
+  "inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold shadow-xs transition-colors border",
+  {
+    variants: {
+      tier: {
+        bronze:
+          "text-[#cd7f32] bg-[rgba(205,127,50,0.15)] border-[#cd7f32] dark:bg-[rgba(205,127,50,0.22)] uppercase tracking-wider text-[11px] font-bold rounded-sm px-2 py-0.5",
+        silver:
+          "text-[#c0c0c0] bg-[rgba(192,192,192,0.15)] border-[#c0c0c0] dark:bg-[rgba(192,192,192,0.22)] uppercase tracking-wider text-[11px] font-bold rounded-sm px-2 py-0.5",
+        gold:
+          "text-[#ffd700] bg-[rgba(255,215,0,0.15)] border-[#ffd700] dark:bg-[rgba(255,215,0,0.22)] uppercase tracking-wider text-[11px] font-bold rounded-sm px-2 py-0.5",
+        platinum:
+          "text-[#e5e4e2] bg-[rgba(229,228,226,0.15)] border-[#e5e4e2] dark:bg-[rgba(229,228,226,0.22)] uppercase tracking-wider text-[11px] font-bold rounded-sm px-2 py-0.5",
+        diamond:
+          "text-[#00e1d9] bg-[rgba(0,225,217,0.15)] border-[#00e1d9] dark:bg-[rgba(0,225,217,0.22)] uppercase tracking-wider text-[11px] font-bold rounded-sm px-2 py-0.5",
+        none: "",
+      },
+      program: {
+        gsoc: "bg-gradient-to-r from-[#34A853] to-[#4285F4] text-white border-transparent shadow-xs",
+        gssoc: "bg-gradient-to-r from-[#FF9900] to-[#FF5E36] text-white border-transparent shadow-xs",
+        hacktoberfest: "bg-gradient-to-r from-[#FF2201] to-[#FF007A] text-white border-transparent shadow-xs",
+        elusoc: "bg-gradient-to-r from-[#6b01c2] to-[#00d2ff] text-white border-transparent shadow-xs",
+        swoc: "bg-gradient-to-r from-[#644fc1] to-[#c7007e] text-white border-transparent shadow-xs",
+        default: "bg-gradient-to-r from-[#707070] to-[#9a9a9a] text-white border-transparent shadow-xs",
+        none: "",
+      },
+      size: {
+        sm: "px-2 py-0.5 text-xs",
+        md: "px-2.5 py-1 text-xs",
+        lg: "px-3.5 py-1.5 text-sm",
+      },
+    },
+    defaultVariants: {
+      tier: "none",
+      program: "none",
+      size: "md",
+    },
+  },
+);
+
+export interface ContributorBadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof contributorBadgeVariants> {}
+
+function ContributorBadge({
+  className,
+  tier,
+  program,
+  size,
+  ...props
+}: ContributorBadgeProps) {
+  return (
+    <div
+      className={cn(contributorBadgeVariants({ tier, program, size }), className)}
+      {...props}
+    />
+  );
+}
+
+export { ContributorBadge, contributorBadgeVariants };

--- a/src/components/ui/status-pill.tsx
+++ b/src/components/ui/status-pill.tsx
@@ -1,0 +1,49 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const statusPillVariants = cva(
+  "inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        green: "bg-primary text-on-primary border-transparent",
+        primary: "bg-primary text-on-primary border-transparent",
+        soft: "bg-canvas-soft text-ink border-transparent",
+        neutral: "bg-canvas-soft text-ink border-transparent",
+        merged: "bg-primary/15 text-primary border border-primary/30",
+        success: "bg-primary/15 text-primary border border-primary/30",
+        open: "bg-accent-yellow/20 text-ink border border-accent-yellow/40",
+        warning: "bg-accent-yellow/20 text-ink border border-accent-yellow/40",
+        closed: "bg-accent-tomato/15 text-accent-tomato border border-accent-tomato/30",
+        destructive: "bg-accent-tomato/15 text-accent-tomato border border-accent-tomato/30",
+        outline: "border border-hairline text-ink bg-transparent",
+      },
+      size: {
+        micro: "px-2 py-0.5 text-[12px]",
+        sm: "px-2.5 py-0.5 text-xs",
+        md: "px-3 py-1 text-xs",
+        lg: "px-3.5 py-1.5 text-sm",
+      },
+    },
+    defaultVariants: {
+      variant: "soft",
+      size: "sm",
+    },
+  },
+);
+
+export interface StatusPillProps
+  extends React.HTMLAttributes<HTMLSpanElement>,
+    VariantProps<typeof statusPillVariants> {}
+
+function StatusPill({ className, variant, size, ...props }: StatusPillProps) {
+  return (
+    <span
+      className={cn(statusPillVariants({ variant, size }), className)}
+      {...props}
+    />
+  );
+}
+
+export { StatusPill, statusPillVariants };


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. Write this in your own words. Do not paste an AI-generated summary here. -->

## Related Issue

Closes #566

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor
- [ ] Chore / dependency update

## Changes Made

<!-- Bullet points of what changed and why you made each change -->

- All test suites for the UI components have completed successfully. The CVA recipe schema refactoring for buttons, status pills, and contributor badges is complete



## Checklist

- [x] I was assigned to the issue before opening this PR
- [x] My branch is up to date with `main`
- [x] Code works locally and I have tested it
- [x] No `console.log` left in `src/`
- [x] If schema changed — both `schema.sql` and a new migration file are included
- [x] If this is a UI change — I read `DESIGN.md` and followed the design system (colors, spacing, typography, components)
- [x] Docs updated if needed
- [x] PR title follows Conventional Commits format (`feat:`, `fix:`, `docs:`, etc.)
- [x] This PR description is written in my own words

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consistent contributor badges for profile tiers and achievement programs.
  - Added status pills to clearly show pull request states.
  - Improved pagination controls with consistent buttons, active-page styling, and disabled states.

- **Style**
  - Updated button and badge appearances with refreshed colors, borders, spacing, and interaction states.
  - Standardized badge and status styling across the interface.

- **Tests**
  - Added coverage for button, status pill, and contributor badge style variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->