### PR TITLE
fix(fetch): implement signal chaining to respect external abort controllers

### DIFF
--- a/src/lib/fetch-with-timeout.ts
+++ b/src/lib/fetch-with-timeout.ts
@@ -25,21 +25,31 @@ export async function fetchWithTimeout(
     controller.abort();
   }, timeoutMs);
 
+  // 1. Signal Chaining: Combine the external signal (if any) with our internal timeout signal
+  const combinedSignal = init.signal
+    ? AbortSignal.any([init.signal, controller.signal])
+    : controller.signal;
+
   try {
     const res = await fetch(input, {
       ...init,
-      signal: controller.signal,
+      signal: combinedSignal,
     });
     return res;
   } catch (err) {
     if (isAbortLikeError(err)) {
-      throw new FetchTimeoutError(
-        `Request timed out after ${timeoutMs}ms`,
-        timeoutMs,
-      );
+      // Only throw our custom timeout error if our specific controller caused the abort
+      if (controller.signal.aborted) {
+        throw new FetchTimeoutError(
+          `Request timed out after ${timeoutMs}ms`,
+          timeoutMs,
+        );
+      }
+      // If the external signal caused the abort, just let the original error propagate
     }
     throw err;
   } finally {
+    // 2. Timeout Cleanup: Reliably clear the interval to prevent memory leaks
     clearTimeout(timeoutId);
   }
 }


### PR DESCRIPTION


### Description
This PR addresses signal overriding bugs within `src/lib/fetch-with-timeout.ts`.

Closes #689

#### Key Changes:
* **Signal Chaining:** The previous implementation explicitly overwrote `init.signal` with the internal timeout controller's signal, completely breaking upstream cancellation requests. Upgraded to use `AbortSignal.any()` to cleanly merge the external signal (if provided) with the internal timeout signal.
* **Precise Error Handling:** Added a `controller.signal.aborted` guard inside the catch block. This ensures that if the fetch is aborted by an upstream caller rather than the internal timer, it cleanly propagates the standard `AbortError` instead of falsely swallowing it and masking it as a `FetchTimeoutError`.

