### PR TITLE
fix(languages): sync popular languages array and enforce strict const typings

### DIFF
--- a/src/lib/languages.ts
+++ b/src/lib/languages.ts
@@ -1,4 +1,4 @@
-export const LANG_COLORS: Record<string, string> = {
+export const LANG_COLORS = {
   TypeScript: "#3178c6",
   JavaScript: "#f1e05a",
   Python: "#3572A5",
@@ -20,7 +20,9 @@ export const LANG_COLORS: Record<string, string> = {
   PHP: "#4F5D95",
   "Jupyter Notebook": "#DA5B0B",
   Dockerfile: "#384d54",
-};
+} as const;
+
+export type KnownLanguage = keyof typeof LANG_COLORS;
 
 /**
  * Languages offered as filter options in the UI.
@@ -42,6 +44,10 @@ export const POPULAR_LANGUAGES = [
   "Ruby",
   "PHP",
   "Swift",
+  "Kotlin",
+  "Dart",
+  "Vue",
+  "Svelte",
 ] as const;
 
 export type PopularLanguage = (typeof POPULAR_LANGUAGES)[number];


### PR DESCRIPTION


### Description
This PR addresses language filter desyncs and type widening issues in `src/lib/languages.ts`.

Closes #685

#### Key Changes:
* **Language Synchronization:** Added Kotlin, Dart, Vue, and Svelte to the `POPULAR_LANGUAGES` array, ensuring they successfully populate as options in the UI's explore filters alongside the other mapped languages.
* **Strict Type Inference:** Removed the broad `Record<string, string>` annotation from `LANG_COLORS` and replaced it with a strict `as const` assertion. This prevents TypeScript from widening the dictionary keys to generic strings, restoring full IDE autocomplete and ensuring robust type safety for language-to-color mapping downstream. Created a new `KnownLanguage` type exported for use in other components.

