### PR TITLE
[Perf]: Add next/image priority hints for hero section avatars

### DIFF
--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -464,6 +464,7 @@ function ProfileDownloadCard({
                   width={64}
                   height={64}
                   unoptimized
+                  priority
                   style={{
                     width: "64px",
                     height: "64px",
@@ -1187,6 +1188,7 @@ export function ProfileView({
           alt={displayName}
           width={88}
           height={88}
+          priority
           style={{
             borderRadius: "9999px",
             border: "1px solid var(--color-hairline)",


### PR DESCRIPTION
Fixes #797. This PR adds the \priority\ prop to the main user avatar in the profile hero section to optimize Largest Contentful Paint (LCP).