### PR TITLE
fix(network): deduplicate graph edges and harden repo name parsing

### DIFF
--- a/src/lib/impact-network.ts
+++ b/src/lib/impact-network.ts
@@ -40,6 +40,7 @@ export function buildImpactNetwork({
   const nodes: NetworkNode[] = [];
   const edges: NetworkEdge[] = [];
   const nodeMap = new Set<string>();
+  const edgeMap = new Set<string>(); // Tracks unique source->target edges to prevent duplicates
 
   const centralId = `user:${user.login.toLowerCase()}`;
   const centralLabel = user.name || user.login;
@@ -91,12 +92,17 @@ export function buildImpactNetwork({
 
     // Edge thickness based on PR count and stars
     const weight = Math.max(1, Math.min(7, 1 + prCount * 1.5 + Math.min(3, stars / 10)));
-    edges.push({
-      source: centralId,
-      target: repoId,
-      weight,
-      label: prCount > 0 ? `${prCount} PRs` : "Repository",
-    });
+    const edgeKey = `${centralId}->${repoId}`;
+    
+    if (!edgeMap.has(edgeKey)) {
+      edges.push({
+        source: centralId,
+        target: repoId,
+        weight,
+        label: prCount > 0 ? `${prCount} PRs` : "Repository",
+      });
+      edgeMap.add(edgeKey);
+    }
   }
 
   // 3. Organization Nodes
@@ -117,12 +123,16 @@ export function buildImpactNetwork({
     });
     nodeMap.add(orgId);
 
-    edges.push({
-      source: centralId,
-      target: orgId,
-      weight: 3,
-      label: "Member",
-    });
+    const edgeKey = `${centralId}->${orgId}`;
+    if (!edgeMap.has(edgeKey)) {
+      edges.push({
+        source: centralId,
+        target: orgId,
+        weight: 3,
+        label: "Member",
+      });
+      edgeMap.add(edgeKey);
+    }
   }
 
   // 4. Collaborator Nodes (Co-contributors)
@@ -132,9 +142,11 @@ export function buildImpactNetwork({
   if (allCollaborators.length === 0 && mergedPRs.length > 0) {
     const repoNames = Array.from(new Set(mergedPRs.map((p) => p.repoName).filter(Boolean)));
     repoNames.slice(0, 5).forEach((rName, idx) => {
-      if (rName.includes("/")) {
-        const owner = rName.split("/")[0];
-        if (owner.toLowerCase() !== user.login.toLowerCase()) {
+      // Robust owner parsing
+      const parts = rName.split("/");
+      if (parts.length >= 2) {
+        const owner = parts[0];
+        if (owner && owner.toLowerCase() !== user.login.toLowerCase()) {
           allCollaborators.push({
             login: owner,
             avatarUrl: `https://github.com/${owner}.png`,
@@ -167,12 +179,16 @@ export function buildImpactNetwork({
     const targetRepoId = collab.repoName ? `repo:${collab.repoName.toLowerCase()}` : null;
     const targetId = targetRepoId && nodeMap.has(targetRepoId) ? targetRepoId : centralId;
 
-    edges.push({
-      source: collabId,
-      target: targetId,
-      weight: Math.max(1, Math.min(5, collab.contributionsCount || 2)),
-      label: "Co-contributor",
-    });
+    const edgeKey = `${collabId}->${targetId}`;
+    if (!edgeMap.has(edgeKey)) {
+      edges.push({
+        source: collabId,
+        target: targetId,
+        weight: Math.max(1, Math.min(5, collab.contributionsCount || 2)),
+        label: "Co-contributor",
+      });
+      edgeMap.add(edgeKey);
+    }
   }
 
   return { nodes, edges };


### PR DESCRIPTION
### Description
This PR addresses visual graph bugs and runtime safety within `src/lib/impact-network.ts`.

Closes #686

#### Key Changes:
* **Edge Deduplication:** Introduced an `edgeMap` (`Set`) to track unique connections by ID (`source->target`). The graph builder now strictly checks this map before pushing to the `edges` array, preventing overlapping lines from rendering unnecessarily on the canvas when multiple contributors overlap on the same repo.
* **Safe Owner Parsing:** Hardened the repository name parsing block. Swapped `rName.includes('/')` for a much safer `split("/")` array length guard, preventing unexpected undefined behavior or index out-of-bounds exceptions when handling malformed repository strings.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate repository, organization, and collaborator connections from appearing in impact network visualizations.
  * Improved handling of collaborator information when repository details are incomplete or invalid.
  * Network results are now cleaner and more accurate, with fewer redundant or incorrectly generated relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->