### PR TITLE
fix(constants): add env override and trailing slash guard for github api base

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,1 +1,8 @@
-export const GITHUB_API_BASE = 'https://api.github.com';
+
+/**
+ * The base URL for the GitHub REST API.
+ * 
+ * Overridable via environment variables for GitHub Enterprise support or local mock testing.
+ * Automatically strips trailing slashes to ensure clean and safe URL concatenation across fetch clients.
+ */
+export const GITHUB_API_BASE = (process.env.GITHUB_API_BASE || 'https://api.github.com').replace(/\/+$/, '');


### PR DESCRIPTION

### Description
This PR hardens the `GITHUB_API_BASE` constant in `src/lib/constants.ts` to support environment overrides and prevent URL concatenation bugs.

Closes #696

#### Key Changes:
* **Environment Variable Support:** Updated the constant to respect `process.env.GITHUB_API_BASE`, allowing the application to easily target a GitHub Enterprise instance or a local mock server during testing, while safely defaulting to `https://api.github.com`.
* **Trailing Slash Sanitization:** Implemented a regex `.replace(/\/+$/, '')` guard. If a user or deployment pipeline accidentally supplies an environment variable with a trailing slash (e.g., `https://api.github.com/`), this ensures it is stripped. This prevents double-slash URL corruption (e.g., `https://api.github.com//users/...`) in downstream fetch clients.

