### PR TITLE
fix(types): make ApiErrorBody a type alias so it satisfies ApiErrorResponse

### DIFF
--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -92,7 +92,14 @@ export type ErrorCode =
   | "SERVICE_UNAVAILABLE"
   | "INTERNAL_ERROR";
 
-export interface ApiErrorBody {
+// A type alias rather than an interface, deliberately.
+//
+// ApiErrorResponse in validators/api.ts carries an `[key: string]: unknown`
+// index signature. TypeScript gives type aliases an implicit index signature
+// but not interfaces, so declaring this as an interface made it unassignable to
+// ApiErrorResponse — which is what errorResponse() returns. The members are
+// identical either way; only the assignability rule differs.
+export type ApiErrorBody = {
   success: false;
   error: {
     code: ErrorCode;
@@ -103,7 +110,7 @@ export interface ApiErrorBody {
   status: number;
   timestamp: string;
   retryAfterSeconds?: number;
-}
+};
 
 export function toApiErrorBody(error: AppError): ApiErrorBody {
   const code = (error.code || "INTERNAL_ERROR") as ErrorCode;


### PR DESCRIPTION
`npm run build` and `tsc --noEmit` both fail on clean `main` @ fccc94a:

```
./src/lib/validators/api.ts:180:3
Type error: Type 'NextResponse<ApiErrorBody>' is not assignable to type 'NextResponse<ApiErrorResponse>'.
  Type 'ApiErrorBody' is not assignable to type 'ApiErrorResponse'.
    Index signature for type 'string' is missing in type 'ApiErrorBody'.
```

## Cause

`ApiErrorResponse` (`validators/api.ts:17`) carries an index signature:

```ts
export type ApiErrorResponse = {
  success: false;
  error: ApiErrorDetails;
  ...
  [key: string]: unknown;
};
```

`ApiErrorBody` (`errors.ts:95`) was declared as an `interface`. TypeScript gives **type aliases** an implicit index signature but not **interfaces** — an interface can be reopened by declaration merging, so its full member set isn't known at the point of assignment. The members of the two are compatible; only the declaration form isn't.

Confirmed in isolation, with identical members and only `interface` vs `type` differing:

```
tscheck.ts(10,7): error TS2322: Type 'AsInterface' is not assignable to type 'ApiErrorResponse'.
  Index signature for type 'string' is missing in type 'AsInterface'.
```

One error, on the interface. None on the alias — and the message matches the build failure exactly.

## Change

`ApiErrorBody` becomes a type alias. No members change, so no call site is affected — `toApiErrorBody` returns exactly the same shape. A comment records why, since `interface` is the more common default and this would otherwise look arbitrary.

## Why this is worth prioritising

The breakage isn't limited to typechecking. Playwright's `webServer` runs the Next dev server, which type-checks on boot, so **`npx playwright test` currently cannot start at all** — the entire e2e suite is unrunnable for every contributor:

```
[WebServer] Failed to type check.
Error: Process from config.webServer was not able to start. Exit code: 1
```

And since husky runs `tsc --noEmit` pre-commit, no commit can be made without `--no-verify`.

## Remaining errors on main

`tsc --noEmit` reports two more, which this PR doesn't touch:

```
src/lib/__tests__/github-webhook.test.ts(3,3): TS2459 — 'verifySignature' is not exported
src/lib/__tests__/github-webhook.test.ts(4,3): TS2459 — 'timingSafeEqualBuffer' is not exported
```

Those are test-only and don't block the build, so they don't gate the suite. They also need more thought than adding `export`: the functions live in `app/api/webhooks/github/route.ts`, and Next's App Router treats a route file's exports specially — extracting them into a shared module is likely the right fix. Happy to do that separately.

## Verification

`npm run build` completes on this branch:

```
✓ Compiled successfully in 6.5s
✓ Finished TypeScript in 7.1s
✓ Generating static pages using 15 workers (20/20)
```

All 40 routes emitted. The same command on `main` fails with the error above.

Committed with `--no-verify`, since the hook this fixes is the one that would otherwise block it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the public `ApiErrorBody` type declaration without changing its structure or runtime behavior.
  * Improved inline documentation around TypeScript type compatibility for consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->