### PR TITLE
fix(radar): harden metric normalization and safeguard data integrity

### DIFF
--- a/src/lib/radar-metrics.ts
+++ b/src/lib/radar-metrics.ts
@@ -34,6 +34,14 @@ export interface RadarAxis {
   bRaw: number;
 }
 
+/** Guards against negatives, non-finite values, and ensures strict integers. */
+const safeCount = (value: unknown): number => {
+  if (value == null) return 0;
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(parsed) || Number.isNaN(parsed) || parsed < 0) return 0;
+  return Math.floor(parsed);
+};
+
 /**
  * Sums stargazers across a contributor's repositories.
  *
@@ -43,20 +51,10 @@ export interface RadarAxis {
  * the comparison fair, but the absolute figure is a floor rather than a total.
  */
 export const sumRepoStars = (repos: Repo[] | null | undefined): number => {
-  if (!Array.isArray(repos)) return 0;
+  if (!repos || !Array.isArray(repos)) return 0;
   return repos.reduce((total, repo) => {
-    const stars = typeof repo?.stars === "number" && Number.isFinite(repo.stars)
-      ? repo.stars
-      : 0;
-    return total + Math.max(0, stars);
+    return total + safeCount(repo?.stars);
   }, 0);
-};
-
-/** Guards against negatives and non-finite values arriving from the API. */
-const safeCount = (value: unknown): number => {
-  const parsed = typeof value === "number" ? value : Number(value);
-  if (!Number.isFinite(parsed) || parsed < 0) return 0;
-  return parsed;
 };
 
 /**
@@ -71,20 +69,22 @@ export const normalizePair = (a: number, b: number): { a: number; b: number } =>
   const safeA = safeCount(a);
   const safeB = safeCount(b);
   const max = Math.max(safeA, safeB);
-  if (max === 0) return { a: 0, b: 0 };
+  
+  if (max <= 0) return { a: 0, b: 0 };
+  
   return {
-    a: Math.round((safeA / max) * 100),
-    b: Math.round((safeB / max) * 100),
+    a: Math.max(0, Math.min(100, Math.round((safeA / max) * 100))),
+    b: Math.max(0, Math.min(100, Math.round((safeB / max) * 100))),
   };
 };
 
 /** The five axes, in the order the issue specifies. */
 const AXES: Array<{ metric: string; read: (_input: RadarMetricInput) => number }> = [
-  { metric: "Commits", read: (i) => safeCount(i.stats?.totalCommits) },
-  { metric: "Pull Requests", read: (i) => safeCount(i.stats?.totalPRs) },
-  { metric: "Code Reviews", read: (i) => safeCount(i.stats?.totalReviews) },
-  { metric: "Issues Opened", read: (i) => safeCount(i.stats?.totalIssues) },
-  { metric: "Repo Stars", read: (i) => sumRepoStars(i.repos) },
+  { metric: "Commits", read: (i) => safeCount(i?.stats?.totalCommits) },
+  { metric: "Pull Requests", read: (i) => safeCount(i?.stats?.totalPRs) },
+  { metric: "Code Reviews", read: (i) => safeCount(i?.stats?.totalReviews) },
+  { metric: "Issues Opened", read: (i) => safeCount(i?.stats?.totalIssues) },
+  { metric: "Repo Stars", read: (i) => sumRepoStars(i?.repos) },
 ];
 
 /**
@@ -97,17 +97,22 @@ const AXES: Array<{ metric: string; read: (_input: RadarMetricInput) => number }
 export const buildRadarData = (
   userA: RadarMetricInput,
   userB: RadarMetricInput,
-): RadarAxis[] =>
-  AXES.map(({ metric, read }) => {
+): RadarAxis[] => {
+  if (!userA || !userB) return [];
+  
+  return AXES.map(({ metric, read }) => {
     const aRaw = read(userA);
     const bRaw = read(userB);
     const { a, b } = normalizePair(aRaw, bRaw);
     return { metric, a, b, aRaw, bRaw };
   });
+};
 
 /**
  * True when every axis is zero for both contributors, meaning the chart would
  * render an empty polygon and is better replaced with a message.
  */
-export const isRadarEmpty = (data: RadarAxis[]): boolean =>
-  data.every((axis) => axis.aRaw === 0 && axis.bRaw === 0);
+export const isRadarEmpty = (data: RadarAxis[] | null | undefined): boolean => {
+  if (!data || !Array.isArray(data) || data.length === 0) return true;
+  return data.every((axis) => safeCount(axis.aRaw) === 0 && safeCount(axis.bRaw) === 0);
+};


### PR DESCRIPTION
### Description
This PR addresses data purity and edge-case rendering bugs within the radar chart math in `src/lib/radar-metrics.ts`.

Closes #675

#### Key Changes:
* **Strict Integer Coercion:** Refactored `safeCount` to explicitly check for `null/undefined/NaN` and added `Math.floor()`. This ensures all API metric inputs strictly resolve to valid positive integers, preventing NaN propagation downstream. Unified `sumRepoStars` to use this hardened helper.
* **Bounded Normalization:** Updated `normalizePair` to check for `max <= 0` instead of strict equality to completely avoid divide-by-zero vulnerabilities. Also added explicit clamp boundaries (`Math.max(0, Math.min(100, ...))`) so that fractional drift can never cause the radar polygon to overflow its SVG container boundaries.
* **Degraded State Safety:** Added array validations to `isRadarEmpty` and optional chaining fallback guards (e.g., `i?.stats?.totalCommits`) to the `AXES` config to safely gracefully handle malformed data inputs when partial/degraded API objects are passed in.

