### PR TITLE
Update milestones.tsrefactor(milestones): unify timestamps and handle upsert errors

### DIFF
--- a/src/lib/milestones.ts
+++ b/src/lib/milestones.ts
@@ -58,10 +58,13 @@ export async function syncUnlockedAchievements(
     const newUnlocks = unlocked.filter((a) => !existing[a.id]);
 
     if (newUnlocks.length > 0) {
+      // 1. Unify the timestamp so the DB and local state match exactly
+      const now = new Date().toISOString();
+
       const recordsToInsert = newUnlocks.map((a) => ({
         username: normalizedUsername,
         achievement_id: a.id,
-        unlocked_at: new Date().toISOString(),
+        unlocked_at: now,
         metadata: {
           name: a.name,
           target: a.target,
@@ -69,13 +72,19 @@ export async function syncUnlockedAchievements(
         },
       }));
 
-      await supabase
+      // 2. Explicitly catch and handle the upsert error
+      const { error } = await supabase
         .from("achievement_unlocks")
         .upsert(recordsToInsert, { onConflict: "username, achievement_id" });
 
-      // Merge newly inserted timestamps into result
+      if (error) {
+        console.error("Supabase upsert failed during achievement sync:", error.message);
+        return existing; // Abort local merge so we don't falsely show them as saved
+      }
+
+      // Merge newly inserted timestamps into result using the unified timestamp
       newUnlocks.forEach((a) => {
-        existing[a.id] = new Date().toISOString();
+        existing[a.id] = now;
       });
     }
 


### PR DESCRIPTION


### Description
This PR refactors `src/lib/milestones.ts` to ensure timestamp consistency and robust error handling during achievement synchronization.

Closes #682

#### Key Changes:
* **Timestamp Unification:** Extracted `new Date().toISOString()` into a single `now` constant. This guarantees that both the Supabase records and the returned local state share the exact same timestamp, preventing microsecond drift across map iterations.
* **Robust Error Propagation:** Added explicit error checking on the Supabase `upsert` operation. If the database write fails, it now logs the specific error message and aborts the local state merge to prevent the UI from falsely assuming the synchronization was successful.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved achievement synchronization consistency by ensuring unlock timestamps remain aligned across saved progress and local displays.
  * Prevented unsuccessful achievement updates from appearing as completed.
  * Added clearer error handling when achievement progress cannot be saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->