### PR TITLE
Implement lazy initialization of Redis client

### DIFF
--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -1,14 +1,29 @@
 import { Redis } from "@upstash/redis";
 
-const url = process.env.UPSTASH_REDIS_REST_URL;
-const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+let redisClient: Redis | null = null;
 
-// If variables are missing (like during a CI build), export a dummy mock object
-// to prevent crashing. At runtime in production, it will use the real Upstash instance.
-export const redis =
-  url && token
-    ? new Redis({ url, token })
-    : ({
-        get: async () => null,
-        set: async () => "OK",
-      } as unknown as Redis);
+// Wrap the Redis client in a lazy-evaluated Proxy. 
+// This prevents Next.js / CI build-time crashes if environment variables are 
+// missing during static analysis by deferring initialization until runtime execution.
+export const redis = new Proxy({} as Redis, {
+  get(_target, prop) {
+    const url = process.env.UPSTASH_REDIS_REST_URL;
+    const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+
+    // Safe Fallback Mock: If credentials are missing, return harmless mock resolvers.
+    if (!url || !token) {
+      if (prop === "get") return async () => null;
+      if (prop === "set") return async () => "OK";
+      // Catch-all safe default for any other Redis method calls
+      return async () => null;
+    }
+
+    // Lazily initialize the real Upstash client on first use
+    if (!redisClient) {
+      redisClient = new Redis({ url, token });
+    }
+
+    const value = (redisClient as Record<string | symbol, any>)[prop];
+    return typeof value === "function" ? value.bind(redisClient) : value;
+  },
+});


### PR DESCRIPTION
### Description
This PR refactors `src/lib/redis.ts` to use a lazy proxy pattern, addressing build-time crashes and mock implementation bugs.

Closes #669

#### Key Changes:
* **Lazy Proxy Pattern:** Wrapped the Upstash Redis client inside a JavaScript `Proxy`. This defers the instantiation of the `Redis` class until a method is actively invoked at runtime, preventing Next.js static analysis or CI builds from attempting to connect or crashing when environment variables are missing.

* **Safe Fallback Mock:** Integrated the fallback logic directly into the Proxy's `get` trap. If `UPSTASH_REDIS_REST_URL` or `UPSTASH_REDIS_REST_TOKEN` are absent, the proxy dynamically intercepts method calls and returns safe, lightweight promises (`null` for `.get()`, `"OK"` for `.set()`) to ensure the application remains stable.