### PR TITLE
feat(api): serve an OpenAPI 3.1 spec and interactive docs for the public read API (Closes #577)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ossfolio",
       "version": "0.1.0",
       "dependencies": {
+        "@asteasolutions/zod-to-openapi": "^9.1.0",
         "@radix-ui/react-avatar": "^1.1.3",
         "@radix-ui/react-dialog": "^1.1.6",
         "@radix-ui/react-dropdown-menu": "^2.1.6",
@@ -36,7 +37,8 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "recharts": "^2.15.4",
-        "tailwind-merge": "^3.3.0"
+        "tailwind-merge": "^3.3.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@emnapi/core": "^1.11.1",
@@ -306,6 +308,18 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@asteasolutions/zod-to-openapi": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@asteasolutions/zod-to-openapi/-/zod-to-openapi-9.1.0.tgz",
+      "integrity": "sha512-pLMeRgRYS7/vZIgAAkOe2P6+XGTifR1MT9pqDoxZ11EmcJJ+DPmdPqLN8ZZF4U8R9KHCCQCS9c2wtuE8wSrfkw==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi3-ts": "^4.6.0"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
       }
     },
     "node_modules/@aws-crypto/sha1-browser": {
@@ -1327,6 +1341,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1781,6 +1796,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1829,6 +1845,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1892,6 +1909,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1936,6 +1954,7 @@
       "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
@@ -1945,8 +1964,9 @@
       "version": "1.11.2",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
       "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -2716,6 +2736,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2738,6 +2759,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2760,6 +2782,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2776,6 +2799,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2792,6 +2816,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2808,6 +2833,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2824,6 +2850,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2840,6 +2867,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2856,6 +2884,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2872,6 +2901,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2888,6 +2918,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2904,6 +2935,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2920,6 +2952,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2942,6 +2975,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2964,6 +2998,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2986,6 +3021,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3008,6 +3044,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3030,6 +3067,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3052,6 +3090,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3074,6 +3113,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3096,6 +3136,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -3115,6 +3156,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3134,6 +3176,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3153,6 +3196,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3405,6 +3449,7 @@
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -4487,6 +4532,7 @@
       "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.61.1"
       },
@@ -6355,6 +6401,7 @@
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
       "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -6666,7 +6713,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -6752,8 +6798,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/canvas-confetti": {
       "version": "1.9.0",
@@ -6922,6 +6967,7 @@
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -6932,6 +6978,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -6981,6 +7028,7 @@
       "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.63.0",
         "@typescript-eslint/types": "8.63.0",
@@ -7759,6 +7807,7 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8257,6 +8306,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001800",
@@ -8891,6 +8941,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9188,7 +9239,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -9226,8 +9276,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -9600,6 +9649,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -9671,6 +9721,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9856,6 +9907,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -12498,7 +12550,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -12798,6 +12849,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.10.tgz",
       "integrity": "sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "16.2.10",
         "@swc/helpers": "0.5.15",
@@ -13242,6 +13294,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openapi3-ts": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-4.6.1.tgz",
+      "integrity": "sha512-XW9MOldkhoICNeXVzzmXzmOW5G73ppOEGmh7fLCqHjgfdEYCGGN+00MlVCeUZgovjjfC56j9tvtDt1zGabNjjA==",
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.9.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -13476,6 +13537,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -13547,7 +13609,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -13563,7 +13624,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -13576,8 +13636,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -13687,6 +13746,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13696,6 +13756,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -14994,6 +15055,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -15256,6 +15318,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15336,6 +15399,7 @@
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -15538,6 +15602,7 @@
       "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
@@ -15916,6 +15981,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -15936,6 +16002,7 @@
       "integrity": "sha512-xZeXKYi7hxQRF5anL+v77RkufJNpF9f3Eqeyqq2QBsETpLZgh0Agj0jJ6JPtkbgn6ukZdh8OK5egsGPWIditgg==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.5.0",
         "@cloudflare/unenv-preset": "2.16.1",
@@ -16093,7 +16160,6 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -16175,8 +16241,8 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@asteasolutions/zod-to-openapi": "^9.1.0",
     "@radix-ui/react-avatar": "^1.1.3",
     "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-dropdown-menu": "^2.1.6",
@@ -45,7 +46,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "recharts": "^2.15.4",
-    "tailwind-merge": "^3.3.0"
+    "tailwind-merge": "^3.3.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@emnapi/core": "^1.11.1",

--- a/src/app/api-docs/page.tsx
+++ b/src/app/api-docs/page.tsx
@@ -1,0 +1,43 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "API Documentation - OSSfolio",
+  description:
+    "Interactive reference for the OSSfolio public read API, including rate " +
+    "limiting and conditional request behaviour.",
+};
+
+/**
+ * Interactive viewer for /api/openapi.json.
+ *
+ * The renderer is loaded from a CDN rather than bundled. It is only ever needed
+ * on this page, and pulling a documentation UI into the application bundle
+ * would cost every other route in the app for something an integrator visits
+ * once. Nothing here runs during the build.
+ */
+export default function ApiDocsPage() {
+  return (
+    <main style={{ minHeight: "100vh" }}>
+      <script
+        id="api-reference"
+        data-url="/api/openapi.json"
+        // Matches the site's light-canvas commitment in DESIGN.md rather than
+        // defaulting to the renderer's dark theme.
+        data-configuration='{"theme":"default","darkMode":false,"hideDownloadButton":false}'
+      />
+      <script
+        src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"
+        async
+      />
+      <noscript>
+        <div style={{ padding: "24px" }}>
+          <h1>API Documentation</h1>
+          <p>
+            The interactive viewer needs JavaScript. The specification itself is
+            available at <a href="/api/openapi.json">/api/openapi.json</a>.
+          </p>
+        </div>
+      </noscript>
+    </main>
+  );
+}

--- a/src/app/api-docs/page.tsx
+++ b/src/app/api-docs/page.tsx
@@ -1,10 +1,10 @@
-import type { Metadata } from "next";
+import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: "API Documentation - OSSfolio",
+  title: 'API Documentation - OSSfolio',
   description:
-    "Interactive reference for the OSSfolio public read API, including rate " +
-    "limiting and conditional request behaviour.",
+    'Interactive reference for the OSSfolio public read API, including rate ' +
+    'limiting and conditional request behaviour.',
 };
 
 /**
@@ -17,7 +17,7 @@ export const metadata: Metadata = {
  */
 export default function ApiDocsPage() {
   return (
-    <main style={{ minHeight: "100vh" }}>
+    <main style={{ minHeight: '100vh' }}>
       <script
         id="api-reference"
         data-url="/api/openapi.json"
@@ -25,12 +25,9 @@ export default function ApiDocsPage() {
         // defaulting to the renderer's dark theme.
         data-configuration='{"theme":"default","darkMode":false,"hideDownloadButton":false}'
       />
-      <script
-        src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"
-        async
-      />
+      <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference" async />
       <noscript>
-        <div style={{ padding: "24px" }}>
+        <div style={{ padding: '24px' }}>
           <h1>API Documentation</h1>
           <p>
             The interactive viewer needs JavaScript. The specification itself is

--- a/src/app/api/openapi.json/route.ts
+++ b/src/app/api/openapi.json/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { buildOpenApiDocument } from "@/lib/openapi";
+
+/**
+ * Serves the OpenAPI 3.1 description of the public read API.
+ *
+ * Generated per request from the schemas in lib/openapi.ts rather than checked
+ * in as a static file, so it cannot drift from them — which is the failure mode
+ * the issue names under "Alternatives Considered".
+ *
+ * CORS is open because the document is public by definition and integrators
+ * fetch it from their own tooling.
+ */
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  return NextResponse.json(buildOpenApiDocument(), {
+    headers: {
+      "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",
+      "Access-Control-Allow-Origin": "*",
+    },
+  });
+}

--- a/src/app/api/openapi.json/route.ts
+++ b/src/app/api/openapi.json/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from "next/server";
-import { buildOpenApiDocument } from "@/lib/openapi";
+import { NextResponse } from 'next/server';
+import { buildOpenApiDocument } from '@/lib/openapi';
 
 /**
  * Serves the OpenAPI 3.1 description of the public read API.
@@ -11,13 +11,13 @@ import { buildOpenApiDocument } from "@/lib/openapi";
  * CORS is open because the document is public by definition and integrators
  * fetch it from their own tooling.
  */
-export const dynamic = "force-dynamic";
+export const dynamic = 'force-dynamic';
 
 export async function GET() {
   return NextResponse.json(buildOpenApiDocument(), {
     headers: {
-      "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",
-      "Access-Control-Allow-Origin": "*",
+      'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
+      'Access-Control-Allow-Origin': '*',
     },
   });
 }

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -1,0 +1,290 @@
+import { z } from "zod";
+import {
+  OpenAPIRegistry,
+  OpenApiGeneratorV31,
+  extendZodWithOpenApi,
+} from "@asteasolutions/zod-to-openapi";
+
+extendZodWithOpenApi(z);
+
+/**
+ * OpenAPI 3.1 description of the public read API.
+ *
+ * Scope is the endpoints an external integrator consumes. Authentication,
+ * webhooks and the internal mutation routes are deliberately absent — they are
+ * not part of a public integration surface, and publishing their shapes invites
+ * probing rather than integration.
+ *
+ * Response schemas are declared here rather than inferred from the handlers.
+ * Next route handlers return `NextResponse`, which carries no type information a
+ * generator can read back, so a schema is the closest thing to a single source
+ * of truth available without rewriting request handling across every route.
+ * They are written against the exact object each handler builds, and the
+ * envelope below matches `createApiResponse` in `lib/validators/api.ts`.
+ *
+ * Two endpoints return no JSON at all and are described by hand: the badge
+ * endpoint emits SVG and the export endpoint emits a file. Both are documented
+ * with their real media types rather than pretended into a schema.
+ */
+
+// Mirrors ApiSuccessResponse in lib/validators/api.ts.
+const successEnvelope = <T extends z.ZodTypeAny>(data: T) =>
+  z.object({ success: z.literal(true), data });
+
+// Mirrors ApiErrorBody in lib/errors.ts.
+export const ApiErrorSchema = z
+  .object({
+    success: z.literal(false),
+    error: z.object({
+      code: z.string(),
+      message: z.string(),
+      details: z.record(z.string(), z.unknown()).optional(),
+    }),
+    code: z.string(),
+    status: z.number(),
+    timestamp: z.string(),
+    retryAfterSeconds: z.number().optional(),
+  })
+  .openapi("ApiError");
+
+export const UserProfileSchema = z
+  .object({
+    username: z.string(),
+    name: z.string().nullable(),
+    avatar_url: z.string().nullable(),
+    github_url: z.string().nullable(),
+    bio: z.string().nullable(),
+    headline: z.string().nullable(),
+    score: z.number(),
+    followers: z.number(),
+    top_languages: z.array(z.string()),
+    stats: z.object({
+      commits: z.number(),
+      prs: z.number(),
+      issues: z.number(),
+      reviews: z.number(),
+    }),
+    badges: z.unknown(),
+    last_refreshed_at: z.string().nullable(),
+  })
+  .openapi("UserProfile");
+
+export const DiscoverPageSchema = z
+  .object({
+    profiles: z.array(z.unknown()),
+    page: z.number(),
+    hasNext: z.boolean(),
+    hasPrev: z.boolean(),
+  })
+  .openapi("DiscoverPage");
+
+export const SponsorshipSchema = z
+  .object({
+    username: z.string(),
+    fundingLinks: z.array(z.object({ platform: z.string(), url: z.string() })),
+    sponsors: z.array(z.unknown()),
+  })
+  .openapi("Sponsorship");
+
+export const AnalyticsSchema = z
+  .object({
+    username: z.string(),
+    days: z.number(),
+    totalViews: z.number(),
+    uniqueVisitors: z.number(),
+    viewsTrend: z.array(z.unknown()),
+    referrers: z.array(z.unknown()),
+    topCountries: z.array(z.unknown()),
+    deviceBreakdown: z.array(z.unknown()),
+  })
+  .openapi("Analytics");
+
+const usernameParam = z.object({
+  username: z.string().openapi({ example: "e2e-alice" }),
+});
+
+const jsonError = (description: string) => ({
+  description,
+  content: { "application/json": { schema: ApiErrorSchema } },
+});
+
+export function buildOpenApiDocument() {
+  const registry = new OpenAPIRegistry();
+
+  registry.registerPath({
+    method: "get",
+    path: "/api/v1/users/{username}",
+    tags: ["Profiles"],
+    summary: "Fetch a contributor profile",
+    description:
+      "Returns a contributor's score, statistics and badge metadata. Supports " +
+      "conditional requests: send the ETag from a previous response as " +
+      "If-None-Match and a 304 is returned with no body when nothing has changed.",
+    request: { params: usernameParam },
+    responses: {
+      200: {
+        description: "The contributor profile.",
+        content: {
+          "application/json": { schema: successEnvelope(UserProfileSchema) },
+        },
+        headers: z.object({
+          ETag: z
+            .string()
+            .openapi({ description: "Validator for conditional requests." }),
+          "Cache-Control": z.string(),
+        }),
+      },
+      304: {
+        description:
+          "The If-None-Match validator matched. No body is returned; reuse the " +
+          "cached representation.",
+      },
+      400: jsonError("The username failed validation."),
+      404: jsonError("No profile exists for that username."),
+      429: {
+        ...jsonError("Rate limit exceeded."),
+        headers: z.object({
+          "Retry-After": z.string().openapi({
+            description: "Seconds to wait before retrying.",
+          }),
+        }),
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/api/analytics/{username}",
+    tags: ["Profiles"],
+    summary: "Fetch profile analytics",
+    request: { params: usernameParam },
+    responses: {
+      200: {
+        description: "View counts and traffic breakdown.",
+        content: {
+          "application/json": { schema: successEnvelope(AnalyticsSchema) },
+        },
+      },
+      400: jsonError("The username failed validation."),
+      401: jsonError("Analytics are only readable by the profile owner."),
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/api/sponsors/{username}",
+    tags: ["Profiles"],
+    summary: "Fetch sponsorship links",
+    request: { params: usernameParam },
+    responses: {
+      200: {
+        description: "Funding links and sponsors.",
+        content: {
+          "application/json": { schema: successEnvelope(SponsorshipSchema) },
+        },
+      },
+      400: jsonError("The username failed validation."),
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/api/discover",
+    tags: ["Discovery"],
+    summary: "Browse contributor profiles",
+    request: {
+      query: z.object({
+        page: z.string().optional().openapi({ example: "1" }),
+      }),
+    },
+    responses: {
+      200: {
+        description: "A page of profiles.",
+        content: {
+          "application/json": { schema: successEnvelope(DiscoverPageSchema) },
+        },
+      },
+      500: jsonError("The profile query failed."),
+    },
+  });
+
+  // Described by hand: this endpoint emits SVG, so there is no JSON schema to
+  // derive. Documenting it with its real media type is more useful to an
+  // integrator than omitting it.
+  registry.registerPath({
+    method: "get",
+    path: "/api/badge/{username}",
+    tags: ["Badges"],
+    summary: "Render a contributor score badge",
+    description:
+      "Returns an SVG badge suitable for embedding in a README. This endpoint " +
+      "does not return JSON.",
+    request: { params: usernameParam },
+    responses: {
+      200: {
+        description: "The badge.",
+        content: { "image/svg+xml": { schema: z.string() } },
+      },
+      400: {
+        description: "The username parameter was missing.",
+        content: { "text/plain": { schema: z.string() } },
+      },
+      500: {
+        description: "Badge generation failed.",
+        content: { "text/plain": { schema: z.string() } },
+      },
+    },
+  });
+
+  // Also hand-described: a file download rather than a JSON body.
+  registry.registerPath({
+    method: "get",
+    path: "/api/export/{username}",
+    tags: ["Profiles"],
+    summary: "Export a profile",
+    description:
+      "Returns the profile as a downloadable document rather than a JSON API " +
+      "response.",
+    request: { params: usernameParam },
+    responses: {
+      200: {
+        description: "The exported profile.",
+        content: { "application/octet-stream": { schema: z.string() } },
+      },
+      400: {
+        description: "The username parameter was missing.",
+        content: { "text/plain": { schema: z.string() } },
+      },
+      500: {
+        description: "Export failed.",
+        content: { "text/plain": { schema: z.string() } },
+      },
+    },
+  });
+
+  return new OpenApiGeneratorV31(registry.definitions).generateDocument({
+    openapi: "3.1.0",
+    info: {
+      title: "OSSfolio Public API",
+      version: "1.0.0",
+      description:
+        "Read-only endpoints for consuming OSSfolio contributor scores and " +
+        "badge metadata.\n\n" +
+        "**Rate limiting.** Requests are limited per client. A 429 carries a " +
+        "`Retry-After` header giving the seconds to wait, and the body's " +
+        "`retryAfterSeconds` field repeats it.\n\n" +
+        "**Conditional requests.** Endpoints that return an `ETag` accept " +
+        "`If-None-Match`. Sending back the validator you already hold returns " +
+        "304 with no body, which saves bandwidth and does not count against " +
+        "your rate limit budget any differently from a 200.\n\n" +
+        "Authentication, webhook and internal mutation endpoints are " +
+        "intentionally not documented here.",
+    },
+    servers: [{ url: "https://ossfolio.dev" }],
+    tags: [
+      { name: "Profiles", description: "Contributor profile data." },
+      { name: "Discovery", description: "Browsing and search." },
+      { name: "Badges", description: "Embeddable SVG badges." },
+    ],
+  });
+}

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -1,9 +1,9 @@
-import { z } from "zod";
+import { z } from 'zod';
 import {
   OpenAPIRegistry,
   OpenApiGeneratorV31,
   extendZodWithOpenApi,
-} from "@asteasolutions/zod-to-openapi";
+} from '@asteasolutions/zod-to-openapi';
 
 extendZodWithOpenApi(z);
 
@@ -45,7 +45,7 @@ export const ApiErrorSchema = z
     timestamp: z.string(),
     retryAfterSeconds: z.number().optional(),
   })
-  .openapi("ApiError");
+  .openapi('ApiError');
 
 export const UserProfileSchema = z
   .object({
@@ -67,7 +67,7 @@ export const UserProfileSchema = z
     badges: z.unknown(),
     last_refreshed_at: z.string().nullable(),
   })
-  .openapi("UserProfile");
+  .openapi('UserProfile');
 
 export const DiscoverPageSchema = z
   .object({
@@ -76,7 +76,7 @@ export const DiscoverPageSchema = z
     hasNext: z.boolean(),
     hasPrev: z.boolean(),
   })
-  .openapi("DiscoverPage");
+  .openapi('DiscoverPage');
 
 export const SponsorshipSchema = z
   .object({
@@ -84,7 +84,7 @@ export const SponsorshipSchema = z
     fundingLinks: z.array(z.object({ platform: z.string(), url: z.string() })),
     sponsors: z.array(z.unknown()),
   })
-  .openapi("Sponsorship");
+  .openapi('Sponsorship');
 
 export const AnalyticsSchema = z
   .object({
@@ -97,55 +97,55 @@ export const AnalyticsSchema = z
     topCountries: z.array(z.unknown()),
     deviceBreakdown: z.array(z.unknown()),
   })
-  .openapi("Analytics");
+  .openapi('Analytics');
 
 const usernameParam = z.object({
-  username: z.string().openapi({ example: "e2e-alice" }),
+  username: z.string().openapi({ example: 'e2e-alice' }),
 });
 
 const jsonError = (description: string) => ({
   description,
-  content: { "application/json": { schema: ApiErrorSchema } },
+  content: { 'application/json': { schema: ApiErrorSchema } },
 });
 
 export function buildOpenApiDocument() {
   const registry = new OpenAPIRegistry();
 
   registry.registerPath({
-    method: "get",
-    path: "/api/v1/users/{username}",
-    tags: ["Profiles"],
-    summary: "Fetch a contributor profile",
+    method: 'get',
+    path: '/api/v1/users/{username}',
+    tags: ['Profiles'],
+    summary: 'Fetch a contributor profile',
     description:
       "Returns a contributor's score, statistics and badge metadata. Supports " +
-      "conditional requests: send the ETag from a previous response as " +
-      "If-None-Match and a 304 is returned with no body when nothing has changed.",
+      'conditional requests: send the ETag from a previous response as ' +
+      'If-None-Match and a 304 is returned with no body when nothing has changed.',
     request: { params: usernameParam },
     responses: {
       200: {
-        description: "The contributor profile.",
+        description: 'The contributor profile.',
         content: {
-          "application/json": { schema: successEnvelope(UserProfileSchema) },
+          'application/json': { schema: successEnvelope(UserProfileSchema) },
         },
         headers: z.object({
           ETag: z
             .string()
-            .openapi({ description: "Validator for conditional requests." }),
-          "Cache-Control": z.string(),
+            .openapi({ description: 'Validator for conditional requests.' }),
+          'Cache-Control': z.string(),
         }),
       },
       304: {
         description:
-          "The If-None-Match validator matched. No body is returned; reuse the " +
-          "cached representation.",
+          'The If-None-Match validator matched. No body is returned; reuse the ' +
+          'cached representation.',
       },
-      400: jsonError("The username failed validation."),
-      404: jsonError("No profile exists for that username."),
+      400: jsonError('The username failed validation.'),
+      404: jsonError('No profile exists for that username.'),
       429: {
-        ...jsonError("Rate limit exceeded."),
+        ...jsonError('Rate limit exceeded.'),
         headers: z.object({
-          "Retry-After": z.string().openapi({
-            description: "Seconds to wait before retrying.",
+          'Retry-After': z.string().openapi({
+            description: 'Seconds to wait before retrying.',
           }),
         }),
       },
@@ -153,58 +153,58 @@ export function buildOpenApiDocument() {
   });
 
   registry.registerPath({
-    method: "get",
-    path: "/api/analytics/{username}",
-    tags: ["Profiles"],
-    summary: "Fetch profile analytics",
+    method: 'get',
+    path: '/api/analytics/{username}',
+    tags: ['Profiles'],
+    summary: 'Fetch profile analytics',
     request: { params: usernameParam },
     responses: {
       200: {
-        description: "View counts and traffic breakdown.",
+        description: 'View counts and traffic breakdown.',
         content: {
-          "application/json": { schema: successEnvelope(AnalyticsSchema) },
+          'application/json': { schema: successEnvelope(AnalyticsSchema) },
         },
       },
-      400: jsonError("The username failed validation."),
-      401: jsonError("Analytics are only readable by the profile owner."),
+      400: jsonError('The username failed validation.'),
+      401: jsonError('Analytics are only readable by the profile owner.'),
     },
   });
 
   registry.registerPath({
-    method: "get",
-    path: "/api/sponsors/{username}",
-    tags: ["Profiles"],
-    summary: "Fetch sponsorship links",
+    method: 'get',
+    path: '/api/sponsors/{username}',
+    tags: ['Profiles'],
+    summary: 'Fetch sponsorship links',
     request: { params: usernameParam },
     responses: {
       200: {
-        description: "Funding links and sponsors.",
+        description: 'Funding links and sponsors.',
         content: {
-          "application/json": { schema: successEnvelope(SponsorshipSchema) },
+          'application/json': { schema: successEnvelope(SponsorshipSchema) },
         },
       },
-      400: jsonError("The username failed validation."),
+      400: jsonError('The username failed validation.'),
     },
   });
 
   registry.registerPath({
-    method: "get",
-    path: "/api/discover",
-    tags: ["Discovery"],
-    summary: "Browse contributor profiles",
+    method: 'get',
+    path: '/api/discover',
+    tags: ['Discovery'],
+    summary: 'Browse contributor profiles',
     request: {
       query: z.object({
-        page: z.string().optional().openapi({ example: "1" }),
+        page: z.string().optional().openapi({ example: '1' }),
       }),
     },
     responses: {
       200: {
-        description: "A page of profiles.",
+        description: 'A page of profiles.',
         content: {
-          "application/json": { schema: successEnvelope(DiscoverPageSchema) },
+          'application/json': { schema: successEnvelope(DiscoverPageSchema) },
         },
       },
-      500: jsonError("The profile query failed."),
+      500: jsonError('The profile query failed.'),
     },
   });
 
@@ -212,79 +212,79 @@ export function buildOpenApiDocument() {
   // derive. Documenting it with its real media type is more useful to an
   // integrator than omitting it.
   registry.registerPath({
-    method: "get",
-    path: "/api/badge/{username}",
-    tags: ["Badges"],
-    summary: "Render a contributor score badge",
+    method: 'get',
+    path: '/api/badge/{username}',
+    tags: ['Badges'],
+    summary: 'Render a contributor score badge',
     description:
-      "Returns an SVG badge suitable for embedding in a README. This endpoint " +
-      "does not return JSON.",
+      'Returns an SVG badge suitable for embedding in a README. This endpoint ' +
+      'does not return JSON.',
     request: { params: usernameParam },
     responses: {
       200: {
-        description: "The badge.",
-        content: { "image/svg+xml": { schema: z.string() } },
+        description: 'The badge.',
+        content: { 'image/svg+xml': { schema: z.string() } },
       },
       400: {
-        description: "The username parameter was missing.",
-        content: { "text/plain": { schema: z.string() } },
+        description: 'The username parameter was missing.',
+        content: { 'text/plain': { schema: z.string() } },
       },
       500: {
-        description: "Badge generation failed.",
-        content: { "text/plain": { schema: z.string() } },
+        description: 'Badge generation failed.',
+        content: { 'text/plain': { schema: z.string() } },
       },
     },
   });
 
   // Also hand-described: a file download rather than a JSON body.
   registry.registerPath({
-    method: "get",
-    path: "/api/export/{username}",
-    tags: ["Profiles"],
-    summary: "Export a profile",
+    method: 'get',
+    path: '/api/export/{username}',
+    tags: ['Profiles'],
+    summary: 'Export a profile',
     description:
-      "Returns the profile as a downloadable document rather than a JSON API " +
-      "response.",
+      'Returns the profile as a downloadable document rather than a JSON API ' +
+      'response.',
     request: { params: usernameParam },
     responses: {
       200: {
-        description: "The exported profile.",
-        content: { "application/octet-stream": { schema: z.string() } },
+        description: 'The exported profile.',
+        content: { 'application/octet-stream': { schema: z.string() } },
       },
       400: {
-        description: "The username parameter was missing.",
-        content: { "text/plain": { schema: z.string() } },
+        description: 'The username parameter was missing.',
+        content: { 'text/plain': { schema: z.string() } },
       },
       500: {
-        description: "Export failed.",
-        content: { "text/plain": { schema: z.string() } },
+        description: 'Export failed.',
+        content: { 'text/plain': { schema: z.string() } },
       },
     },
   });
 
   return new OpenApiGeneratorV31(registry.definitions).generateDocument({
-    openapi: "3.1.0",
+    openapi: '3.1.0',
     info: {
-      title: "OSSfolio Public API",
-      version: "1.0.0",
+      title: 'OSSfolio Public API',
+      version: '1.0.0',
       description:
-        "Read-only endpoints for consuming OSSfolio contributor scores and " +
-        "badge metadata.\n\n" +
-        "**Rate limiting.** Requests are limited per client. A 429 carries a " +
+        'Read-only endpoints for consuming OSSfolio contributor scores and ' +
+        'badge metadata.\n\n' +
+        '**Rate limiting.** Requests are limited per client. A 429 carries a ' +
         "`Retry-After` header giving the seconds to wait, and the body's " +
-        "`retryAfterSeconds` field repeats it.\n\n" +
-        "**Conditional requests.** Endpoints that return an `ETag` accept " +
-        "`If-None-Match`. Sending back the validator you already hold returns " +
-        "304 with no body, which saves bandwidth and does not count against " +
-        "your rate limit budget any differently from a 200.\n\n" +
-        "Authentication, webhook and internal mutation endpoints are " +
-        "intentionally not documented here.",
+        '`retryAfterSeconds` field repeats it.\n\n' +
+        '**Conditional requests.** Endpoints that return an `ETag` accept ' +
+        '`If-None-Match`. Sending back the validator you already hold returns ' +
+        '304 with no body, which saves bandwidth and does not count against ' +
+        'your rate limit budget any differently from a 200.\n\n' +
+        'Authentication, webhook and internal mutation endpoints are ' +
+        'intentionally not documented here.',
     },
-    servers: [{ url: "https://ossfolio.dev" }],
+    servers: [{ url: 'https://ossfolio.dev' }],
     tags: [
-      { name: "Profiles", description: "Contributor profile data." },
-      { name: "Discovery", description: "Browsing and search." },
-      { name: "Badges", description: "Embeddable SVG badges." },
+      { name: 'Profiles', description: 'Contributor profile data.' },
+      { name: 'Discovery', description: 'Browsing and search.' },
+      { name: 'Badges', description: 'Embeddable SVG badges.' },
     ],
   });
 }


### PR DESCRIPTION
Closes #577

Built to the scope and approach agreed on the issue: option C, public read endpoints only, with the two non-JSON responses described by hand.

## What's included

Six endpoints — the surface an external integrator actually consumes:

| endpoint | response |
|---|---|
| `GET /api/v1/users/{username}` | JSON, with ETag and rate-limit semantics |
| `GET /api/analytics/{username}` | JSON |
| `GET /api/sponsors/{username}` | JSON |
| `GET /api/discover` | JSON |
| `GET /api/badge/{username}` | `image/svg+xml` |
| `GET /api/export/{username}` | file download |

Authentication, webhook and internal mutation routes are excluded per your call — publishing their shapes invites probing rather than integration. That exclusion is stated in the spec's own description, so it reads as a decision rather than an omission.

## How it's derived

`src/lib/openapi.ts` holds zod schemas for the four JSON response bodies, written against the exact object each handler constructs, plus the `{ success, data }` envelope from `createApiResponse` and the error body from `lib/errors.ts`. `@asteasolutions/zod-to-openapi` turns them into named components.

Route handlers return `NextResponse`, which carries no type information a generator can read back, so schemas are the closest thing to a single source of truth available without rewriting request handling on every route — which was the distinction between options B and C.

The two non-JSON endpoints are hand-described with their real media types, as agreed.

## Rate limits and conditional requests

The issue asked for these specifically, and `/api/v1/users/{username}` is where they live:

- **429** carries a documented `Retry-After` header, and the error body's `retryAfterSeconds` field is in the `ApiError` schema
- **200** carries `ETag` and `Cache-Control`
- **304** is documented as a null-body response, matching the handler — which builds it with an explicit `null` body because `NextResponse.json(x, { status: 304 })` throws

Both are also explained in prose in the spec's `info.description`, so they surface at the top of the viewer rather than only inside one endpoint.

## The viewer

`/api-docs` renders the spec through Scalar, loaded from a CDN rather than bundled. It's needed on exactly one page, and pulling a documentation UI into the application bundle would cost every other route for something an integrator visits once. There's a `<noscript>` fallback pointing at the raw spec.

Configured for the light canvas rather than the renderer's dark default, per DESIGN.md.

## Verification

The generator was exercised directly — transpiled and run — rather than only typechecked:

```
openapi: 3.1.0
paths  : 6
schemas: UserProfile, ApiError, Analytics, Sponsorship, DiscoverPage
ETag on 200       : true
Retry-After on 429: true
304 has no content: true
badge media type  : image/svg+xml
export media type : application/octet-stream
JSON round-trips  : true
```

`npm run build` completes with both `/api-docs` and `/api/openapi.json` registered in the route table.

## Follow-ups

The remaining 13 routes aren't covered. The internal mutation endpoints could be documented in a second pass if useful; auth and webhooks I'd leave out permanently.