### PR TITLE
fix(pwa): harden service worker registration and ssr standalone detection

### DIFF
--- a/src/lib/pwa.ts
+++ b/src/lib/pwa.ts
@@ -1,31 +1,40 @@
 "use client";
 
+export interface BeforeInstallPromptEvent extends Event {
+  prompt(): Promise<void>;
+  userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
+}
+
+export interface WindowWithPrompt extends Window {
+  __deferredPrompt?: BeforeInstallPromptEvent;
+}
+
 export function isStandalone(): boolean {
-  if (typeof window === "undefined") return false;
+  if (typeof window === "undefined" || !window.matchMedia) return false;
   return window.matchMedia("(display-mode: standalone)").matches;
 }
 
 export function registerServiceWorker(): void {
   if (typeof window !== "undefined" && "serviceWorker" in navigator) {
-    window.addEventListener("load", () => {
-      navigator.serviceWorker.register("/sw.js");
-    });
+    const register = () => {
+      navigator.serviceWorker
+        .register("/sw.js")
+        .catch((err) => {
+          console.warn("[PWA] Service Worker registration failed:", err);
+        });
+    };
+
+    // If the page is already fully loaded, register immediately.
+    // Otherwise, wait for the load event to avoid blocking critical rendering.
+    if (document.readyState === "complete") {
+      register();
+    } else {
+      window.addEventListener("load", register);
+    }
   }
 }
 
 export function getInstallPromptEvent(): BeforeInstallPromptEvent | null {
-  const deferredPrompt =
-    typeof window !== "undefined"
-      ? (window as WindowWithPrompt).__deferredPrompt
-      : null;
-  return deferredPrompt || null;
-}
-
-interface BeforeInstallPromptEvent extends Event {
-  prompt(): Promise<void>;
-  userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
-}
-
-interface WindowWithPrompt extends Window {
-  __deferredPrompt?: BeforeInstallPromptEvent;
+  if (typeof window === "undefined") return null;
+  return (window as WindowWithPrompt).__deferredPrompt || null;
 }


### PR DESCRIPTION

### Description
This PR addresses edge cases with Service Worker registration timing and hardens SSR checks in `src/lib/pwa.ts`.

Closes #676

#### Key Changes:
* **Robust Service Worker Registration:** Updated `registerServiceWorker` to check `document.readyState`. If the application is already loaded when the function is invoked, it registers the service worker immediately rather than attaching a `load` listener that will never fire. Also added a `.catch()` block to gracefully handle unhandled promise rejections if the registration fails.
* **Hardened SSR Guards:** Added a fallback check for `window.matchMedia` in `isStandalone` to prevent crashes in headless environments or older browsers where `window` exists but the media matcher does not.
* **Type Exports:** Exported `BeforeInstallPromptEvent` and `WindowWithPrompt` interfaces so that UI components handling the PWA installation prompts can properly type their event payloads.

