### PR TITLE
fix(webhooks): extract signature helpers so the route exports only POST Closes #708

### DIFF
--- a/src/app/api/webhooks/github/route.ts
+++ b/src/app/api/webhooks/github/route.ts
@@ -7,82 +7,9 @@ import {
 import { refreshProfile } from '@/lib/refresh-profile';
 import { enqueueDeadLetterPayload } from '@/lib/webhook-dead-letter';
 
-// Receives GitHub `push` webhooks and triggers a (rate-limited) refresh of the
-// affected profile in the background. Signature verification uses edge-safe Web Crypto
-// APIs and constant-time buffer comparison (crypto.subtle.timingSafeEqual).
+import { verifySignature } from '@/lib/webhook-signature';
 
-/** Converts a hex string into a Uint8Array byte buffer. */
-function hexToBytes(hex: string): Uint8Array | null {
-  if (hex.length % 2 !== 0 || !/^[0-9a-fA-F]+$/.test(hex)) {
-    return null;
-  }
-  const bytes = new Uint8Array(hex.length / 2);
-  for (let i = 0; i < hex.length; i += 2) {
-    bytes[i / 2] = parseInt(hex.slice(i, i + 2), 16);
-  }
-  return bytes;
-}
-
-/** Constant-time comparison of two ArrayBuffer or ArrayBufferView byte buffers. */
-function timingSafeEqualBuffer(
-  a: ArrayBuffer | ArrayBufferView,
-  b: ArrayBuffer | ArrayBufferView,
-): boolean {
-  const subtle = crypto.subtle as unknown as {
-    timingSafeEqual?: (
-      _a: ArrayBuffer | ArrayBufferView,
-      _b: ArrayBuffer | ArrayBufferView,
-    ) => boolean;
-  };
-
-  if (typeof subtle.timingSafeEqual === 'function') {
-    return subtle.timingSafeEqual(a, b);
-  }
-
-  const viewA =
-    a instanceof Uint8Array ? a : new Uint8Array('buffer' in a ? a.buffer : a);
-  const viewB =
-    b instanceof Uint8Array ? b : new Uint8Array('buffer' in b ? b.buffer : b);
-
-  if (viewA.byteLength !== viewB.byteLength) return false;
-  let mismatch = 0;
-  for (let i = 0; i < viewA.byteLength; i++) {
-    mismatch |= viewA[i] ^ viewB[i];
-  }
-  return mismatch === 0;
-}
-
-/** Verify GitHub's `X-Hub-Signature-256` (HMAC-SHA256 of raw body in constant time). */
-async function verifySignature(
-  secret: string,
-  body: string,
-  header: string | null,
-): Promise<boolean> {
-  if (!header || !header.startsWith('sha256=')) return false;
-
-  const headerHex = header.slice(7);
-  if (headerHex.length !== 64) return false;
-
-  const headerBytes = hexToBytes(headerHex);
-  if (!headerBytes) return false;
-
-  const key = await crypto.subtle.importKey(
-    'raw',
-    new TextEncoder().encode(secret),
-    { name: 'HMAC', hash: 'SHA-256' },
-    false,
-    ['sign'],
-  );
-  const signedBuffer = await crypto.subtle.sign(
-    'HMAC',
-    key,
-    new TextEncoder().encode(body),
-  );
-  const computedBytes = new Uint8Array(signedBuffer);
-
-  return timingSafeEqualBuffer(computedBytes, headerBytes);
-}
-
+/** The subset of GitHub's push event this route reads. */
 interface PushPayload {
   repository?: { owner?: { login?: string; name?: string } };
 }

--- a/src/lib/__tests__/github-webhook.test.ts
+++ b/src/lib/__tests__/github-webhook.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { POST } from "@/app/api/webhooks/github/route";
 import {
   verifySignature,
   timingSafeEqualBuffer,
-  POST,
-} from "@/app/api/webhooks/github/route";
+} from "@/lib/webhook-signature";
 import { NextRequest } from "next/server";
 import { enqueueDeadLetterPayload } from "../webhook-dead-letter";
 import { refreshProfile } from "../refresh-profile";
@@ -123,7 +123,8 @@ describe("GitHub Webhook HMAC-SHA256 Verification & Endpoint", () => {
       const res = await POST(req);
       expect(res.status).toBe(503);
       const json = await res.json();
-      expect(json.error).toBe("Webhook not configured");
+      // The API returns a structured error object, not a bare string.
+      expect(json.error.message).toBe("Webhook not configured");
     });
 
     it("should return 401 for an invalid signature", async () => {
@@ -138,7 +139,7 @@ describe("GitHub Webhook HMAC-SHA256 Verification & Endpoint", () => {
       const res = await POST(req);
       expect(res.status).toBe(401);
       const json = await res.json();
-      expect(json.error).toBe("Invalid signature");
+      expect(json.error.message).toBe("Invalid signature");
     });
 
     it("should return 200 pong for ping event", async () => {
@@ -155,7 +156,9 @@ describe("GitHub Webhook HMAC-SHA256 Verification & Endpoint", () => {
       const res = await POST(req);
       expect(res.status).toBe(200);
       const json = await res.json();
-      expect(json).toEqual({ ok: true, message: "pong" });
+      // Success bodies travel inside the { success, data } envelope that
+      // createApiResponse applies.
+      expect(json).toEqual({ success: true, data: { ok: true, message: "pong" } });
     });
 
     it("should return 200 accepted for valid push event and trigger background refresh", async () => {
@@ -177,7 +180,10 @@ describe("GitHub Webhook HMAC-SHA256 Verification & Endpoint", () => {
       const res = await POST(req);
       expect(res.status).toBe(200);
       const json = await res.json();
-      expect(json).toEqual({ ok: true, accepted: "octocat" });
+      expect(json).toEqual({
+        success: true,
+        data: { ok: true, accepted: "octocat" },
+      });
     });
 
     it("should enqueue to dead-letter queue when background refresh encounters error", async () => {

--- a/src/lib/__tests__/github-webhook.test.ts
+++ b/src/lib/__tests__/github-webhook.test.ts
@@ -1,15 +1,16 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { POST } from "@/app/api/webhooks/github/route";
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST } from '@/app/api/webhooks/github/route';
 import {
   verifySignature,
   timingSafeEqualBuffer,
-} from "@/lib/webhook-signature";
-import { NextRequest } from "next/server";
-import { enqueueDeadLetterPayload } from "../webhook-dead-letter";
-import { refreshProfile } from "../refresh-profile";
+} from '@/lib/webhook-signature';
+import { NextRequest } from 'next/server';
+import { enqueueDeadLetterPayload } from '../webhook-dead-letter';
+import { refreshProfile } from '../refresh-profile';
 
-vi.mock("next/server", async () => {
-  const actual = await vi.importActual<typeof import("next/server")>("next/server");
+vi.mock('next/server', async () => {
+  const actual =
+    await vi.importActual<typeof import('next/server')>('next/server');
   return {
     ...actual,
     after: vi.fn((fn: () => Promise<void> | void) => {
@@ -18,38 +19,41 @@ vi.mock("next/server", async () => {
   };
 });
 
-vi.mock("../refresh-profile", () => ({
+vi.mock('../refresh-profile', () => ({
   refreshProfile: vi.fn(),
 }));
 
-vi.mock("../webhook-dead-letter", () => ({
+vi.mock('../webhook-dead-letter', () => ({
   enqueueDeadLetterPayload: vi.fn(),
 }));
 
 // Helper to calculate valid HMAC-SHA256 signature string for testing
-async function computeTestSignature(secret: string, body: string): Promise<string> {
+async function computeTestSignature(
+  secret: string,
+  body: string,
+): Promise<string> {
   const key = await crypto.subtle.importKey(
-    "raw",
+    'raw',
     new TextEncoder().encode(secret),
-    { name: "HMAC", hash: "SHA-256" },
+    { name: 'HMAC', hash: 'SHA-256' },
     false,
-    ["sign"],
+    ['sign'],
   );
   const signed = await crypto.subtle.sign(
-    "HMAC",
+    'HMAC',
     key,
     new TextEncoder().encode(body),
   );
   const digest = Array.from(new Uint8Array(signed))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
   return `sha256=${digest}`;
 }
 
-describe("GitHub Webhook HMAC-SHA256 Verification & Endpoint", () => {
-  const testSecret = "my-super-secret-webhook-key";
+describe('GitHub Webhook HMAC-SHA256 Verification & Endpoint', () => {
+  const testSecret = 'my-super-secret-webhook-key';
   const testBody = JSON.stringify({
-    repository: { owner: { login: "octocat" } },
+    repository: { owner: { login: 'octocat' } },
   });
 
   beforeEach(() => {
@@ -57,66 +61,66 @@ describe("GitHub Webhook HMAC-SHA256 Verification & Endpoint", () => {
     process.env.GITHUB_WEBHOOK_SECRET = testSecret;
   });
 
-  describe("timingSafeEqualBuffer", () => {
-    it("should return true for identical Uint8Arrays", () => {
+  describe('timingSafeEqualBuffer', () => {
+    it('should return true for identical Uint8Arrays', () => {
       const a = new Uint8Array([1, 2, 3, 4, 5, 255]);
       const b = new Uint8Array([1, 2, 3, 4, 5, 255]);
       expect(timingSafeEqualBuffer(a, b)).toBe(true);
     });
 
-    it("should return false for different Uint8Arrays of same length", () => {
+    it('should return false for different Uint8Arrays of same length', () => {
       const a = new Uint8Array([1, 2, 3, 4, 5, 255]);
       const b = new Uint8Array([1, 2, 3, 4, 5, 0]);
       expect(timingSafeEqualBuffer(a, b)).toBe(false);
     });
 
-    it("should return false for buffers of different byte lengths", () => {
+    it('should return false for buffers of different byte lengths', () => {
       const a = new Uint8Array([1, 2, 3]);
       const b = new Uint8Array([1, 2, 3, 4]);
       expect(timingSafeEqualBuffer(a, b)).toBe(false);
     });
   });
 
-  describe("verifySignature", () => {
-    it("should return true for a valid signature", async () => {
+  describe('verifySignature', () => {
+    it('should return true for a valid signature', async () => {
       const signature = await computeTestSignature(testSecret, testBody);
       const isValid = await verifySignature(testSecret, testBody, signature);
       expect(isValid).toBe(true);
     });
 
-    it("should return false if header signature is missing or null", async () => {
+    it('should return false if header signature is missing or null', async () => {
       expect(await verifySignature(testSecret, testBody, null)).toBe(false);
     });
 
-    it("should return false if header does not start with sha256=", async () => {
+    it('should return false if header does not start with sha256=', async () => {
       expect(
-        await verifySignature(testSecret, testBody, "sha1=abcdef1234567890"),
+        await verifySignature(testSecret, testBody, 'sha1=abcdef1234567890'),
       ).toBe(false);
     });
 
-    it("should return false for incorrect signature length or invalid hex", async () => {
+    it('should return false for incorrect signature length or invalid hex', async () => {
       expect(
-        await verifySignature(testSecret, testBody, "sha256=invalidhex"),
+        await verifySignature(testSecret, testBody, 'sha256=invalidhex'),
       ).toBe(false);
     });
 
-    it("should return false when body has been tampered with", async () => {
+    it('should return false when body has been tampered with', async () => {
       const signature = await computeTestSignature(testSecret, testBody);
       const isValid = await verifySignature(
         testSecret,
-        testBody + "tampered",
+        testBody + 'tampered',
         signature,
       );
       expect(isValid).toBe(false);
     });
   });
 
-  describe("POST /api/webhooks/github", () => {
-    it("should return 503 if GITHUB_WEBHOOK_SECRET is not configured", async () => {
+  describe('POST /api/webhooks/github', () => {
+    it('should return 503 if GITHUB_WEBHOOK_SECRET is not configured', async () => {
       delete process.env.GITHUB_WEBHOOK_SECRET;
 
-      const req = new NextRequest("http://localhost/api/webhooks/github", {
-        method: "POST",
+      const req = new NextRequest('http://localhost/api/webhooks/github', {
+        method: 'POST',
         body: testBody,
       });
 
@@ -124,14 +128,14 @@ describe("GitHub Webhook HMAC-SHA256 Verification & Endpoint", () => {
       expect(res.status).toBe(503);
       const json = await res.json();
       // The API returns a structured error object, not a bare string.
-      expect(json.error.message).toBe("Webhook not configured");
+      expect(json.error.message).toBe('Webhook not configured');
     });
 
-    it("should return 401 for an invalid signature", async () => {
-      const req = new NextRequest("http://localhost/api/webhooks/github", {
-        method: "POST",
+    it('should return 401 for an invalid signature', async () => {
+      const req = new NextRequest('http://localhost/api/webhooks/github', {
+        method: 'POST',
         headers: {
-          "x-hub-signature-256": "sha256=" + "0".repeat(64),
+          'x-hub-signature-256': 'sha256=' + '0'.repeat(64),
         },
         body: testBody,
       });
@@ -139,16 +143,16 @@ describe("GitHub Webhook HMAC-SHA256 Verification & Endpoint", () => {
       const res = await POST(req);
       expect(res.status).toBe(401);
       const json = await res.json();
-      expect(json.error.message).toBe("Invalid signature");
+      expect(json.error.message).toBe('Invalid signature');
     });
 
-    it("should return 200 pong for ping event", async () => {
+    it('should return 200 pong for ping event', async () => {
       const signature = await computeTestSignature(testSecret, testBody);
-      const req = new NextRequest("http://localhost/api/webhooks/github", {
-        method: "POST",
+      const req = new NextRequest('http://localhost/api/webhooks/github', {
+        method: 'POST',
         headers: {
-          "x-hub-signature-256": signature,
-          "x-github-event": "ping",
+          'x-hub-signature-256': signature,
+          'x-github-event': 'ping',
         },
         body: testBody,
       });
@@ -158,21 +162,24 @@ describe("GitHub Webhook HMAC-SHA256 Verification & Endpoint", () => {
       const json = await res.json();
       // Success bodies travel inside the { success, data } envelope that
       // createApiResponse applies.
-      expect(json).toEqual({ success: true, data: { ok: true, message: "pong" } });
+      expect(json).toEqual({
+        success: true,
+        data: { ok: true, message: 'pong' },
+      });
     });
 
-    it("should return 200 accepted for valid push event and trigger background refresh", async () => {
+    it('should return 200 accepted for valid push event and trigger background refresh', async () => {
       vi.mocked(refreshProfile).mockResolvedValue({
-        status: "refreshed",
-        username: "octocat",
+        status: 'refreshed',
+        username: 'octocat',
       });
 
       const signature = await computeTestSignature(testSecret, testBody);
-      const req = new NextRequest("http://localhost/api/webhooks/github", {
-        method: "POST",
+      const req = new NextRequest('http://localhost/api/webhooks/github', {
+        method: 'POST',
         headers: {
-          "x-hub-signature-256": signature,
-          "x-github-event": "push",
+          'x-hub-signature-256': signature,
+          'x-github-event': 'push',
         },
         body: testBody,
       });
@@ -182,21 +189,21 @@ describe("GitHub Webhook HMAC-SHA256 Verification & Endpoint", () => {
       const json = await res.json();
       expect(json).toEqual({
         success: true,
-        data: { ok: true, accepted: "octocat" },
+        data: { ok: true, accepted: 'octocat' },
       });
     });
 
-    it("should enqueue to dead-letter queue when background refresh encounters error", async () => {
+    it('should enqueue to dead-letter queue when background refresh encounters error', async () => {
       vi.mocked(refreshProfile).mockResolvedValue({
-        status: "error",
+        status: 'error',
       });
 
       const signature = await computeTestSignature(testSecret, testBody);
-      const req = new NextRequest("http://localhost/api/webhooks/github", {
-        method: "POST",
+      const req = new NextRequest('http://localhost/api/webhooks/github', {
+        method: 'POST',
         headers: {
-          "x-hub-signature-256": signature,
-          "x-github-event": "push",
+          'x-hub-signature-256': signature,
+          'x-github-event': 'push',
         },
         body: testBody,
       });
@@ -205,12 +212,11 @@ describe("GitHub Webhook HMAC-SHA256 Verification & Endpoint", () => {
       expect(res.status).toBe(200);
       expect(enqueueDeadLetterPayload).toHaveBeenCalledWith(
         expect.objectContaining({
-          eventType: "push",
-          username: "octocat",
-          errorReason: "refresh_status_error",
+          eventType: 'push',
+          username: 'octocat',
+          errorReason: 'refresh_status_error',
         }),
       );
     });
   });
 });
-

--- a/src/lib/webhook-signature.ts
+++ b/src/lib/webhook-signature.ts
@@ -1,0 +1,88 @@
+/**
+ * GitHub webhook signature verification.
+ *
+ * These live here rather than in the route module because a Next App Router
+ * route file has a defined export surface — the HTTP method handlers and a few
+ * recognised config values. Exporting helpers from one so a test can import
+ * them puts arbitrary names into that surface, and the test previously imported
+ * two that weren't exported at all, which failed `tsc --noEmit` on every commit.
+ *
+ * Extracting them keeps the route's exports to POST and gives the test a normal
+ * module to import from.
+ */
+
+// Receives GitHub `push` webhooks and triggers a (rate-limited) refresh of the
+// affected profile in the background. Signature verification uses edge-safe Web Crypto
+// APIs and constant-time buffer comparison (crypto.subtle.timingSafeEqual).
+
+/** Converts a hex string into a Uint8Array byte buffer. */
+export function hexToBytes(hex: string): Uint8Array | null {
+  if (hex.length % 2 !== 0 || !/^[0-9a-fA-F]+$/.test(hex)) {
+    return null;
+  }
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes[i / 2] = parseInt(hex.slice(i, i + 2), 16);
+  }
+  return bytes;
+}
+
+/** Constant-time comparison of two ArrayBuffer or ArrayBufferView byte buffers. */
+export function timingSafeEqualBuffer(
+  a: ArrayBuffer | ArrayBufferView,
+  b: ArrayBuffer | ArrayBufferView,
+): boolean {
+  const subtle = crypto.subtle as unknown as {
+    timingSafeEqual?: (
+      _a: ArrayBuffer | ArrayBufferView,
+      _b: ArrayBuffer | ArrayBufferView,
+    ) => boolean;
+  };
+
+  if (typeof subtle.timingSafeEqual === 'function') {
+    return subtle.timingSafeEqual(a, b);
+  }
+
+  const viewA =
+    a instanceof Uint8Array ? a : new Uint8Array('buffer' in a ? a.buffer : a);
+  const viewB =
+    b instanceof Uint8Array ? b : new Uint8Array('buffer' in b ? b.buffer : b);
+
+  if (viewA.byteLength !== viewB.byteLength) return false;
+  let mismatch = 0;
+  for (let i = 0; i < viewA.byteLength; i++) {
+    mismatch |= viewA[i] ^ viewB[i];
+  }
+  return mismatch === 0;
+}
+
+/** Verify GitHub's `X-Hub-Signature-256` (HMAC-SHA256 of raw body in constant time). */
+export async function verifySignature(
+  secret: string,
+  body: string,
+  header: string | null,
+): Promise<boolean> {
+  if (!header || !header.startsWith('sha256=')) return false;
+
+  const headerHex = header.slice(7);
+  if (headerHex.length !== 64) return false;
+
+  const headerBytes = hexToBytes(headerHex);
+  if (!headerBytes) return false;
+
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const signedBuffer = await crypto.subtle.sign(
+    'HMAC',
+    key,
+    new TextEncoder().encode(body),
+  );
+  const computedBytes = new Uint8Array(signedBuffer);
+
+  return timingSafeEqualBuffer(computedBytes, headerBytes);
+}


### PR DESCRIPTION
`tsc --noEmit` fails on clean `main` @ bd9bfc0, which blocks the pre-commit hook for everyone:

```
src/lib/__tests__/github-webhook.test.ts:3:3 - error TS2459: Module '"@/app/api/webhooks/github/route"' declares 'verifySignature' locally, but it is not exported.
src/lib/__tests__/github-webhook.test.ts:4:3 - error TS2459: Module '"@/app/api/webhooks/github/route"' declares 'timingSafeEqualBuffer' locally, but it is not exported.
```
Closes #708 

## It was worse than a type error

Running the suite showed the compile errors were the visible face of something larger — the test file was failing **12 of 13**:

```
main @ bd9bfc0        Tests  12 failed | 1 passed (13)
this branch           Tests  13 passed (13)
```

Eight of those twelve failed with `TypeError: verifySignature is not a function`. Because the helpers weren't exported, the imports resolved to `undefined` at runtime, so every test of the signature verification logic — the security-critical part — was throwing rather than testing anything.

## Why not just add `export`

A Next App Router route module has a defined export surface: the HTTP method handlers plus a few recognised config values. Exporting helpers from one so a test can reach them puts arbitrary names into that surface.

So `hexToBytes`, `timingSafeEqualBuffer` and `verifySignature` move to `src/lib/webhook-signature.ts`. The route imports `verifySignature` — the only one it calls directly — and exports just `POST`. The test imports `POST` from the route and the helpers from the new module.

`PushPayload` stays in the route: it describes the request body this handler parses, not signature verification.

## Four stale assertions, also fixed

The remaining four failures were assertions written against the previous response contract — `json.error` as a string, and bare `{ ok, message }` bodies. The API now returns a structured `error` object and the `{ success, data }` envelope from `createApiResponse`:

```
expect(json.error).toBe("Invalid signature")
  received: { code: "AUTH_ERROR", message: "Invalid signature" }
```

Updated here rather than left red, since this PR already touches the file.

## Verification

- `npx vitest run src/lib/__tests__/github-webhook.test.ts` — **13 passed**, up from 1.
- `npx tsc --noEmit` silent across the whole project.
- `npm run build` completes.
- Committed **without** `--no-verify`; the pre-commit hook now passes.

Net effect at runtime: nothing changes. The same functions, called from the same place — they're just importable now, which is what lets the tests actually exercise them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub webhook signature validation for malformed or invalid signatures.
  * Standardized webhook responses for clearer success and error handling.
  * Preserved handling for ping events, push updates, and failed-event processing.

* **Tests**
  * Expanded coverage for signature validation and webhook response scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->