### PR TITLE
fix(http-cache): enforce strict RFC 9110 structural validation on origin ETags

### DIFF
--- a/src/lib/http-cache.ts
+++ b/src/lib/http-cache.ts
@@ -105,7 +105,14 @@ export function isNotModified(
   if (header === "") return false;
   if (header === "*") return true;
 
-  const current = stripWeakPrefix(etag);
+  // Strict RFC 9110 validation: the origin ETag must be enclosed in double quotes.
+  // If quotes were accidentally stripped upstream, fail closed and warn.
+  if (!etag.includes('"')) {
+    console.warn(`[http-cache] Rejected malformed origin ETag (missing quotes): ${etag}`);
+    return false;
+  }
+
+  const current = stripWeakPrefix(etag.trim());
 
   return splitEntityTags(header)
     .map((candidate) => stripWeakPrefix(candidate.trim()))


### PR DESCRIPTION


### Description
This PR addresses RFC 9110 compliance within `src/lib/http-cache.ts` by hardening the conditional request validation boundaries.

Closes #687

#### Key Changes:
* **Strict ETag Structural Guards:** The `computeETag` function correctly wraps generated hashes in double quotes. However, `isNotModified` previously lacked structural validation on the `etag` parameter. I added a strict guard that ensures the origin ETag contains mandatory double quotes before comparing it against the `If-None-Match` header.
* **Telemetry & Safety:** If a malformed ETag (e.g., quotes stripped by a middleware or proxy bug) is passed to `isNotModified`, it now cleanly fails closed (returning `false` to serve a 200 rather than a corrupted 304) and triggers a `console.warn` to surface the anomaly in logs.

