### PR TITLE
feat: Implement CODEOWNERS for automated PR review assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -49,7 +49,7 @@ vitest.setup.ts         @PRODHOSH
 # ------------------------------------------------------------------------------
 /.github/               @PRODHOSH
 /Dockerfile             @PRODHOSH
-/docker-compose.yml     @PRODHOSH
+# /docker-compose.yml     @PRODHOSH
 
 # ------------------------------------------------------------------------------
 # Configuration & Package Management

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,69 @@
+# ------------------------------------------------------------------------------
+# GitHub CODEOWNERS for ossfolio
+#
+# This file specifies which teams or individuals own certain files/paths in 
+# the repository. GitHub uses this to automatically request reviews.
+# 
+# Format:
+# [pattern] [owners]
+# 
+# Precedence:
+# - Order matters: the *last* matching pattern takes the most precedence.
+# - If you want an overarching rule to be overwritten by a specific file,
+#   put the specific file rule at the bottom.
+# ------------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------------
+# Global Default
+# ------------------------------------------------------------------------------
+# These owners will be the default owners for everything in the repo. 
+# Unless a later match takes precedence, @PRODHOSH will be requested for 
+# review when someone opens a pull request.
+* @PRODHOSH
+
+# ------------------------------------------------------------------------------
+# Source Code & Frontend (React/Next.js)
+# ------------------------------------------------------------------------------
+/src/       @PRODHOSH
+/public/    @PRODHOSH
+*.ts        @PRODHOSH
+*.tsx       @PRODHOSH
+
+# ------------------------------------------------------------------------------
+# Backend & Database (Supabase)
+# ------------------------------------------------------------------------------
+# Any changes to database migrations, edge functions, or local configs
+/supabase/  @PRODHOSH
+
+# ------------------------------------------------------------------------------
+# Testing & QA
+# ------------------------------------------------------------------------------
+# End-to-end tests and unit tests configurations
+/e2e/                   @PRODHOSH
+playwright.config.ts    @PRODHOSH
+vitest.config.ts        @PRODHOSH
+vitest.setup.ts         @PRODHOSH
+
+# ------------------------------------------------------------------------------
+# CI/CD, Workflows & Infrastructure
+# ------------------------------------------------------------------------------
+/.github/               @PRODHOSH
+/Dockerfile             @PRODHOSH
+/docker-compose.yml     @PRODHOSH
+
+# ------------------------------------------------------------------------------
+# Configuration & Package Management
+# ------------------------------------------------------------------------------
+/package.json           @PRODHOSH
+/package-lock.json      @PRODHOSH
+/next.config.ts         @PRODHOSH
+/open-next.config.ts    @PRODHOSH
+/eslint.config.mjs      @PRODHOSH
+/lint-staged.config.mjs @PRODHOSH
+/postcss.config.mjs     @PRODHOSH
+
+# ------------------------------------------------------------------------------
+# Documentation
+# ------------------------------------------------------------------------------
+/docs/                  @PRODHOSH
+*.md                    @PRODHOSH


### PR DESCRIPTION
Closes #780. 

### What this PR does:
- Implements a comprehensive \.github/CODEOWNERS\ file.
- Specifies \@PRODHOSH\ as the global default owner for all files and explicitly maps critical paths (frontend, backend, infrastructure, workflows, configs) for automatic review requests when contributors open PRs.

### Why this is needed:
As the project scales, having automated review requests via \CODEOWNERS\ ensures that the maintainer is always notified of changes across any part of the codebase without contributors needing to manually request reviews.

Thank you for assigning me! 🚀

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added repository ownership rules to improve code review routing across source code, frontend, backend services, tests, infrastructure, configuration, dependencies, and documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->