### PR TITLE
fix(env): harden supabase configuration validation against default templates

### DIFF
--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,10 +1,13 @@
 export function isSupabaseConfigured(): boolean {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-  return !!(
+  
+  return Boolean(
     url &&
     key &&
     !url.includes("placeholder") &&
-    !key.includes("placeholder")
+    !key.includes("placeholder") &&
+    !url.includes("your-project-url") &&
+    !key.includes("your-anon-key")
   );
 }


### PR DESCRIPTION


### Description
This PR hardens the environment validation logic in `src/lib/env.ts` to prevent the application from attempting to boot with invalid Supabase credentials.

Closes #692

#### Key Changes:
* **Expanded Placeholder Checks:** The previous logic only guarded against the literal string `"placeholder"`. Added explicit validation for `"your-project-url"` and `"your-anon-key"`, which are the standard dummy values found in standard `.env.example` templates, preventing unhelpful network crashes on first boot.
* **Strict Boolean Coercion:** Swapped the double-bang (`!!`) syntax for a more readable and strictly typed `Boolean()` cast to ensure the configuration flag resolves safely.

