### PR TITLE
fix(profile): call useState before the early return (Closes #709)

### DIFF
--- a/src/components/profile/MilestoneCelebration.tsx
+++ b/src/components/profile/MilestoneCelebration.tsx
@@ -64,6 +64,16 @@ export function MilestoneCelebration({
     }
   }, [isOpen, achievement, fireConfetti]);
 
+  // Declared above the early return below, with the other hooks.
+  //
+  // React identifies hook state by call order, so every hook has to run on
+  // every render. This one sat after `if (!isOpen || !achievement) return null`,
+  // which meant the component called two hooks while closed and three while
+  // open. The `copied` state was created and torn down as the dialog toggled,
+  // and any hook added after it would have landed on a shifting index — the
+  // failure mode where state appears to belong to the wrong variable.
+  const [copied, setCopied] = React.useState(false);
+
   if (!isOpen || !achievement) return null;
 
   const shareUrl = typeof window !== "undefined"
@@ -98,7 +108,6 @@ export function MilestoneCelebration({
     }
   };
 
-  const [copied, setCopied] = React.useState(false);
   const handleCopyLink = () => {
     if (navigator.clipboard) {
       navigator.clipboard.writeText(`${shareText} ${shareUrl}`);


### PR DESCRIPTION
Closes #709

## The bug

`MilestoneCelebration` runs three hooks, with the early return between them:

```
line 57   useCallback              ← always
line 61   useEffect                ← always
line 67   if (!isOpen || !achievement) return null;
line 101  React.useState           ← only when the dialog is open
```

So React sees **two hooks when the dialog is closed and three when it's open**. `copied` is created and torn down as the modal toggles.

Nothing visibly breaks today because it's the last hook in the component — but that's luck, not design. Any hook added after it would land on an index that shifts with `isOpen`, and the symptom of that is state appearing to belong to the wrong variable after a re-render, which is miserable to diagnose because it looks like a bug somewhere else entirely.

## The fix

The `useState` moves above the guard, joining the other two. `handleCopyLink` is declared further down and only closes over `setCopied`, so it doesn't care where the declaration sits.

Ten lines added, one removed — and eight of the additions are a comment explaining why the hook has to stay above the return, so the next person doesn't move it back.

## Formatting left alone

I didn't run prettier on this file. It isn't currently formatted, and doing so would turn a 10-line diff into 129 insertions and 119 deletions, burying the one line that matters. That belongs in the repo-wide pass discussed in #710.

## Verification

- `npm run lint` — the error count drops from 1 to 0. The 61 warnings are unchanged and pre-existing.
- `npm run build` completes.

This clears the failure that made `CI - Build & Lint` red on every PR in the repository regardless of content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could affect milestone celebration rendering across different states.
  * Improved the reliability of sharing interactions within milestone celebrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->